### PR TITLE
feat: ape uninstall — remove APE CLI from system — closes #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ doc/
 - [x] `ape target get` — deploy APE agents and skills to all AI coding tools
 - [x] `ape target clean` — remove deployed APE files from all targets
 - [x] `ape upgrade` — download and install the latest APE release
+- [x] `ape uninstall` — remove APE CLI from the system
 - [ ] `ape memory` — Memory as Code CLI commands
 - [ ] `ape task` — GitHub Issues-backed task management
 - [ ] Orchestrator prompts for Copilot (first target)

--- a/code/cli/lib/ape_cli.dart
+++ b/code/cli/lib/ape_cli.dart
@@ -12,6 +12,7 @@ import 'assets.dart';
 import 'commands/init.dart';
 import 'commands/target_clean.dart';
 import 'commands/target_get.dart';
+import 'commands/uninstall.dart';
 import 'commands/upgrade.dart';
 import 'commands/version.dart';
 import 'targets/all_adapters.dart';
@@ -69,6 +70,15 @@ Future<int> runApe(List<String> args) async {
       description: 'Remove deployed APE files from all targets',
     );
   });
+
+  cli.command<UninstallInput, UninstallOutput>(
+    'uninstall',
+    (req) => UninstallCommand(
+      UninstallInput.fromCliRequest(req),
+      deployer: deployer,
+    ),
+    description: 'Remove APE CLI from the system',
+  );
 
   return cli.run(args);
 }

--- a/code/cli/lib/commands/uninstall.dart
+++ b/code/cli/lib/commands/uninstall.dart
@@ -1,0 +1,131 @@
+/// `ape uninstall` — removes APE CLI from the system.
+///
+/// 1. Cleans all deployed targets (agents + skills).
+/// 2. Removes ape\bin\ from the user PATH.
+/// 3. Spawns a background process to delete the install directory.
+library;
+
+import 'dart:io';
+
+import 'package:cli_router/cli_router.dart';
+import 'package:modular_cli_sdk/modular_cli_sdk.dart';
+import 'package:path/path.dart' as p;
+
+import '../targets/deployer.dart';
+
+// ─── Input ──────────────────────────────────────────────────────────────────
+
+class UninstallInput extends Input {
+  final String installDir;
+
+  UninstallInput({required this.installDir});
+
+  factory UninstallInput.fromCliRequest(CliRequest req) {
+    final installDir = p.dirname(p.dirname(Platform.resolvedExecutable));
+    return UninstallInput(installDir: installDir);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'installDir': installDir};
+}
+
+// ─── Output ─────────────────────────────────────────────────────────────────
+
+class UninstallOutput extends Output {
+  final String message;
+
+  UninstallOutput({required this.message});
+
+  @override
+  Map<String, dynamic> toJson() => {'message': message};
+
+  @override
+  int get exitCode => ExitCode.ok;
+}
+
+// ─── Command ────────────────────────────────────────────────────────────────
+
+class UninstallCommand implements Command<UninstallInput, UninstallOutput> {
+  @override
+  final UninstallInput input;
+  final TargetDeployer deployer;
+
+  UninstallCommand(this.input, {required this.deployer});
+
+  @override
+  String? validate() => null;
+
+  @override
+  Future<UninstallOutput> execute() async {
+    // 1. Clean all targets
+    deployer.clean();
+
+    // 2. Remove ape\bin\ from user PATH
+    _removeFromPath(p.join(input.installDir, 'bin'));
+
+    // 3. Spawn background process to delete install directory
+    _scheduleDirectoryDeletion(input.installDir);
+
+    return UninstallOutput(
+      message: 'APE uninstalled. Restart your terminal to apply PATH changes.',
+    );
+  }
+
+  void _removeFromPath(String binDir) {
+    final userPath =
+        _getEnvironmentVariable('PATH', 'User') ?? '';
+    final parts = userPath
+        .split(';')
+        .where((p) => p.isNotEmpty)
+        .where((p) => !_pathEquals(p, binDir))
+        .toList();
+    final newPath = parts.join(';');
+
+    if (newPath != userPath) {
+      _setEnvironmentVariable('PATH', newPath, 'User');
+    }
+  }
+
+  void _scheduleDirectoryDeletion(String dir) {
+    // Rename the running exe so the directory can be deleted.
+    final currentExe = File(Platform.resolvedExecutable);
+    final bakPath = '${Platform.resolvedExecutable}.bak';
+    try {
+      currentExe.renameSync(bakPath);
+    } on FileSystemException {
+      // Best effort — may already be renamed
+    }
+
+    // Spawn a detached cmd process that waits 2 seconds then deletes.
+    Process.start(
+      'cmd',
+      ['/c', 'timeout /t 2 /nobreak >nul & rmdir /s /q "$dir"'],
+      mode: ProcessStartMode.detached,
+    );
+  }
+
+  bool _pathEquals(String a, String b) =>
+      p.normalize(a).toLowerCase() == p.normalize(b).toLowerCase();
+
+  // Wrappers for testability — PowerShell is the reliable way to
+  // read/write user-scoped environment variables on Windows.
+
+  String? _getEnvironmentVariable(String name, String scope) {
+    final result = Process.runSync('powershell', [
+      '-NoProfile',
+      '-Command',
+      '[System.Environment]::GetEnvironmentVariable("$name", "$scope")',
+    ]);
+    if (result.exitCode != 0) return null;
+    final value = (result.stdout as String).trim();
+    return value.isEmpty ? null : value;
+  }
+
+  void _setEnvironmentVariable(String name, String value, String scope) {
+    Process.runSync('powershell', [
+      '-NoProfile',
+      '-Command',
+      '[System.Environment]::SetEnvironmentVariable("$name", "$value", "$scope")',
+    ]);
+  }
+}

