### PR TITLE
fix: soporte para repos privados en install y upgrade — closes #5

### DIFF
--- a/code/cli/lib/commands/upgrade.dart
+++ b/code/cli/lib/commands/upgrade.dart
@@ -79,9 +79,13 @@ class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
       // 1. Fetch latest release metadata
       final releaseUrl = Uri.parse(
           'https://api.github.com/repos/$_repo/releases/latest');
+      final token = await _resolveToken();
       final metaRequest = await client.getUrl(releaseUrl);
       metaRequest.headers.set('Accept', 'application/vnd.github+json');
       metaRequest.headers.set('User-Agent', 'ape-cli/$apeVersion');
+      if (token != null) {
+        metaRequest.headers.set('Authorization', 'Bearer $token');
+      }
       final metaResponse = await metaRequest.close();
 
       if (metaResponse.statusCode != 200) {
@@ -118,14 +122,20 @@ class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
         ),
       );
 
-      final downloadUrl = asset['browser_download_url'] as String;
+      final assetId = asset['id'] as int;
 
-      // 3. Download to temp
+      // 3. Download to temp (use API URL for private repo support)
       final tempDir = Directory.systemTemp.createTempSync('ape_upgrade_');
       final zipFile = File(p.join(tempDir.path, _assetName));
 
-      final dlRequest = await client.getUrl(Uri.parse(downloadUrl));
+      final dlUrl = Uri.parse(
+          'https://api.github.com/repos/$_repo/releases/assets/$assetId');
+      final dlRequest = await client.getUrl(dlUrl);
+      dlRequest.headers.set('Accept', 'application/octet-stream');
       dlRequest.headers.set('User-Agent', 'ape-cli/$apeVersion');
+      if (token != null) {
+        dlRequest.headers.set('Authorization', 'Bearer $token');
+      }
       final dlResponse = await dlRequest.close();
 
       // Follow redirect if needed
@@ -169,5 +179,22 @@ class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
     } finally {
       if (httpClientOverride == null) client.close();
     }
+  }
+
+  /// Resolves a GitHub token from GITHUB_TOKEN env var or `gh auth token`.
+  Future<String?> _resolveToken() async {
+    final envToken = Platform.environment['GITHUB_TOKEN'];
+    if (envToken != null && envToken.isNotEmpty) return envToken;
+
+    try {
+      final result = await Process.run('gh', ['auth', 'token']);
+      if (result.exitCode == 0) {
+        final token = (result.stdout as String).trim();
+        if (token.isNotEmpty) return token;
+      }
+    } on ProcessException {
+      // gh not installed — that's fine
+    }
+    return null;
   }
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -55,7 +55,17 @@ Write-Host "    Asset:   $($asset.name)"
 $tempZip = Join-Path $env:TEMP "ape-$($release.tag_name).zip"
 
 Write-Host '>>> Downloading...'
-Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $tempZip -Headers $headers
+# Use API URL for private repos, browser URL for public repos
+if ($env:GITHUB_TOKEN) {
+    $dlUrl = "https://api.github.com/repos/$repo/releases/assets/$($asset.id)"
+    $dlHeaders = @{
+        Accept        = 'application/octet-stream'
+        Authorization = "Bearer $env:GITHUB_TOKEN"
+    }
+    Invoke-WebRequest -Uri $dlUrl -OutFile $tempZip -Headers $dlHeaders
+} else {
+    Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $tempZip
+}
 
 # Clean previous installation
 if (Test-Path $installDir) {


### PR DESCRIPTION
## Problema

El repo es privado. \rowser_download_url\ devuelve 404 sin autenticación.

## Solución

### install.ps1
Cuando \GITHUB_TOKEN\ está presente, descarga vía GitHub API con \Accept: application/octet-stream\ en vez de \rowser_download_url\.

### ape upgrade
- Resuelve token desde \GITHUB_TOKEN\ env var o \gh auth token\
- Usa API URL con \^Gpplication/octet-stream\ para la descarga del asset
- Envía \Authorization: Bearer\ en ambas requests (metadata + download)

## Tests
- 105 tests, 0 failures
- \dart analyze\ — cero warnings