### PR TITLE
fix(ci): use plain dart command in Build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build
         run: |
           New-Item -ItemType Directory -Force -Path build\bin | Out-Null
-          & "$env:DART_HOME\bin\dart.exe" compile exe bin/main.dart -o build\bin\ape.exe
+          dart compile exe bin/main.dart -o build\bin\ape.exe
           Copy-Item -Recurse assets build\assets
 
       - name: Package


### PR DESCRIPTION
## Problema

El paso Build usaba `& "$env:DART_HOME\bin\dart.exe"` que no existe en el runner.

## Solución

Usar `dart compile exe` directamente. El shell por defecto hereda el PATH configurado por `setup-dart`, igual que los pasos Install/Analyze/Test que ya funcionan.

Closes #14 (pipeline)