### PR TITLE
feat: GitHub Pages landing page + install script — closes #7

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,35 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages.yml'
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ doc/
 ## Install (Windows)
 
 ```powershell
-irm https://raw.githubusercontent.com/ccisnedev/finite_ape_machine/main/scripts/install.ps1 | iex
+irm https://ccisnedev.github.io/finite_ape_machine/install.ps1 | iex
 ```
 
 This downloads the latest release, extracts it to `%LOCALAPPDATA%\ape\`, adds it to PATH, and deploys APE agents/skills to all supported AI coding tools.

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Finite APE Machine</title>
+  <style>
+    :root {
+      --bg: #0d1117;
+      --fg: #e6edf3;
+      --muted: #8b949e;
+      --accent: #58a6ff;
+      --green: #3fb950;
+      --border: #30363d;
+      --code-bg: #161b22;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+      line-height: 1.6;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .container {
+      max-width: 720px;
+      width: 100%;
+      padding: 2rem 1.5rem;
+    }
+
+    header {
+      text-align: center;
+      padding: 3rem 0 2rem;
+    }
+
+    h1 {
+      font-size: 2.5rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+    }
+
+    h1 .ape { color: var(--green); }
+
+    .tagline {
+      color: var(--muted);
+      font-size: 1.1rem;
+      font-style: italic;
+    }
+
+    .badge {
+      display: inline-block;
+      margin-top: 1rem;
+      padding: 0.25rem 0.75rem;
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 1rem;
+      font-size: 0.85rem;
+      color: var(--green);
+    }
+
+    section {
+      margin-top: 2.5rem;
+    }
+
+    h2 {
+      font-size: 1.3rem;
+      margin-bottom: 1rem;
+      color: var(--accent);
+    }
+
+    p { margin-bottom: 1rem; color: var(--muted); }
+
+    .install-block {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      position: relative;
+      margin-bottom: 1.5rem;
+    }
+
+    .install-block code {
+      font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+      font-size: 0.9rem;
+      color: var(--fg);
+      word-break: break-all;
+    }
+
+    .install-block .label {
+      display: block;
+      font-size: 0.75rem;
+      color: var(--muted);
+      margin-bottom: 0.5rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .copy-btn {
+      position: absolute;
+      top: 0.75rem;
+      right: 0.75rem;
+      background: var(--border);
+      border: none;
+      color: var(--muted);
+      padding: 0.3rem 0.6rem;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 0.8rem;
+    }
+
+    .copy-btn:hover { color: var(--fg); background: #484f58; }
+
+    .commands {
+      display: grid;
+      gap: 0.75rem;
+    }
+
+    .cmd {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.75rem 1rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .cmd code {
+      font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+      font-size: 0.85rem;
+    }
+
+    .cmd .desc {
+      color: var(--muted);
+      font-size: 0.8rem;
+    }
+
+    .targets {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+    }
+
+    .target-badge {
+      padding: 0.2rem 0.6rem;
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-size: 0.8rem;
+      color: var(--fg);
+    }
+
+    .cycle {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 0.75rem;
+      margin-top: 0.5rem;
+    }
+
+    .phase {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 1rem;
+      text-align: center;
+    }
+
+    .phase .name {
+      font-weight: 700;
+      font-size: 1rem;
+      color: var(--green);
+    }
+
+    .phase .detail {
+      font-size: 0.8rem;
+      color: var(--muted);
+      margin-top: 0.25rem;
+    }
+
+    footer {
+      margin-top: 3rem;
+      padding: 1.5rem 0;
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.8rem;
+      border-top: 1px solid var(--border);
+      width: 100%;
+      max-width: 720px;
+    }
+
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>Finite <span class="ape">APE</span> Machine</h1>
+      <p class="tagline">Infinite monkeys produce noise. Finite APEs produce software.</p>
+      <span class="badge">v0.0.2 — Windows</span>
+    </header>
+
+    <section>
+      <h2>Install</h2>
+      <div class="install-block">
+        <span class="label">PowerShell</span>
+        <button class="copy-btn" onclick="copy(this)">Copy</button>
+        <code>irm https://ccisnedev.github.io/finite_ape_machine/install.ps1 | iex</code>
+      </div>
+      <p>Downloads the latest release, installs to <code>%LOCALAPPDATA%\ape\</code>, adds to PATH, and deploys APE agents to all supported AI coding tools.</p>
+    </section>
+
+    <section>
+      <h2>Commands</h2>
+      <div class="commands">
+        <div class="cmd">
+          <code>ape target get</code>
+          <span class="desc">Deploy agents &amp; skills to all targets</span>
+        </div>
+        <div class="cmd">
+          <code>ape target clean</code>
+          <span class="desc">Remove deployed files from all targets</span>
+        </div>
+        <div class="cmd">
+          <code>ape upgrade</code>
+          <span class="desc">Update to the latest release</span>
+        </div>
+        <div class="cmd">
+          <code>ape version</code>
+          <span class="desc">Print current version</span>
+        </div>
+        <div class="cmd">
+          <code>ape init</code>
+          <span class="desc">Initialize .ape/ workspace</span>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Targets</h2>
+      <p>APE deploys agents and skills to the global configuration of:</p>
+      <div class="targets">
+        <span class="target-badge">Copilot</span>
+        <span class="target-badge">Claude</span>
+        <span class="target-badge">Codex</span>
+        <span class="target-badge">Crush</span>
+        <span class="target-badge">Gemini</span>
+      </div>
+    </section>
+
+    <section>
+      <h2>The APE Cycle</h2>
+      <div class="cycle">
+        <div class="phase">
+          <div class="name">Analyze</div>
+          <div class="detail">Understand &amp; classify</div>
+        </div>
+        <div class="phase">
+          <div class="name">Plan</div>
+          <div class="detail">Runbook &amp; criteria</div>
+        </div>
+        <div class="phase">
+          <div class="name">Execute</div>
+          <div class="detail">TDD &amp; collaborate</div>
+        </div>
+        <div class="phase">
+          <div class="name">Learn</div>
+          <div class="detail">Extract &amp; improve</div>
+        </div>
+      </div>
+    </section>
+
+    <footer>
+      <a href="https://github.com/ccisnedev/finite_ape_machine">GitHub</a> ·
+      MIT License
+    </footer>
+  </div>
+
+  <script>
+    function copy(btn) {
+      const code = btn.parentElement.querySelector('code');
+      navigator.clipboard.writeText(code.textContent);
+      btn.textContent = 'Copied!';
+      setTimeout(() => btn.textContent = 'Copy', 2000);
+    }
+  </script>
+</body>
+</html>

--- a/site/install.ps1
+++ b/site/install.ps1
@@ -1,0 +1,92 @@
+# install.ps1 — Downloads and installs the latest APE CLI release.
+#
+# Usage:
+#   irm https://ccisnedev.github.io/finite_ape_machine/install.ps1 | iex
+#
+# What it does:
+#   1. Detects Windows x64
+#   2. Downloads the latest .zip from GitHub Releases
+#   3. Extracts to $env:LOCALAPPDATA\ape\
+#   4. Adds ape\bin\ to the user PATH
+#   5. Runs `ape target get`
+#   6. Verifies with `ape version`
+
+$ErrorActionPreference = 'Stop'
+
+$repo = 'ccisnedev/finite_ape_machine'
+$installDir = Join-Path $env:LOCALAPPDATA 'ape'
+$binDir = Join-Path $installDir 'bin'
+
+# ─── Platform check ──────────────────────────────────────────────────────────
+
+if ($env:OS -ne 'Windows_NT') {
+    Write-Error 'APE CLI currently supports Windows only.'
+    exit 1
+}
+
+if ([System.Environment]::Is64BitOperatingSystem -eq $false) {
+    Write-Error 'APE CLI requires a 64-bit operating system.'
+    exit 1
+}
+
+# ─── Fetch latest release ────────────────────────────────────────────────────
+
+Write-Host '>>> Fetching latest release...'
+$releaseUrl = "https://api.github.com/repos/$repo/releases/latest"
+$headers = @{ Accept = 'application/vnd.github+json' }
+
+$release = Invoke-RestMethod -Uri $releaseUrl -Headers $headers
+$asset = $release.assets | Where-Object { $_.name -like 'ape-windows-x64*.zip' } | Select-Object -First 1
+
+if (-not $asset) {
+    Write-Error "No ape-windows-x64 asset found in release $($release.tag_name)."
+    exit 1
+}
+
+Write-Host "    Release: $($release.tag_name)"
+Write-Host "    Asset:   $($asset.name)"
+
+# ─── Download and extract ────────────────────────────────────────────────────
+
+$tempZip = Join-Path $env:TEMP "ape-$($release.tag_name).zip"
+
+Write-Host '>>> Downloading...'
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $tempZip
+
+# Clean previous installation
+if (Test-Path $installDir) {
+    Write-Host '>>> Removing previous installation...'
+    Remove-Item -Recurse -Force $installDir
+}
+
+Write-Host '>>> Extracting...'
+Expand-Archive -Path $tempZip -DestinationPath $installDir -Force
+Remove-Item $tempZip
+
+# ─── Update PATH ─────────────────────────────────────────────────────────────
+
+$userPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
+
+if ($userPath -notlike "*$binDir*") {
+    Write-Host '>>> Adding ape\bin\ to PATH...'
+    [System.Environment]::SetEnvironmentVariable(
+        'PATH',
+        "$userPath;$binDir",
+        'User'
+    )
+    $env:PATH = "$env:PATH;$binDir"
+}
+
+# ─── Deploy and verify ───────────────────────────────────────────────────────
+
+Write-Host '>>> Deploying APE to all targets...'
+& (Join-Path $binDir 'ape.exe') target get
+
+Write-Host '>>> Verifying installation...'
+$versionOutput = & (Join-Path $binDir 'ape.exe') version
+Write-Host "    $versionOutput"
+
+Write-Host ''
+Write-Host '>>> APE CLI installed successfully!'
+Write-Host "    Location: $installDir"
+Write-Host '    Restart your terminal to use `ape` from any directory.'


### PR DESCRIPTION
## Resumen

Landing page en GitHub Pages + install script servido desde Pages.

### Landing page
- \site/index.html\ — dark theme, muestra comandos, targets, ciclo APE, botón copy para install
- URL: \https://ccisnedev.github.io/finite_ape_machine/\

### Install script
- \site/install.ps1\ — servido directamente por Pages
- Instalación: \irm https://ccisnedev.github.io/finite_ape_machine/install.ps1 | iex\

### Workflow
- \.github/workflows/pages.yml\ — despliega \site/\ a GitHub Pages en push a main

### README
- URL de instalación actualizada a la URL de Pages

### Nota
- Cerré PR #6 (fix repos privados) — ya no es necesario con el repo público
- Después del merge, hay que habilitar GitHub Pages en Settings → Pages → Source: GitHub Actions