### PR TITLE
fix(ci): update workflow paths after site/ move and fix dart in pwsh

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'site/**'
+      - 'code/site/**'
       - '.github/workflows/pages.yml'
 
 permissions:
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: site
+          path: code/site
 
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - 'code/cli/**'
-      - 'scripts/**'
       - '.github/workflows/release.yml'
 
 permissions:
@@ -46,7 +45,7 @@ jobs:
       - name: Build
         run: |
           New-Item -ItemType Directory -Force -Path build\bin | Out-Null
-          dart compile exe bin/main.dart -o build\bin\ape.exe
+          & "$env:DART_HOME\bin\dart.exe" compile exe bin/main.dart -o build\bin\ape.exe
           Copy-Item -Recurse assets build\assets
         shell: pwsh
 


### PR DESCRIPTION
## Problemas

1. **Release workflow falla**: `dart` no se encuentra en el step Build porque `shell: pwsh` no hereda el PATH de `setup-dart`. Fix: usar `\\bin\dart.exe` explícitamente.
2. **Pages workflow falla**: `upload-pages-artifact` apunta a `site/` pero se movió a `code/site/` en #11.
3. **Path trigger obsoleto**: `scripts/**` ya no existe en la raíz (movido a `code/cli/scripts/`).