### PR TITLE
fix: rename running exe before extract in upgrade — closes #14

### DIFF
--- a/code/cli/lib/commands/upgrade.dart
+++ b/code/cli/lib/commands/upgrade.dart
@@ -133,7 +133,19 @@ class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
       await dlResponse.pipe(sink);
 
       // 4. Extract over current installation
+      //
+      // Windows locks running executables, so we rename the current binary
+      // before extracting. The .bak file is cleaned up after extraction.
       final installDir = input.installDir;
+      final currentExe = File(Platform.resolvedExecutable);
+      final bakFile = File('${Platform.resolvedExecutable}.bak');
+
+      // Clean up any leftover .bak from a previous upgrade
+      if (bakFile.existsSync()) bakFile.deleteSync();
+
+      // Rename the running exe — Windows allows renaming a locked file
+      currentExe.renameSync(bakFile.path);
+
       final result = await Process.run(
         'powershell',
         [
@@ -144,6 +156,13 @@ class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
       );
 
       tempDir.deleteSync(recursive: true);
+
+      // Best-effort cleanup of the old binary
+      try {
+        if (bakFile.existsSync()) bakFile.deleteSync();
+      } on FileSystemException {
+        // Still locked — will be cleaned up on next upgrade
+      }
 
       if (result.exitCode != 0) {
         return UpgradeOutput(

--- a/code/cli/lib/commands/version.dart
+++ b/code/cli/lib/commands/version.dart
@@ -4,7 +4,7 @@ library;
 import 'package:cli_router/cli_router.dart';
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 
-const String apeVersion = '0.0.3';
+const String apeVersion = '0.0.4';
 
 // ─── Input ──────────────────────────────────────────────────────────────────
 

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ape_cli
 description: >
   CLI for the finite ape machine — workspace initialization and orchestration.
-version: 0.0.3
+version: 0.0.4
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
## Problema

`ape upgrade` reporta éxito pero el binario no se actualiza. `Expand-Archive -Force` falla silenciosamente porque Windows bloquea el ejecutable en ejecución.

## Solución

Antes de extraer el zip:
1. Limpiar `ape.exe.bak` residual de upgrades anteriores
2. Renombrar `ape.exe` → `ape.exe.bak` (Windows permite renombrar un exe bloqueado)
3. Extraer el zip (ahora la ruta está libre)
4. Eliminar `.bak` (best-effort — si sigue bloqueado, se limpia en el próximo upgrade)

También bump a `0.0.4`.

Closes #14