--- a/code/cli/lib/commands/version.dart
+++ b/code/cli/lib/commands/version.dart
@@ -4,7 +4,7 @@ library;
 import 'package:cli_router/cli_router.dart';
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 
-const String apeVersion = '0.0.4';
+const String apeVersion = '0.0.5';
 
 // ─── Input ──────────────────────────────────────────────────────────────────
 

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ape_cli
 description: >
   CLI for the finite ape machine — workspace initialization and orchestration.
-version: 0.0.4
+version: 0.0.5
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/uninstall_test.dart
+++ b/code/cli/test/uninstall_test.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:modular_cli_sdk/modular_cli_sdk.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:ape_cli/assets.dart';
+import 'package:ape_cli/commands/uninstall.dart';
+import 'package:ape_cli/targets/deployer.dart';
+import 'package:ape_cli/targets/target_adapter.dart';
+
+class _FakeAdapter extends TargetAdapter {
+  @override
+  String get name => 'fake';
+
+  @override
+  String baseDirectory(String homeDir) => p.join(homeDir, '.fake');
+
+  @override
+  String skillsDirectory(String homeDir) =>
+      p.join(homeDir, '.fake', 'skills');
+
+  @override
+  String agentDirectory(String homeDir) =>
+      p.join(homeDir, '.fake', 'agents');
+}
+
+void main() {
+  late Directory tempDir;
+  late Directory homeDir;
+  late TargetDeployer deployer;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('ape_uninstall_test_');
+    homeDir = Directory(p.join(tempDir.path, 'home'))..createSync();
+
+    final skillDir =
+        Directory(p.join(tempDir.path, 'assets', 'skills', 'memory-read'));
+    skillDir.createSync(recursive: true);
+    File(p.join(skillDir.path, 'SKILL.md')).writeAsStringSync('# Memory Read');
+
+    final agentDir = Directory(p.join(tempDir.path, 'assets', 'agents'));
+    agentDir.createSync(recursive: true);
+    File(p.join(agentDir.path, 'ape.agent.md'))
+        .writeAsStringSync('# APE Agent');
+
+    deployer = TargetDeployer(
+      assets: Assets(root: tempDir.path),
+      adapters: [_FakeAdapter()],
+      homeDir: homeDir.path,
+    );
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  group('UninstallCommand', () {
+    test('cleans deployed targets', () async {
+      deployer.deploy();
+
+      expect(
+        File(p.join(homeDir.path, '.fake', 'skills', 'memory-read', 'SKILL.md'))
+            .existsSync(),
+        isTrue,
+      );
+
+      final command = UninstallCommand(
+        UninstallInput(installDir: tempDir.path),
+        deployer: deployer,
+      );
+
+      final output = await command.execute();
+
+      expect(output.exitCode, ExitCode.ok);
+      expect(output.message, contains('uninstalled'));
+
+      // Targets should be cleaned
+      expect(
+        Directory(p.join(homeDir.path, '.fake', 'skills')).existsSync(),
+        isFalse,
+      );
+      expect(
+        Directory(p.join(homeDir.path, '.fake', 'agents')).existsSync(),
+        isFalse,
+      );
+    });
+
+    test('exits 0 when nothing was deployed', () async {
+      final command = UninstallCommand(
+        UninstallInput(installDir: tempDir.path),
+        deployer: deployer,
+      );
+
+      final output = await command.execute();
+      expect(output.exitCode, ExitCode.ok);
+    });
+  });
+}


### PR DESCRIPTION
## Descripción

Nuevo comando `ape uninstall` que limpia la instalación completa:

1. **Clean targets** — elimina agentes y skills de todos los targets (`~/.claude/`, `~/.copilot/`, etc.)
2. **Remove PATH** — elimina `ape\bin\` del PATH de usuario
3. **Delete install dir** — renombra el exe (trick de Windows) y lanza un proceso background que elimina `%LOCALAPPDATA%\ape\`

### Por qué

Cuando `ape upgrade` falla (#14), el usuario necesita reinstalar. Sin `uninstall`, debe limpiar manualmente PATH + directorio + targets.

### Tests

73 tests pasan (2 nuevos para uninstall).

Bump a `v0.0.5`.

Closes #16