### PR TITLE
chore: actualizar URLs a dominio ccisne.dev — closes #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ doc/
 ## Install (Windows)
 
 ```powershell
-irm https://ccisnedev.github.io/finite_ape_machine/install.ps1 | iex
+irm https://www.ccisne.dev/finite_ape_machine/install.ps1 | iex
 ```
 
 This downloads the latest release, extracts it to `%LOCALAPPDATA%\ape\`, adds it to PATH, and deploys APE agents/skills to all supported AI coding tools.

--- a/site/index.html
+++ b/site/index.html
@@ -212,7 +212,7 @@
       <div class="install-block">
         <span class="label">PowerShell</span>
         <button class="copy-btn" onclick="copy(this)">Copy</button>
-        <code>irm https://ccisnedev.github.io/finite_ape_machine/install.ps1 | iex</code>
+        <code>irm https://www.ccisne.dev/finite_ape_machine/install.ps1 | iex</code>
       </div>
       <p>Downloads the latest release, installs to <code>%LOCALAPPDATA%\ape\</code>, adds to PATH, and deploys APE agents to all supported AI coding tools.</p>
     </section>

--- a/site/install.ps1
+++ b/site/install.ps1
@@ -1,7 +1,7 @@
 # install.ps1 — Downloads and installs the latest APE CLI release.
 #
 # Usage:
-#   irm https://ccisnedev.github.io/finite_ape_machine/install.ps1 | iex
+#   irm https://www.ccisne.dev/finite_ape_machine/install.ps1 | iex
 #
 # What it does:
 #   1. Detects Windows x64


### PR DESCRIPTION
Actualiza las 3 referencias de \ccisnedev.github.io/finite_ape_machine\ a \www.ccisne.dev/finite_ape_machine\.

Instalación queda:
\\\powershell
irm https://www.ccisne.dev/finite_ape_machine/install.ps1 | iex
\\\