### PR TITLE
feat: release automático en merge + ape upgrade — closes #3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,12 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+    paths:
+      - 'code/cli/**'
+      - 'scripts/**'
+      - '.github/workflows/release.yml'
 
 permissions:
   contents: write
@@ -31,6 +35,14 @@ jobs:
       - name: Test
         run: dart test
 
+      - name: Read version from pubspec.yaml
+        id: version
+        run: |
+          $v = (Select-String -Path pubspec.yaml -Pattern '^version:\s*(.+)$').Matches.Groups[1].Value.Trim()
+          echo "VERSION=$v" >> $env:GITHUB_OUTPUT
+          echo "Version: $v"
+        shell: pwsh
+
       - name: Build
         run: |
           New-Item -ItemType Directory -Force -Path build\bin | Out-Null
@@ -42,8 +54,11 @@ jobs:
         run: Compress-Archive -Path build\* -DestinationPath ape-windows-x64.zip
         shell: pwsh
 
-      - name: Create Release
+      - name: Create or update release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ steps.version.outputs.VERSION }}
+          name: v${{ steps.version.outputs.VERSION }}
           files: code/cli/ape-windows-x64.zip
           generate_release_notes: true
+          make_latest: true

--- a/README.md
+++ b/README.md
@@ -40,11 +40,26 @@ doc/
 - [x] `ape version` — print CLI version
 - [x] `ape target get` — deploy APE agents and skills to all AI coding tools
 - [x] `ape target clean` — remove deployed APE files from all targets
+- [x] `ape upgrade` — download and install the latest APE release
 - [ ] `ape memory` — Memory as Code CLI commands
 - [ ] `ape task` — GitHub Issues-backed task management
 - [ ] Orchestrator prompts for Copilot (first target)
 - [ ] BORGES validation engine
 - [ ] DARWIN learning loop
