### PR TITLE
fix(ci): remove explicit shell:pwsh from release Build step

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'site/**'
+      - 'code/site/**'
       - '.github/workflows/pages.yml'
 
 permissions:
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: site
+          path: code/site
 
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - 'code/cli/**'
-      - 'scripts/**'
       - '.github/workflows/release.yml'
 
 permissions:
@@ -48,11 +47,9 @@ jobs:
           New-Item -ItemType Directory -Force -Path build\bin | Out-Null
           dart compile exe bin/main.dart -o build\bin\ape.exe
           Copy-Item -Recurse assets build\assets
-        shell: pwsh
 
       - name: Package
         run: Compress-Archive -Path build\* -DestinationPath ape-windows-x64.zip
-        shell: pwsh
 
       - name: Create or update release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
El commit anterior (#18) corrigió el path de Pages pero la solución de `DART_HOME` tampoco funcionó. El problema real: `shell: pwsh` explícito crea un nuevo proceso pwsh que no hereda el PATH que `setup-dart` configura.

**Fix:** quitar `shell: pwsh` de los steps Build y Package. En `windows-latest` el shell por defecto ya es pwsh con el PATH correctamente configurado.