+
+## Install (Windows)
+
+```powershell
+irm https://raw.githubusercontent.com/ccisnedev/finite_ape_machine/main/scripts/install.ps1 | iex
+```
+
+This downloads the latest release, extracts it to `%LOCALAPPDATA%\ape\`, adds it to PATH, and deploys APE agents/skills to all supported AI coding tools.
+
+To update to the latest version:
+
+```powershell
+ape upgrade
+```
 
 ## The APE Cycle
 

--- a/code/cli/lib/ape_cli.dart
+++ b/code/cli/lib/ape_cli.dart
@@ -12,6 +12,7 @@ import 'assets.dart';
 import 'commands/init.dart';
 import 'commands/target_clean.dart';
 import 'commands/target_get.dart';
+import 'commands/upgrade.dart';
 import 'commands/version.dart';
 import 'targets/all_adapters.dart';
 import 'targets/deployer.dart';
@@ -32,6 +33,12 @@ Future<int> runApe(List<String> args) async {
     'version',
     (req) => VersionCommand(VersionInput.fromCliRequest(req)),
     description: 'Print the current CLI version',
+  );
+
+  cli.command<UpgradeInput, UpgradeOutput>(
+    'upgrade',
+    (req) => UpgradeCommand(UpgradeInput.fromCliRequest(req)),
+    description: 'Download and install the latest APE release',
   );
 
   final deployer = TargetDeployer(

--- a/code/cli/lib/commands/upgrade.dart
+++ b/code/cli/lib/commands/upgrade.dart
@@ -1,0 +1,173 @@
+/// `ape upgrade` — downloads and installs the latest APE release.
+///
+/// Fetches the latest release from GitHub, downloads the zip,
+/// extracts it over the current installation, and redeploys targets.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:cli_router/cli_router.dart';
+import 'package:modular_cli_sdk/modular_cli_sdk.dart';
+import 'package:path/path.dart' as p;
+
+import 'version.dart';
+
+const String _repo = 'ccisnedev/finite_ape_machine';
+const String _assetName = 'ape-windows-x64.zip';
+
+// ─── Input ──────────────────────────────────────────────────────────────────
+
+class UpgradeInput extends Input {
+  final String installDir;
+
+  UpgradeInput({required this.installDir});
+
+  factory UpgradeInput.fromCliRequest(CliRequest req) {
+    final installDir =
+        p.dirname(p.dirname(Platform.resolvedExecutable));
+    return UpgradeInput(installDir: installDir);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'installDir': installDir};
+}
+
+// ─── Output ─────────────────────────────────────────────────────────────────
+
+class UpgradeOutput extends Output {
+  final String message;
+  final String previousVersion;
+  final String newVersion;
+  final bool upgraded;
+
+  UpgradeOutput({
+    required this.message,
+    required this.previousVersion,
+    required this.newVersion,
+    required this.upgraded,
+  });
+
+  @override
+  Map<String, dynamic> toJson() => {
+        'message': message,
+        'previousVersion': previousVersion,
+        'newVersion': newVersion,
+        'upgraded': upgraded,
+      };
+
+  @override
+  int get exitCode => ExitCode.ok;
+}
+
+// ─── Command ────────────────────────────────────────────────────────────────
+
+class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
+  @override
+  final UpgradeInput input;
+  final HttpClient? httpClientOverride;
+
+  UpgradeCommand(this.input, {this.httpClientOverride});
+
+  @override
+  String? validate() => null;
+
+  @override
+  Future<UpgradeOutput> execute() async {
+    final client = httpClientOverride ?? HttpClient();
+    try {
+      // 1. Fetch latest release metadata
+      final releaseUrl = Uri.parse(
+          'https://api.github.com/repos/$_repo/releases/latest');
+      final metaRequest = await client.getUrl(releaseUrl);
+      metaRequest.headers.set('Accept', 'application/vnd.github+json');
+      metaRequest.headers.set('User-Agent', 'ape-cli/$apeVersion');
+      final metaResponse = await metaRequest.close();
+
+      if (metaResponse.statusCode != 200) {
+        return UpgradeOutput(
+          message: 'Failed to fetch release info (HTTP ${metaResponse.statusCode})',
+          previousVersion: apeVersion,
+          newVersion: apeVersion,
+          upgraded: false,
+        );
+      }
+
+      final body = await metaResponse.transform(utf8.decoder).join();
+      final release = jsonDecode(body) as Map<String, dynamic>;
+      final tagName = release['tag_name'] as String;
+      final latestVersion = tagName.startsWith('v') ? tagName.substring(1) : tagName;
+
+      if (latestVersion == apeVersion) {
+        return UpgradeOutput(
+          message: 'Already on the latest version',
+          previousVersion: apeVersion,
+          newVersion: apeVersion,
+          upgraded: false,
+        );
+      }
+
+      // 2. Find the zip asset
+      final assets = release['assets'] as List<dynamic>;
+      final asset = assets.cast<Map<String, dynamic>>().firstWhere(
+        (a) => (a['name'] as String) == _assetName,
+        orElse: () => throw CommandException(
+          code: 'ASSET_NOT_FOUND',
+          message: 'No $_assetName asset in release $tagName',
+          exitCode: ExitCode.notFound,
+        ),
+      );
+
+      final downloadUrl = asset['browser_download_url'] as String;
+
+      // 3. Download to temp
+      final tempDir = Directory.systemTemp.createTempSync('ape_upgrade_');
+      final zipFile = File(p.join(tempDir.path, _assetName));
+
+      final dlRequest = await client.getUrl(Uri.parse(downloadUrl));
+      dlRequest.headers.set('User-Agent', 'ape-cli/$apeVersion');
+      final dlResponse = await dlRequest.close();
+
+      // Follow redirect if needed
+      final sink = zipFile.openWrite();
+      await dlResponse.pipe(sink);
+
+      // 4. Extract over current installation
+      final installDir = input.installDir;
+      final result = await Process.run(
+        'powershell',
+        [
+          '-NoProfile',
+          '-Command',
+          'Expand-Archive -Path "${zipFile.path}" -DestinationPath "$installDir" -Force',
+        ],
+      );
+
+      tempDir.deleteSync(recursive: true);
+
+      if (result.exitCode != 0) {
+        return UpgradeOutput(
+          message: 'Failed to extract: ${result.stderr}',
+          previousVersion: apeVersion,
+          newVersion: latestVersion,
+          upgraded: false,
+        );
+      }
+
+      // 5. Redeploy targets using the new binary
+      await Process.run(
+        p.join(installDir, 'bin', 'ape.exe'),
+        ['target', 'get'],
+      );
+
+      return UpgradeOutput(
+        message: 'Upgraded from $apeVersion to $latestVersion',
+        previousVersion: apeVersion,
+        newVersion: latestVersion,
+        upgraded: true,
+      );
+    } finally {
+      if (httpClientOverride == null) client.close();
+    }
+  }
+}

--- a/code/cli/test/upgrade_test.dart
+++ b/code/cli/test/upgrade_test.dart
@@ -1,0 +1,38 @@
+import 'package:test/test.dart';
+
+import 'package:ape_cli/commands/upgrade.dart';
+import 'package:ape_cli/commands/version.dart';
+
+void main() {
+  group('ape upgrade', () {
+    test('UpgradeInput serializes correctly', () {
+      final input = UpgradeInput(installDir: '/fake/dir');
+      expect(input.toJson(), {'installDir': '/fake/dir'});
+    });
+
+    test('UpgradeOutput reports no upgrade when already latest', () {
+      final output = UpgradeOutput(
+        message: 'Already on the latest version',
+        previousVersion: apeVersion,
+        newVersion: apeVersion,
+        upgraded: false,
+      );
+      expect(output.exitCode, 0);
+      expect(output.upgraded, isFalse);
+      expect(output.toJson()['message'], contains('latest'));
+    });
+
+    test('UpgradeOutput reports successful upgrade', () {
+      final output = UpgradeOutput(
+        message: 'Upgraded from 0.0.1 to 0.0.2',
+        previousVersion: '0.0.1',
+        newVersion: '0.0.2',
+        upgraded: true,
+      );
+      expect(output.exitCode, 0);
+      expect(output.upgraded, isTrue);
+      expect(output.previousVersion, '0.0.1');
+      expect(output.newVersion, '0.0.2');
+    });
+  });
+}


### PR DESCRIPTION
## Resumen

Tres mejoras al flujo de instalación y distribución:

### 1. Release automático en merge a main

El workflow ya no requiere push de tag manual. Se dispara en push a \main\ cuando cambian archivos en \code/cli/\, \scripts/\ o el propio workflow. Lee la versión de \pubspec.yaml\ y crea el release + tag automáticamente.

### 2. Comando \^Gpe upgrade\

Descarga el último release de GitHub, extrae el zip sobre la instalación actual, y ejecuta \^Gpe target get\ para redesplegar.

\\\
ape upgrade
\\\

Reporta si ya está en la última versión o si se actualizó exitosamente.

### 3. Instrucciones de instalación en README

\\\powershell
irm https://raw.githubusercontent.com/ccisnedev/finite_ape_machine/main/scripts/install.ps1 | iex
\\\

## Tests

- 105 tests, 0 failures
- \dart analyze\ — cero warnings