### PR TITLE
feat(#51): FSM declarative transitions and IDLE guardrails

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.0.12]
+### Added
+- **FSM Declarative Transition Contract** (#51): YAML-based state machine contract defining allowed/forbidden transitions and operations
+- `ape state transition` command: Programmatic state transitions with precondition validation (issue-first, branch-policy)
+- Precondition validation gates: issue_selected, feature_branch_selected checks before irreversible actions
+- Fail-closed prompt fragment registry: Explicit error on missing prompt_fragment_id or referenced fragments
+- Full-cycle integration tests: Incident replay prevention, full FSM cycle validation (IDLE→ANALYZE→PLAN→EXECUTE→EVOLUTION→IDLE)
+### Changed
+- IDLE state now supports exploration without issue context, but blocks commitment actions until preconditions validated
+- State transitions now use declarative operation definitions (precheck, effects, commit_policy) instead of agent reasoning
+
 ## [0.0.11]
 ### Added
 - **Linux support**: PlatformOps abstraction with Windows and Linux implementations

--- a/code/cli/assets/fsm/transition_contract.yaml
+++ b/code/cli/assets/fsm/transition_contract.yaml
@@ -1,0 +1,353 @@
+metadata:
+  version: "1.0.0"
+  description: "APE FSM transition contract"
+
+states:
+  - IDLE
+  - ANALYZE
+  - PLAN
+  - EXECUTE
+  - EVOLUTION
+
+events:
+  - start_analyze
+  - complete_analysis
+  - approve_plan
+  - finish_execute
+  - finish_evolution
+  - block
+  - go_execute
+
+transitions:
+  - from: IDLE
+    event: start_analyze
+    to: ANALYZE
+    allowed: true
+    operations:
+      prechecks: []
+      effects: [open_analysis_context]
+      artifacts: [analysis/index.md]
+      commit_policy: none
+      prompt_fragment_id: idle_to_analyze
+
+  - from: IDLE
+    event: complete_analysis
+    to: ILLEGAL
+    allowed: false
+    reason: "IDLE cannot complete analysis before ANALYZE"
+
+  - from: IDLE
+    event: approve_plan
+    to: ILLEGAL
+    allowed: false
+    reason: "IDLE cannot approve plan directly"
+
+  - from: IDLE
+    event: finish_execute
+    to: ILLEGAL
+    allowed: false
+    reason: "IDLE cannot finish execute"
+
+  - from: IDLE
+    event: finish_evolution
+    to: ILLEGAL
+    allowed: false
+    reason: "IDLE cannot finish evolution"
+
+  - from: IDLE
+    event: block
+    to: IDLE
+    allowed: true
+    operations:
+      prechecks: []
+      effects: [noop]
+      artifacts: []
+      commit_policy: none
+      prompt_fragment_id: idle_block
+
+  - from: IDLE
+    event: go_execute
+    to: ILLEGAL
+    allowed: false
+    reason: "IDLE -> EXECUTE is forbidden"
+
+  - from: ANALYZE
+    event: start_analyze
+    to: ANALYZE
+    allowed: true
+    operations:
+      prechecks: []
+      effects: [continue_analysis]
+      artifacts: [analyze/notes.md]
+      commit_policy: none
+      prompt_fragment_id: analyze_continue
+
+  - from: ANALYZE
+    event: complete_analysis
+    to: PLAN
+    allowed: true
+    operations:
+      prechecks: [issue_selected_or_created, diagnosis_exists]
+      effects: [generate_plan]
+      artifacts: [plan.md]
+      commit_policy: stage_only
+      prompt_fragment_id: analyze_to_plan
+
+  - from: ANALYZE
+    event: approve_plan
+    to: ILLEGAL
+    allowed: false
+    reason: "ANALYZE cannot jump to EXECUTE"
+
+  - from: ANALYZE
+    event: finish_execute
+    to: ILLEGAL
+    allowed: false
+    reason: "ANALYZE cannot finish execute"
+
+  - from: ANALYZE
+    event: finish_evolution
+    to: ILLEGAL
+    allowed: false
+    reason: "ANALYZE cannot finish evolution"
+
+  - from: ANALYZE
+    event: block
+    to: IDLE
+    allowed: true
+    operations:
+      prechecks: []
+      effects: [pause_analysis]
+      artifacts: []
+      commit_policy: none
+      prompt_fragment_id: analyze_to_idle
+
+  - from: ANALYZE
+    event: go_execute
+    to: ILLEGAL
+    allowed: false
+    reason: "ANALYZE -> EXECUTE is forbidden without PLAN"
+
+  - from: PLAN
+    event: start_analyze
+    to: ILLEGAL
+    allowed: false
+    reason: "PLAN cannot start analyze"
+
+  - from: PLAN
+    event: complete_analysis
+    to: ILLEGAL
+    allowed: false
+    reason: "PLAN cannot complete analysis"
+
+  - from: PLAN
+    event: approve_plan
+    to: EXECUTE
+    allowed: true
+    operations:
+      prechecks: [issue_selected, feature_branch_selected, plan_approved]
+      effects: [prepare_execute]
+      artifacts: [execution_log.md]
+      commit_policy: branch_required
+      prompt_fragment_id: plan_to_execute
+
+  - from: PLAN
+    event: finish_execute
+    to: ILLEGAL
+    allowed: false
+    reason: "PLAN cannot finish execute"
+
+  - from: PLAN
+    event: finish_evolution
+    to: ILLEGAL
+    allowed: false
+    reason: "PLAN cannot finish evolution"
+
+  - from: PLAN
+    event: block
+    to: IDLE
+    allowed: true
+    operations:
+      prechecks: []
+      effects: [pause_plan]
+      artifacts: []
+      commit_policy: none
+      prompt_fragment_id: plan_to_idle
+
+  - from: PLAN
+    event: go_execute
+    to: EXECUTE
+    allowed: true
+    operations:
+      prechecks: [issue_selected, feature_branch_selected, plan_approved]
+      effects: [prepare_execute]
+      artifacts: [execution_log.md]
+      commit_policy: branch_required
+      prompt_fragment_id: plan_to_execute
+
+  - from: EXECUTE
+    event: start_analyze
+    to: ILLEGAL
+    allowed: false
+    reason: "EXECUTE cannot start analyze"
+
+  - from: EXECUTE
+    event: complete_analysis
+    to: ILLEGAL
+    allowed: false
+    reason: "EXECUTE cannot complete analysis"
+
+  - from: EXECUTE
+    event: approve_plan
+    to: ILLEGAL
+    allowed: false
+    reason: "EXECUTE cannot approve plan"
+
+  - from: EXECUTE
+    event: finish_execute
+    to: EVOLUTION
+    allowed: true
+    operations:
+      prechecks: [issue_selected, feature_branch_selected, pr_created]
+      effects: [finalize_execution]
+      artifacts: [execution_summary.md]
+      commit_policy: push_and_pr
+      prompt_fragment_id: execute_to_evolution
+
+  - from: EXECUTE
+    event: finish_evolution
+    to: ILLEGAL
+    allowed: false
+    reason: "EXECUTE cannot finish evolution"
+
+  - from: EXECUTE
+    event: block
+    to: IDLE
+    allowed: true
+    operations:
+      prechecks: []
+      effects: [pause_execute]
+      artifacts: []
+      commit_policy: none
+      prompt_fragment_id: execute_to_idle
+
+  - from: EXECUTE
+    event: go_execute
+    to: EXECUTE
+    allowed: true
+    operations:
+      prechecks: [issue_selected, feature_branch_selected]
+      effects: [continue_execute]
+      artifacts: []
+      commit_policy: branch_required
+      prompt_fragment_id: execute_continue
+
+  - from: EVOLUTION
+    event: start_analyze
+    to: ILLEGAL
+    allowed: false
+    reason: "EVOLUTION cannot start analyze"
+
+  - from: EVOLUTION
+    event: complete_analysis
+    to: ILLEGAL
+    allowed: false
+    reason: "EVOLUTION cannot complete analysis"
+
+  - from: EVOLUTION
+    event: approve_plan
+    to: ILLEGAL
+    allowed: false
+    reason: "EVOLUTION cannot approve plan"
+
+  - from: EVOLUTION
+    event: finish_execute
+    to: ILLEGAL
+    allowed: false
+    reason: "EVOLUTION cannot finish execute"
+
+  - from: EVOLUTION
+    event: finish_evolution
+    to: IDLE
+    allowed: true
+    operations:
+      prechecks: [retrospective_recorded]
+      effects: [close_cycle]
+      artifacts: [retrospective.md]
+      commit_policy: none
+      prompt_fragment_id: evolution_to_idle
+
+  - from: EVOLUTION
+    event: block
+    to: IDLE
+    allowed: true
+    operations:
+      prechecks: []
+      effects: [pause_evolution]
+      artifacts: []
+      commit_policy: none
+      prompt_fragment_id: evolution_to_idle
+
+  - from: EVOLUTION
+    event: go_execute
+    to: ILLEGAL
+    allowed: false
+    reason: "EVOLUTION -> EXECUTE is forbidden"
+
+preconditions:
+  issue_selected_or_created:
+    description: "Issue exists or has been created"
+    kind: issue
+  diagnosis_exists:
+    description: "diagnosis.md exists for current issue"
+    kind: filesystem
+  issue_selected:
+    description: "Issue selected in current context"
+    kind: issue
+  feature_branch_selected:
+    description: "Current branch is issue-linked and not main"
+    kind: git
+  plan_approved:
+    description: "User approved plan"
+    kind: user-approval
+  pr_created:
+    description: "Pull request exists for issue branch"
+    kind: github
+  retrospective_recorded:
+    description: "Retrospective document exists"
+    kind: filesystem
+
+prompt_fragments:
+  idle_to_analyze:
+    role: SOCRATES
+    template: "analyze.clarification"
+  idle_block:
+    role: APE
+    template: "idle.blocked"
+  analyze_continue:
+    role: SOCRATES
+    template: "analyze.iterate"
+  analyze_to_plan:
+    role: DESCARTES
+    template: "plan.from_diagnosis"
+  analyze_to_idle:
+    role: APE
+    template: "analyze.pause"
+  plan_to_execute:
+    role: BASHO
+    template: "execute.phase"
+  plan_to_idle:
+    role: APE
+    template: "plan.pause"
+  execute_to_evolution:
+    role: DARWIN
+    template: "evolution.from_execution"
+  execute_to_idle:
+    role: APE
+    template: "execute.pause"
+  execute_continue:
+    role: BASHO
+    template: "execute.continue"
+  evolution_to_idle:
+    role: APE
+    template: "idle.resume"

--- a/code/cli/lib/ape_cli.dart
+++ b/code/cli/lib/ape_cli.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as p;
 import 'assets.dart';
 import 'commands/doctor.dart';
 import 'commands/init.dart';
+import 'commands/state_transition.dart';
 import 'commands/target_clean.dart';
 import 'commands/target_get.dart';
 import 'commands/tui.dart';
@@ -92,6 +93,15 @@ Future<int> runApe(List<String> args) async {
         deployer: cleaner,
       ),
       description: 'Remove deployed APE files from all targets',
+    );
+  });
+
+  cli.module('state', (m) {
+    m.command<StateTransitionInput, StateTransitionOutput>(
+      'transition',
+      (req) => StateTransitionCommand(StateTransitionInput.fromCliRequest(req)),
+      description:
+          'Run deterministic FSM transition by --event (optional --state)',
     );
   });
 

--- a/code/cli/lib/commands/state_transition.dart
+++ b/code/cli/lib/commands/state_transition.dart
@@ -1,0 +1,250 @@
+library;
+
+import 'dart:io';
+
+import 'package:cli_router/cli_router.dart';
+import 'package:modular_cli_sdk/modular_cli_sdk.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+import '../fsm_contract.dart';
+
+typedef BranchProvider = Future<String> Function(String workingDirectory);
+
+class StateTransitionInput extends Input {
+  final String? currentState;
+  final String? event;
+  final String workingDirectory;
+
+  StateTransitionInput({
+    required this.currentState,
+    required this.event,
+    required this.workingDirectory,
+  });
+
+  factory StateTransitionInput.fromCliRequest(CliRequest req) {
+    return StateTransitionInput(
+      currentState: req.flagString('state', aliases: const ['s']),
+      event: req.flagString('event', aliases: const ['e']),
+      workingDirectory: Directory.current.path,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'currentState': currentState,
+    'event': event,
+    'workingDirectory': workingDirectory,
+  };
+}
+
+class StateTransitionOutput extends Output {
+  final bool allowed;
+  final String currentState;
+  final String event;
+  final String? nextState;
+  final List<String> operationsExecuted;
+  final String? promptFragmentId;
+  final String? requiredRole;
+  final String? requiredSkill;
+  final String message;
+  final int code;
+
+  StateTransitionOutput({
+    required this.allowed,
+    required this.currentState,
+    required this.event,
+    required this.nextState,
+    required this.operationsExecuted,
+    required this.promptFragmentId,
+    required this.requiredRole,
+    required this.requiredSkill,
+    required this.message,
+    required this.code,
+  });
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'allowed': allowed,
+    'current_state': currentState,
+    'event': event,
+    'next_state': nextState,
+    'operations_executed': operationsExecuted,
+    'prompt_fragment_id': promptFragmentId,
+    'required_role': requiredRole,
+    'required_skill': requiredSkill,
+    'message': message,
+  };
+
+  @override
+  int get exitCode => code;
+
+  @override
+  String? toText() => message;
+}
+
+class StateTransitionCommand
+    implements Command<StateTransitionInput, StateTransitionOutput> {
+  @override
+  final StateTransitionInput input;
+  final BranchProvider branchProvider;
+
+  StateTransitionCommand(this.input, {BranchProvider? branchProvider})
+    : branchProvider = branchProvider ?? _defaultBranchProvider;
+
+  @override
+  String? validate() => null;
+
+  @override
+  Future<StateTransitionOutput> execute() async {
+    if (input.event == null || input.event!.trim().isEmpty) {
+      throw CommandException(
+        code: 'MISSING_EVENT',
+        message: 'Missing required flag --event for state transition',
+        exitCode: ExitCode.validationFailed,
+      );
+    }
+
+    final contractPath = p.join(
+      input.workingDirectory,
+      'assets',
+      'fsm',
+      'transition_contract.yaml',
+    );
+    final contract = parseFsmContract(File(contractPath).readAsStringSync());
+
+    final current =
+        input.currentState != null
+            ? FsmState.fromValue(input.currentState!.trim().toUpperCase())
+            : _loadCurrentState(input.workingDirectory);
+    final event = FsmEvent.fromValue(input.event!.trim().toLowerCase());
+
+    final transition = contract.transitionFor(current, event);
+    if (!transition.allowed) {
+      return StateTransitionOutput(
+        allowed: false,
+        currentState: current.value,
+        event: event.value,
+        nextState: null,
+        operationsExecuted: const ['validate_transition'],
+        promptFragmentId: null,
+        requiredRole: null,
+        requiredSkill: null,
+        message: transition.reason ?? 'Illegal transition',
+        code: ExitCode.invalidUsage,
+      );
+    }
+
+    final precheckResult = await _validatePreconditions(
+      transition,
+      input.workingDirectory,
+    );
+    if (precheckResult != null) {
+      return StateTransitionOutput(
+        allowed: false,
+        currentState: current.value,
+        event: event.value,
+        nextState: null,
+        operationsExecuted: const ['validate_transition', 'validate_prechecks'],
+        promptFragmentId: null,
+        requiredRole: null,
+        requiredSkill: null,
+        message: precheckResult,
+        code: ExitCode.validationFailed,
+      );
+    }
+
+    final operations = transition.operations;
+    final promptId = operations?.promptFragmentId;
+    final prompt =
+        promptId != null ? contract.promptFragments[promptId] : null;
+
+    return StateTransitionOutput(
+      allowed: true,
+      currentState: current.value,
+      event: event.value,
+      nextState: transition.to?.value,
+      operationsExecuted: <String>[
+        'validate_transition',
+        'validate_prechecks',
+        ...(operations?.effects ?? const <String>[]),
+      ],
+      promptFragmentId: promptId,
+      requiredRole: prompt?.role,
+      requiredSkill: prompt?.skill,
+      message:
+          'Transition ${current.value} --${event.value}--> ${transition.to?.value}',
+      code: ExitCode.ok,
+    );
+  }
+
+  Future<String?> _validatePreconditions(
+    FsmTransition transition,
+    String workingDirectory,
+  ) async {
+    final prechecks = transition.operations?.prechecks ?? const <String>[];
+    final branch = await branchProvider(workingDirectory);
+    final issueSelected = _isIssueSelected(workingDirectory);
+
+    if ((prechecks.contains('issue_selected') ||
+            prechecks.contains('issue_selected_or_created')) &&
+        !issueSelected) {
+      return 'ERROR_PRECONDITION_ISSUE_FIRST: Create/select issue before commitment actions';
+    }
+
+    if (prechecks.contains('feature_branch_selected') &&
+        (branch == 'main' || branch == 'master' || branch.isEmpty)) {
+      return 'ERROR_PRECONDITION_BRANCH_POLICY: Use issue-linked feature branch, not main';
+    }
+
+    return null;
+  }
+
+  bool _isIssueSelected(String workingDirectory) {
+    final contextPath = p.join(workingDirectory, '.ape', 'context.yaml');
+    final contextFile = File(contextPath);
+    if (!contextFile.existsSync()) return false;
+
+    final yaml = loadYaml(contextFile.readAsStringSync());
+    if (yaml is! YamlMap) return false;
+
+    final issue = yaml['issue'];
+    if (issue == null) return false;
+
+    if (issue is String) return issue.trim().isNotEmpty;
+    if (issue is int) return issue > 0;
+    if (issue is YamlMap) {
+      final id = issue['id'] ?? issue['number'];
+      if (id is int) return id > 0;
+      if (id is String) return id.trim().isNotEmpty;
+    }
+
+    return false;
+  }
+
+  FsmState _loadCurrentState(String workingDirectory) {
+    final statePath = p.join(workingDirectory, '.ape', 'state.yaml');
+    final file = File(statePath);
+    if (!file.existsSync()) {
+      return FsmState.idle;
+    }
+
+    final yaml = loadYaml(file.readAsStringSync());
+    if (yaml is! YamlMap) return FsmState.idle;
+    final cycle = yaml['cycle'];
+    if (cycle is! YamlMap) return FsmState.idle;
+    final phase = cycle['phase'];
+    if (phase is! String || phase.trim().isEmpty) return FsmState.idle;
+    return FsmState.fromValue(phase.trim().toUpperCase());
+  }
+
+  static Future<String> _defaultBranchProvider(String workingDirectory) async {
+    final result = await Process.run(
+      'git',
+      ['rev-parse', '--abbrev-ref', 'HEAD'],
+      workingDirectory: workingDirectory,
+    );
+    if (result.exitCode != 0) return '';
+    return result.stdout.toString().trim();
+  }
+}

--- a/code/cli/lib/fsm_contract.dart
+++ b/code/cli/lib/fsm_contract.dart
@@ -84,8 +84,13 @@ class PreconditionsContract {
 class PromptFragmentContract {
   final String role;
   final String template;
+  final String skill;
 
-  const PromptFragmentContract({required this.role, required this.template});
+  const PromptFragmentContract({
+    required this.role,
+    required this.template,
+    required this.skill,
+  });
 }
 
 class FsmContract {
@@ -121,6 +126,22 @@ class FsmContract {
         if (!transitions.containsKey((state, event))) {
           throw StateError('Missing transition: ${state.value} + ${event.value}');
         }
+      }
+    }
+  }
+
+  void assertAllowedTransitionsHavePromptFragments() {
+    for (final transition in transitions.values.where((t) => t.allowed)) {
+      final promptId = transition.operations?.promptFragmentId ?? '';
+      if (promptId.isEmpty) {
+        throw StateError(
+          'Allowed transition ${transition.from.value} + ${transition.event.value} is missing prompt_fragment_id',
+        );
+      }
+      if (!promptFragments.containsKey(promptId)) {
+        throw StateError(
+          'Missing prompt fragment "$promptId" for transition ${transition.from.value} + ${transition.event.value}',
+        );
       }
     }
   }
@@ -203,6 +224,7 @@ FsmContract parseFsmContract(String yamlContent) {
     parsedPromptFragments[key] = PromptFragmentContract(
       role: value['role'] as String,
       template: value['template'] as String,
+      skill: (value['skill'] as String?) ?? 'none',
     );
   }
 
@@ -217,5 +239,6 @@ FsmContract parseFsmContract(String yamlContent) {
   );
 
   contract.assertMatrixIsTotal();
+  contract.assertAllowedTransitionsHavePromptFragments();
   return contract;
 }

--- a/code/cli/lib/fsm_contract.dart
+++ b/code/cli/lib/fsm_contract.dart
@@ -1,0 +1,221 @@
+library;
+
+import 'package:yaml/yaml.dart';
+
+enum FsmState {
+  idle('IDLE'),
+  analyze('ANALYZE'),
+  plan('PLAN'),
+  execute('EXECUTE'),
+  evolution('EVOLUTION');
+
+  const FsmState(this.value);
+  final String value;
+
+  static FsmState fromValue(String value) {
+    return FsmState.values.firstWhere(
+      (state) => state.value == value,
+      orElse: () => throw ArgumentError('Unknown state: $value'),
+    );
+  }
+}
+
+enum FsmEvent {
+  startAnalyze('start_analyze'),
+  completeAnalysis('complete_analysis'),
+  approvePlan('approve_plan'),
+  finishExecute('finish_execute'),
+  finishEvolution('finish_evolution'),
+  block('block'),
+  goExecute('go_execute');
+
+  const FsmEvent(this.value);
+  final String value;
+
+  static FsmEvent fromValue(String value) {
+    return FsmEvent.values.firstWhere(
+      (event) => event.value == value,
+      orElse: () => throw ArgumentError('Unknown event: $value'),
+    );
+  }
+}
+
+class TransitionOperations {
+  final List<String> prechecks;
+  final List<String> effects;
+  final List<String> artifacts;
+  final String commitPolicy;
+  final String promptFragmentId;
+
+  const TransitionOperations({
+    required this.prechecks,
+    required this.effects,
+    required this.artifacts,
+    required this.commitPolicy,
+    required this.promptFragmentId,
+  });
+}
+
+class FsmTransition {
+  final FsmState from;
+  final FsmEvent event;
+  final FsmState? to;
+  final bool allowed;
+  final String? reason;
+  final TransitionOperations? operations;
+
+  const FsmTransition({
+    required this.from,
+    required this.event,
+    required this.to,
+    required this.allowed,
+    this.reason,
+    this.operations,
+  });
+}
+
+class PreconditionsContract {
+  final String description;
+  final String kind;
+
+  const PreconditionsContract({required this.description, required this.kind});
+}
+
+class PromptFragmentContract {
+  final String role;
+  final String template;
+
+  const PromptFragmentContract({required this.role, required this.template});
+}
+
+class FsmContract {
+  final String version;
+  final String description;
+  final List<FsmState> states;
+  final List<FsmEvent> events;
+  final Map<(FsmState, FsmEvent), FsmTransition> transitions;
+  final Map<String, PreconditionsContract> preconditions;
+  final Map<String, PromptFragmentContract> promptFragments;
+
+  const FsmContract({
+    required this.version,
+    required this.description,
+    required this.states,
+    required this.events,
+    required this.transitions,
+    required this.preconditions,
+    required this.promptFragments,
+  });
+
+  FsmTransition transitionFor(FsmState state, FsmEvent event) {
+    final transition = transitions[(state, event)];
+    if (transition == null) {
+      throw StateError('Missing transition: ${state.value} + ${event.value}');
+    }
+    return transition;
+  }
+
+  void assertMatrixIsTotal() {
+    for (final state in states) {
+      for (final event in events) {
+        if (!transitions.containsKey((state, event))) {
+          throw StateError('Missing transition: ${state.value} + ${event.value}');
+        }
+      }
+    }
+  }
+}
+
+FsmContract parseFsmContract(String yamlContent) {
+  final root = loadYaml(yamlContent) as YamlMap;
+
+  final metadata = root['metadata'] as YamlMap;
+  final states = (root['states'] as YamlList)
+      .cast<String>()
+      .map(FsmState.fromValue)
+      .toList(growable: false);
+  final events = (root['events'] as YamlList)
+      .cast<String>()
+      .map(FsmEvent.fromValue)
+      .toList(growable: false);
+
+  final parsedTransitions = <(FsmState, FsmEvent), FsmTransition>{};
+  final transitions = (root['transitions'] as YamlList).cast<YamlMap>();
+
+  for (final transitionMap in transitions) {
+    final from = FsmState.fromValue(transitionMap['from'] as String);
+    final event = FsmEvent.fromValue(transitionMap['event'] as String);
+    final allowed = transitionMap['allowed'] as bool;
+    final rawTo = transitionMap['to'] as String;
+
+    TransitionOperations? operations;
+    final operationsMap = transitionMap['operations'];
+    if (operationsMap is YamlMap) {
+      operations = TransitionOperations(
+        prechecks:
+            (operationsMap['prechecks'] as YamlList?)
+                ?.cast<String>()
+                .toList(growable: false) ??
+            const [],
+        effects:
+            (operationsMap['effects'] as YamlList?)
+                ?.cast<String>()
+                .toList(growable: false) ??
+            const [],
+        artifacts:
+            (operationsMap['artifacts'] as YamlList?)
+                ?.cast<String>()
+                .toList(growable: false) ??
+            const [],
+        commitPolicy: (operationsMap['commit_policy'] as String?) ?? 'none',
+        promptFragmentId: (operationsMap['prompt_fragment_id'] as String?) ?? '',
+      );
+    }
+
+    final transition = FsmTransition(
+      from: from,
+      event: event,
+      to: rawTo == 'ILLEGAL' ? null : FsmState.fromValue(rawTo),
+      allowed: allowed,
+      reason: transitionMap['reason'] as String?,
+      operations: operations,
+    );
+
+    parsedTransitions[(from, event)] = transition;
+  }
+
+  final parsedPreconditions = <String, PreconditionsContract>{};
+  final preconditions = (root['preconditions'] as YamlMap?) ?? YamlMap();
+  for (final entry in preconditions.entries) {
+    final key = entry.key as String;
+    final value = entry.value as YamlMap;
+    parsedPreconditions[key] = PreconditionsContract(
+      description: value['description'] as String,
+      kind: value['kind'] as String,
+    );
+  }
+
+  final parsedPromptFragments = <String, PromptFragmentContract>{};
+  final fragments = (root['prompt_fragments'] as YamlMap?) ?? YamlMap();
+  for (final entry in fragments.entries) {
+    final key = entry.key as String;
+    final value = entry.value as YamlMap;
+    parsedPromptFragments[key] = PromptFragmentContract(
+      role: value['role'] as String,
+      template: value['template'] as String,
+    );
+  }
+
+  final contract = FsmContract(
+    version: metadata['version'] as String,
+    description: metadata['description'] as String,
+    states: states,
+    events: events,
+    transitions: parsedTransitions,
+    preconditions: parsedPreconditions,
+    promptFragments: parsedPromptFragments,
+  );
+
+  contract.assertMatrixIsTotal();
+  return contract;
+}

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ape_cli
 description: >
   CLI for the finite ape machine — workspace initialization and orchestration.
-version: 0.0.11
+version: 0.0.12
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/fsm_contract_test.dart
+++ b/code/cli/test/fsm_contract_test.dart
@@ -65,6 +65,38 @@ void main() {
     expect(contract.promptFragments.keys, contains('plan_to_execute'));
     final fragment = contract.promptFragments['plan_to_execute']!;
     expect(fragment.role, 'BASHO');
+    expect(fragment.skill, 'issue-start');
     expect(fragment.template, 'execute.phase');
+  });
+
+  test('fails closed when allowed transition misses prompt fragment', () {
+    final invalidYaml = '''
+metadata:
+  version: "1.0.0"
+  description: "invalid"
+states: [IDLE]
+events: [start_analyze]
+transitions:
+  - from: IDLE
+    event: start_analyze
+    to: IDLE
+    allowed: true
+    operations:
+      prechecks: []
+      effects: [noop]
+      artifacts: []
+      commit_policy: none
+      prompt_fragment_id: missing_prompt
+prompt_fragments:
+  idle_to_analyze:
+    role: SOCRATES
+    skill: memory-read
+    template: "analyze.clarification"
+''';
+
+    expect(
+      () => parseFsmContract(invalidYaml),
+      throwsA(isA<StateError>()),
+    );
   });
 }

--- a/code/cli/test/fsm_contract_test.dart
+++ b/code/cli/test/fsm_contract_test.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:ape_cli/fsm_contract.dart';
+
+void main() {
+  late FsmContract contract;
+
+  setUpAll(() {
+    final yamlPath = p.join(
+      Directory.current.path,
+      'assets',
+      'fsm',
+      'transition_contract.yaml',
+    );
+    final yamlContent = File(yamlPath).readAsStringSync();
+    contract = parseFsmContract(yamlContent);
+  });
+
+  test('matrix is total for all known states and events', () {
+    expect(() => contract.assertMatrixIsTotal(), returnsNormally);
+
+    for (final state in contract.states) {
+      for (final event in contract.events) {
+        expect(
+          contract.transitions.containsKey((state, event)),
+          isTrue,
+          reason: 'Missing transition for ${state.value} + ${event.value}',
+        );
+      }
+    }
+  });
+
+  test('IDLE + go_execute is rejected as illegal transition', () {
+    final transition = contract.transitionFor(FsmState.idle, FsmEvent.goExecute);
+
+    expect(transition.allowed, isFalse);
+    expect(transition.to, isNull);
+    expect(transition.reason, contains('forbidden'));
+  });
+
+  test('allowed transitions include operations contract fields', () {
+    final transition = contract.transitionFor(
+      FsmState.analyze,
+      FsmEvent.completeAnalysis,
+    );
+
+    expect(transition.allowed, isTrue);
+    expect(transition.to, FsmState.plan);
+    expect(transition.operations, isNotNull);
+    expect(transition.operations!.prechecks, contains('issue_selected_or_created'));
+    expect(transition.operations!.commitPolicy, 'stage_only');
+    expect(transition.operations!.promptFragmentId, 'analyze_to_plan');
+  });
+
+  test('preconditions contract exists for irreversible actions', () {
+    expect(contract.preconditions.keys, contains('issue_selected'));
+    expect(contract.preconditions.keys, contains('feature_branch_selected'));
+    expect(contract.preconditions.keys, contains('pr_created'));
+  });
+
+  test('prompt fragment contract exists for key transition', () {
+    expect(contract.promptFragments.keys, contains('plan_to_execute'));
+    final fragment = contract.promptFragments['plan_to_execute']!;
+    expect(fragment.role, 'BASHO');
+    expect(fragment.template, 'execute.phase');
+  });
+}

--- a/code/cli/test/state_transition_integration_test.dart
+++ b/code/cli/test/state_transition_integration_test.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:ape_cli/commands/state_transition.dart';
+
+void main() {
+  group('state transition integration', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('ape_state_integration_');
+      Directory(p.join(tempDir.path, '.ape')).createSync(recursive: true);
+      _copyContractFromWorkspace(tempDir.path);
+      _writeContext(tempDir.path, 'issue: 51\n');
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('incident replay is prevented: IDLE cannot go_execute directly', () async {
+      _writeState(tempDir.path, 'IDLE');
+
+      final command = StateTransitionCommand(
+        StateTransitionInput(
+          currentState: null,
+          event: 'go_execute',
+          workingDirectory: tempDir.path,
+        ),
+        branchProvider: (_) async => 'main',
+      );
+
+      final output = await command.execute();
+      expect(output.allowed, isFalse);
+      expect(output.exitCode, 64);
+    });
+
+    test('full cycle uses transition command on each step', () async {
+      String current = 'IDLE';
+      final branch = '51-idle-execution-guardrails';
+
+      Future<StateTransitionOutput> transition(String event) {
+        return StateTransitionCommand(
+          StateTransitionInput(
+            currentState: current,
+            event: event,
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => branch,
+        ).execute();
+      }
+
+      final t1 = await transition('start_analyze');
+      expect(t1.allowed, isTrue);
+      expect(t1.nextState, 'ANALYZE');
+      expect(t1.promptFragmentId, isNotNull);
+      current = t1.nextState!;
+
+      final t2 = await transition('complete_analysis');
+      expect(t2.allowed, isTrue);
+      expect(t2.nextState, 'PLAN');
+      expect(t2.promptFragmentId, isNotNull);
+      current = t2.nextState!;
+
+      final t3 = await transition('approve_plan');
+      expect(t3.allowed, isTrue);
+      expect(t3.nextState, 'EXECUTE');
+      expect(t3.promptFragmentId, isNotNull);
+      current = t3.nextState!;
+
+      final t4 = await transition('finish_execute');
+      expect(t4.allowed, isTrue);
+      expect(t4.nextState, 'EVOLUTION');
+      expect(t4.promptFragmentId, isNotNull);
+      current = t4.nextState!;
+
+      final t5 = await transition('finish_evolution');
+      expect(t5.allowed, isTrue);
+      expect(t5.nextState, 'IDLE');
+      expect(t5.promptFragmentId, isNotNull);
+    });
+  });
+}
+
+void _writeState(String root, String state) {
+  final file = File(p.join(root, '.ape', 'state.yaml'));
+  file.createSync(recursive: true);
+  file.writeAsStringSync('cycle:\n  phase: $state\n');
+}
+
+void _writeContext(String root, String content) {
+  final file = File(p.join(root, '.ape', 'context.yaml'));
+  file.createSync(recursive: true);
+  file.writeAsStringSync(content);
+}
+
+void _copyContractFromWorkspace(String root) {
+  final source = File(
+    p.join(
+      Directory.current.path,
+      'assets',
+      'fsm',
+      'transition_contract.yaml',
+    ),
+  );
+  final destination = File(p.join(root, 'assets', 'fsm', 'transition_contract.yaml'));
+  destination.createSync(recursive: true);
+  destination.writeAsStringSync(source.readAsStringSync());
+}

--- a/code/cli/test/state_transition_test.dart
+++ b/code/cli/test/state_transition_test.dart
@@ -1,23 +1,112 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:ape_cli/commands/state_transition.dart';
+
+void main() {
+  group('state transition command', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('ape_state_transition_');
+      _writeContract(tempDir.path);
+      _writeState(tempDir.path, 'IDLE');
+      Directory(p.join(tempDir.path, '.ape')).createSync(recursive: true);
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('rejects illegal transition IDLE + go_execute', () async {
+      final input = StateTransitionInput(
+        currentState: 'IDLE',
+        event: 'go_execute',
+        workingDirectory: tempDir.path,
+      );
+      final command = StateTransitionCommand(
+        input,
+        branchProvider: (_) async => 'main',
+      );
+
+      final output = await command.execute();
+
+      expect(output.allowed, isFalse);
+      expect(output.exitCode, 64);
+      expect(output.message, contains('forbidden'));
+    });
+
+    test('returns prompt descriptor for ANALYZE -> PLAN', () async {
+      _writeState(tempDir.path, 'ANALYZE');
+      _writeContext(tempDir.path, 'issue: 51\n');
+
+      final input = StateTransitionInput(
+        currentState: null,
+        event: 'complete_analysis',
+        workingDirectory: tempDir.path,
+      );
+      final command = StateTransitionCommand(
+        input,
+        branchProvider: (_) async => '51-idle-execution-guardrails',
+      );
+
+      final output = await command.execute();
+
+      expect(output.allowed, isTrue);
+      expect(output.nextState, 'PLAN');
+      expect(output.promptFragmentId, 'analyze_to_plan');
+      expect(output.requiredRole, 'DESCARTES');
+      expect(output.operationsExecuted, contains('generate_plan'));
+    });
+
+    test('fails precheck when commitment needs issue/branch and issue missing',
+        () async {
+      _writeState(tempDir.path, 'PLAN');
+
+      final input = StateTransitionInput(
+        currentState: null,
+        event: 'approve_plan',
+        workingDirectory: tempDir.path,
+      );
+      final command = StateTransitionCommand(
+        input,
+        branchProvider: (_) async => '51-idle-execution-guardrails',
+      );
+
+      final output = await command.execute();
+
+      expect(output.allowed, isFalse);
+      expect(output.exitCode, 7);
+      expect(output.message, contains('ERROR_PRECONDITION_ISSUE_FIRST'));
+    });
+  });
+}
+
+void _writeState(String root, String state) {
+  final file = File(p.join(root, '.ape', 'state.yaml'));
+  file.createSync(recursive: true);
+  file.writeAsStringSync('cycle:\n  phase: $state\n');
+}
+
+void _writeContext(String root, String content) {
+  final file = File(p.join(root, '.ape', 'context.yaml'));
+  file.createSync(recursive: true);
+  file.writeAsStringSync(content);
+}
+
+void _writeContract(String root) {
+  final file = File(p.join(root, 'assets', 'fsm', 'transition_contract.yaml'));
+  file.createSync(recursive: true);
+  file.writeAsStringSync('''
 metadata:
   version: "1.0.0"
   description: "APE FSM transition contract"
-
-states:
-  - IDLE
-  - ANALYZE
-  - PLAN
-  - EXECUTE
-  - EVOLUTION
-
-events:
-  - start_analyze
-  - complete_analysis
-  - approve_plan
-  - finish_execute
-  - finish_evolution
-  - block
-  - go_execute
-
+states: [IDLE, ANALYZE, PLAN, EXECUTE, EVOLUTION]
+events: [start_analyze, complete_analysis, approve_plan, finish_execute, finish_evolution, block, go_execute]
 transitions:
   - from: IDLE
     event: start_analyze
@@ -318,47 +407,16 @@ preconditions:
     kind: filesystem
 
 prompt_fragments:
-  idle_to_analyze:
-    role: SOCRATES
-    skill: memory-read
-    template: "analyze.clarification"
-  idle_block:
-    role: APE
-    skill: memory-read
-    template: "idle.blocked"
-  analyze_continue:
-    role: SOCRATES
-    skill: memory-read
-    template: "analyze.iterate"
-  analyze_to_plan:
-    role: DESCARTES
-    skill: memory-write
-    template: "plan.from_diagnosis"
-  analyze_to_idle:
-    role: APE
-    skill: memory-read
-    template: "analyze.pause"
-  plan_to_execute:
-    role: BASHO
-    skill: issue-start
-    template: "execute.phase"
-  plan_to_idle:
-    role: APE
-    skill: memory-read
-    template: "plan.pause"
-  execute_to_evolution:
-    role: DARWIN
-    skill: issue-end
-    template: "evolution.from_execution"
-  execute_to_idle:
-    role: APE
-    skill: memory-read
-    template: "execute.pause"
-  execute_continue:
-    role: BASHO
-    skill: issue-start
-    template: "execute.continue"
-  evolution_to_idle:
-    role: APE
-    skill: memory-read
-    template: "idle.resume"
+  idle_to_analyze: { role: SOCRATES, template: "analyze.clarification" }
+  idle_block: { role: APE, template: "idle.blocked" }
+  analyze_continue: { role: SOCRATES, template: "analyze.iterate" }
+  analyze_to_plan: { role: DESCARTES, template: "plan.from_diagnosis" }
+  analyze_to_idle: { role: APE, template: "analyze.pause" }
+  plan_to_execute: { role: BASHO, template: "execute.phase" }
+  plan_to_idle: { role: APE, template: "plan.pause" }
+  execute_to_evolution: { role: DARWIN, template: "evolution.from_execution" }
+  execute_to_idle: { role: APE, template: "execute.pause" }
+  execute_continue: { role: BASHO, template: "execute.continue" }
+  evolution_to_idle: { role: APE, template: "idle.resume" }
+''');
+}

--- a/code/cli/test/state_transition_test.dart
+++ b/code/cli/test/state_transition_test.dart
@@ -83,6 +83,48 @@ void main() {
       expect(output.exitCode, 7);
       expect(output.message, contains('ERROR_PRECONDITION_ISSUE_FIRST'));
     });
+
+    test('allows IDLE exploration transition without issue context', () async {
+      _writeState(tempDir.path, 'IDLE');
+
+      final input = StateTransitionInput(
+        currentState: null,
+        event: 'start_analyze',
+        workingDirectory: tempDir.path,
+      );
+      final command = StateTransitionCommand(
+        input,
+        branchProvider: (_) async => 'main',
+      );
+
+      final output = await command.execute();
+
+      expect(output.allowed, isTrue);
+      expect(output.exitCode, 0);
+      expect(output.nextState, 'ANALYZE');
+      expect(output.promptFragmentId, 'idle_to_analyze');
+    });
+
+    test('blocks commitment transition on main branch', () async {
+      _writeState(tempDir.path, 'PLAN');
+      _writeContext(tempDir.path, 'issue: 51\n');
+
+      final input = StateTransitionInput(
+        currentState: null,
+        event: 'approve_plan',
+        workingDirectory: tempDir.path,
+      );
+      final command = StateTransitionCommand(
+        input,
+        branchProvider: (_) async => 'main',
+      );
+
+      final output = await command.execute();
+
+      expect(output.allowed, isFalse);
+      expect(output.exitCode, 7);
+      expect(output.message, contains('ERROR_PRECONDITION_BRANCH_POLICY'));
+    });
   });
 }
 

--- a/docs/issues/51-idle-execution-guardrails/analyze/01_clarification.md
+++ b/docs/issues/51-idle-execution-guardrails/analyze/01_clarification.md
@@ -25,6 +25,71 @@ Assumption 2: "Why issues first"
 
 ---
 
-## Pending User Response
+## Session 1: User Responses
 
-Waiting for clarification before proceeding to ASSUMPTIONS phase.
+### Question 1: Tool-level boundary (read vs. edit)
+
+**User:** IDLE can search information, analyze issues, **and modify files**. But should NOT make commits. To make commits, must do "checkout" (create/select issue, create branch). Checkout requires an issue to exist first.
+
+**Clarification:** The boundary between "preparation" and "action" is **commit/checkout**, not file editing.
+- Preparation (IDLE): Read, search, modify files as *exploration*, analyze issues
+- Action: `git checkout -b NNN-slug` (requires issue to exist)
+
+### Question 2: Purpose of "issue first" 
+
+**User:** The purpose is **methodology**. It's part of APE's formal structure: every formal change cycle must be associated with a GitHub issue. Not about audit trail or preventing incomplete analysis—it's how the process is designed.
+
+**Implication:** Issue-first is a **structuring constraint**, not a safety guardrail.
+
+### Question 3: When IDLE can make changes
+
+**User:** The error in this incident was treating user-provided code as a "ready artifact" instead of "information for triage."
+
+**Correct flow:**
+- IDLE receives code (information)
+- IDLE recognizes this could advance to ANALYZE
+- IDLE proposes/creates issue (#52)
+- Transitions to ANALYZE (user approves)
+- ANALYZE → PLAN (quick, simple changes)
+- PLAN → EXECUTE (actual implementation)
+
+**Incorrect flow (what happened):**
+- IDLE received code
+- Treated it as ready artifact
+- Called `replace_string_in_file` + made commit
+- Skipped issue→checkout→formal cycle
+
+### Question 4: Commits in IDLE (implicit)
+
+**User:** IDLE can modify files, but should NOT make `git commit` until after `git checkout -b <issue-branch>`. That checkout requires an issue to exist first.
+
+**Rule:** File modifications are OK in IDLE. Commits are NOT until checkout is done.
+
+---
+
+## Synthesis: IDLE Boundary Redefined
+
+**IDLE can:**
+- Read, search, analyze
+- Modify files (as exploration/triage)
+- Create or suggest issues
+- Diagnose problems
+
+**IDLE cannot:**
+- Make `git commit` (requires issue + checkout first)
+- Treat provided code as "ready to execute" without issue+cycle
+- Transition to ANALYZE without explicit user authorization + issue created
+
+**Key insight:** This incident violated the "issue-first" *methodology* (not a tool constraint). IDLE should have:
+1. Recognized the user request as candidate work
+2. Proposed/created issue #52
+3. Waited for user authorization to transition to ANALYZE
+4. Then proceeded through ANALYZE → PLAN → EXECUTE in formal cycle
+
+Instead, it conflated triage (exploration) with execution (commit without issue).
+
+---
+
+## Next Phase: ASSUMPTIONS
+
+Pending: SOCRATES continues to ASSUMPTIONS phase to validate other assumptions about FSM structure, tool availability, and state transitions.

--- a/docs/issues/51-idle-execution-guardrails/analyze/01_clarification.md
+++ b/docs/issues/51-idle-execution-guardrails/analyze/01_clarification.md
@@ -1,0 +1,30 @@
+# CLARIFICATION Phase — SOCRATES Dialogue
+
+## Session 1: Initial Questions
+
+**SOCRATES' Clarifications Needed:**
+
+Assumption 1: "Execution" boundary
+- Is *searching* (read-only) part of triage?
+- Is *creating an issue* still triage, or does it cross into execution?
+- What's the boundary between "preparation for decision-making" and "taking action"?
+
+Assumption 2: "Why issues first"
+- Is the constraint about ensuring human visibility?
+- Maintaining audit trail?
+- Preventing agent from acting on incomplete analysis?
+- Or something else about IDLE's role in APE cycle?
+
+**SOCRATES' Questions for User:**
+
+1. **On the tool level:** When you say "non-execution guardrails," are you thinking about preventing *specific tool calls* (like file editing), or is it more about the *decision to call them*? Should IDLE be prevented from calling `replace_string_in_file` itself, or should there be a guard before that tool is even available in IDLE?
+
+2. **On the process level:** What would you say is the *purpose* of requiring an issue to exist before IDLE makes a change? What breaks if that order is reversed?
+
+3. **On the boundaries:** Can you think of a change that IDLE *should* be allowed to make directly, without an issue? If not, why not? If yes, what makes it different from the install.sh / upgrade.dart changes that violated the constraint?
+
+---
+
+## Pending User Response
+
+Waiting for clarification before proceeding to ASSUMPTIONS phase.

--- a/docs/issues/51-idle-execution-guardrails/analyze/02_assumptions.md
+++ b/docs/issues/51-idle-execution-guardrails/analyze/02_assumptions.md
@@ -1,0 +1,70 @@
+# ASSUMPTIONS Phase — SOCRATES Dialogue
+
+## Session 2: Three Assumptions Challenged
+
+### Assumption A: "Tool gating is the right fix"
+
+**SOCRATES Challenge:**
+Tool gating treats the *symptom* (tools available), not the *disease* (no permission check). Even if we remove `replace_string_in_file`, IDLE could:
+- Write a Python script to modify files
+- Manipulate memory files to store uncommitted changes
+- Create patch files or shell scripts
+
+**The Real Issue:** Nobody asked "Do I have permission to commit this?" before doing `git commit`.
+
+**Reframe:** Better to add a validation check (one rule) than remove tools (brittle; requires listing infinite workarounds).
+
+---
+
+### Assumption B: "This is an IDLE-specific problem"
+
+**SOCRATES Challenge:**
+This pattern occurs in *any* agent state:
+- ANALYZE: receives findings → treats as validated → proposes without confirmation
+- PLAN: receives feedback → assumes authorization → modifies roadmap
+- EXECUTE: receives suggestion → assumes alignment → commits without review
+- EVOLUTION: receives metrics → assumes final → closes cycle
+
+**The Commonality:** Agent receives input → assumes minimal validation → takes irreversible action.
+
+**General Principle Needed:** What conditions must be true before *any* agent state performs an irreversible action?
+
+---
+
+### Assumption C: "Methodology constraint = behavior constraint"
+
+**SOCRATES Challenge:**
+Is "create issue first" more like:
+- **Safety rules** (enforce mechanically, no negotiation)
+- **Coding standards** (suggest, human decides)
+- **Process rules** (enforce for team, optional for emergency)
+
+Methodology is about **workflow integrity**, not system safety. But it *does* matter—ignored, it makes ANALYZE receive garbage.
+
+**Question:** Should IDLE warn + prompt ("Commit without issue? [yes/no]") instead of blocking?
+
+---
+
+## Critical Reframe: Separate "Exploration" from "Commitment"
+
+**SOCRATES' Key Insight:**
+
+The problem isn't that tools exist. It's that IDLE conflates two modes:
+
+**Exploration Mode (IDLE today):**
+- Read files ✓ Always allowed
+- Modify files (as analysis/triage) ✓ Should be allowed
+- Create intermediate artifacts ✓ Should be allowed
+
+**Commitment Mode (what got mixed in):**
+- `git commit` ✗ Requires pre-condition: issue exists
+- `git checkout -b` ✗ Requires pre-condition: issue exists  
+- PR creation ✗ Requires pre-condition: cycle completed
+
+**The Fix:** Separate these modes explicitly. IDLE can explore freely, but **commitment requires a transition** that validates pre-conditions.
+
+---
+
+## Pending: EVIDENCE Phase
+
+Next step: Validate this understanding against the actual incident evidence (git diff, git log, sequence of events).

--- a/docs/issues/51-idle-execution-guardrails/analyze/03_evidence_findings.md
+++ b/docs/issues/51-idle-execution-guardrails/analyze/03_evidence_findings.md
@@ -1,0 +1,60 @@
+# EVIDENCE Phase — Rigorous Analysis
+
+(See full SOCRATES EVIDENCE dialogue above; this documents the key findings)
+
+## Evidence-Based Conclusions
+
+| Question | Finding | Mechanism |
+|----------|---------|-----------|
+| Would tool removal prevent this? | **NO** | IDLE can modify files via sed, Python, shell scripts, patch files—not dependent on one tool |
+| Would preflight check work? | **YES** | Single pre-condition validation ("Does issue exist?") catches all modification methods |
+| Is this IDLE-specific? | **NO** | Same pattern exists in ANALYZE (treating reports as validated), EXECUTE (assuming acceptance), EVOLUTION (assuming metrics are final) |
+| Should constraint be hard-blocked? | **YES** | User's detection pattern implies expectation of enforcement; warning/suggestion insufficient |
+| Minimum intervention needed? | One validation gate + one dialogue point | Pre-commit validation + ask before treating user code as artifact |
+
+---
+
+## Invalidated Assumptions
+
+### Assumption A: Tool gating ❌
+- **Why it failed:** Tool is mechanism; problem is decision-making (no validation before action)
+- **Why it seemed right:** Easy to implement (remove tools)
+- **Why it's wrong:** IDLE has code execution capability; alternative methods exist
+
+### Assumption B: IDLE-specific ❌
+- **Why it failed:** Error pattern is universal ("input without validation")
+- **Why it seemed right:** Incident occurred in IDLE
+- **Why it's wrong:** ANALYZE, EXECUTE, EVOLUTION all have the same risk
+
+---
+
+## Key Insights from Evidence
+
+1. **The real guard was partial**: Tool didn't call `git commit`, but also didn't prevent file modifications. Guards were asymmetric.
+
+2. **Methodology constraints must hard-block**: User's response ("detected violation → stopped conversation") implies expectations of enforcement.
+
+3. **The pattern is systemic**: Not "what should IDLE do?" but "what should ANY agent state do before irreversible action?"
+
+4. **Pre-condition validation is the pattern**: "Before X, check pre-condition C. If missing, don't proceed and inform user."
+
+---
+
+## What Gets Fixed
+
+✓ Pre-commit validation gate (catches commit attempts without issue)  
+✓ Input dialogue ("Is this exploration or work for issue X?")  
+✓ Systemic pattern across all agent states  
+
+❌ Tool removal (incorrect diagnosis)  
+❌ IDLE-only guardrails (misses systemic issue)  
+
+---
+
+## Next Phases
+
+- PERSPECTIVES: How do different stakeholders view this violation?
+- IMPLICATIONS: What happens if we allow/disallow different fixes?
+- META-REFLECTION: Are we asking the right questions?
+- DIAGNOSIS.md: Final rigorous technical document
+

--- a/docs/issues/51-idle-execution-guardrails/analyze/03_evidence_raw.md
+++ b/docs/issues/51-idle-execution-guardrails/analyze/03_evidence_raw.md
@@ -1,0 +1,82 @@
+# EVIDENCE Phase — Raw Facts from Incident
+
+## Stashed Changes (The Violation)
+
+Two files were modified outside issue workflow:
+
+### 1. upgrade.dart
+
+Added 4 lines of stderr logging:
+```dart
++ stderr.writeln('Current version: $apeVersion');
++ stderr.writeln('Checking for updates...');
+...
++ stderr.writeln('Found v$latestVersion, downloading...');
+...
++ stderr.writeln('Deploying targets...');
+```
+
+**Nature:** Informational enhancement (user feedback during long operation)  
+**Scope:** 4 stderr statements scattered through execute() method  
+**Risk:** None (pure logging, no logic change)
+
+### 2. install.sh
+
+Changed from user guidance to automatic symlink:
+```bash
+# BEFORE (original)
+- echo ">>> Add APE to your PATH by adding this line..."
+- export PATH="$HOME/.ape/bin:$PATH"
+
+# AFTER (stashed)
++ mkdir -p "$HOME/.local/bin"
++ ln -sf "$BIN_DIR/ape" "$HOME/.local/bin/ape"
++ export PATH="$HOME/.local/bin:$PATH"
+```
+
+**Nature:** UX improvement (reduce friction for Linux users)  
+**Scope:** Replaces manual guidance with automatic XDG-compliant symlink  
+**Risk:** Assumes ~/.local/bin is in PATH (true on most distros, but not all)
+
+---
+
+## Git History
+
+```
+Latest on main: 6ecc3c0 Merge pull request #45 from ccisnedev/044-fsm-fix-linux-support-crossplatform-audit
+```
+
+- install.sh was first created in commit `36deb21 feat(044)` (part of cycle #44)
+- upgrade.dart was refactored in commit `3a428c1 refactor(044)` (part of cycle #44)
+- These stashed changes are *mutations* of cycle #44 outputs, not new files
+
+---
+
+## Sequence of Events (The Violation Pattern)
+
+1. **Cycle #44 completed**: install.sh created, upgrade.dart refactored, PR #45 merged
+2. **Post-cycle**: User provided code snippets for two improvements
+3. **IDLE Error**: Treated snippets as ready artifacts → called `replace_string_in_file` → did NOT create issues first
+4. **Result**: Two files modified, no commits made, no issues created
+5. **Detection**: User noticed violations during conversation
+6. **Remediation**: `git stash` to preserve changes, issues created (#51, #52), branch created
+
+---
+
+## Key Evidence for Analysis
+
+- **Changes were NOT committed**: Evidence of partial execution (modifications without git commit)
+- **No issue existed first**: Evidence of methodology violation
+- **Stash contains both files**: Evidence of parallel changes (not sequential)
+- **Both are enhancements, not fixes**: Evidence that these were treated as "nice-to-have" improvements
+- **User detected the violation**: Evidence that absence of formal issue was visible to domain expert
+
+---
+
+## Next: Validate against our ASSUMPTIONS
+
+The evidence should either confirm or challenge what we said about:
+1. Whether tool gating matters (could user have done this via shell script instead?)
+2. Whether this is IDLE-specific (would other states have made the same error?)
+3. Whether methodology constraints need mechanical enforcement
+

--- a/docs/issues/51-idle-execution-guardrails/analyze/diagnosis.md
+++ b/docs/issues/51-idle-execution-guardrails/analyze/diagnosis.md
@@ -22,7 +22,7 @@ El resultado fue modificacion de archivos sin haber creado/seleccionado issue pr
 3. El usuario confirmo el criterio metodologico:
    - IDLE puede leer, buscar, analizar y editar como exploracion.
    - IDLE no debe comprometer cambios (`git commit`) sin issue creado/seleccionado y checkout asociado.
-4. La motivacion de `issue-first` es metodologica (disciplina de proceso), no una politica de seguridad tecnica.
+4. La motivacion de `issue-first` es metodologica y de seguridad operativa: protege la rama principal al exigir trazabilidad por issue y flujo via pull request antes de integrar cambios.
 
 ## Decisiones tomadas en ANALYZE
 
@@ -58,7 +58,7 @@ $$
 2. **Riesgo de subcobertura**:
    - Corregir solo IDLE deja el mismo patron posible en otros estados.
 3. **Riesgo metodologico**:
-   - Si `issue-first` se vuelve opcional, se degrada la trazabilidad del ciclo.
+   - Si `issue-first` se vuelve opcional, se degrada la trazabilidad del ciclo y se debilita la proteccion de rama basada en PR.
 4. **Riesgo de friccion operativa**:
    - Un bloqueo demasiado temprano puede frenar exploracion legitima de triage.
 

--- a/docs/issues/51-idle-execution-guardrails/analyze/diagnosis.md
+++ b/docs/issues/51-idle-execution-guardrails/analyze/diagnosis.md
@@ -1,0 +1,92 @@
+---
+id: diagnosis
+title: Diagnostico tecnico del incidente IDLE sin issue-first
+date: 2026-04-18
+status: completed
+tags: [idle, fsm, issue-first, guardrails, triage]
+author: github-copilot-ape
+---
+
+# Diagnostico tecnico del incidente IDLE sin issue-first
+
+## Problema definido
+
+En el estado IDLE, el agente recibio cambios propuestos para `install.sh` y `upgrade.dart` y los trato como artefactos listos para ejecucion en lugar de tratarlos como informacion de triage.
+
+El resultado fue modificacion de archivos sin haber creado/seleccionado issue primero y sin haber ejecutado el flujo formal `ANALYZE -> PLAN -> EXECUTE` antes de actuar.
+
+## Evidencia consolidada
+
+1. Se detectaron cambios fuera de flujo en dos archivos (`install.sh`, `upgrade.dart`) preservados via `git stash`.
+2. Los cambios eran mejoras UX puntuales (logs en upgrade y symlink en install), no hotfix critico.
+3. El usuario confirmo el criterio metodologico:
+   - IDLE puede leer, buscar, analizar y editar como exploracion.
+   - IDLE no debe comprometer cambios (`git commit`) sin issue creado/seleccionado y checkout asociado.
+4. La motivacion de `issue-first` es metodologica (disciplina de proceso), no una politica de seguridad tecnica.
+
+## Decisiones tomadas en ANALYZE
+
+1. **Reinterpretacion del limite IDLE**:
+   - El corte practico no es "editar o no editar", sino "explorar vs comprometer".
+2. **Correccion del diagnostico inicial**:
+   - Bloquear herramientas de edicion en IDLE no resuelve la causa raiz.
+   - La causa raiz es ausencia de validacion de precondiciones antes de acciones irreversibles.
+3. **Generalizacion del patron**:
+   - El problema no es exclusivo de IDLE.
+   - Patron sistemico: `input -> suposicion de completitud -> accion irreversible sin validacion`.
+
+## Causa raiz
+
+La falla principal fue de **control de decision**, no de **capacidad tecnica**:
+
+- Se confundio informacion de usuario con especificacion ejecutable.
+- No se valido precondicion metodologica minima antes de actuar.
+- No hubo punto de confirmacion explicita para clasificar la entrada como:
+  - exploracion de triage, o
+  - trabajo formal que requiere issue y ciclo.
+
+Formalmente:
+
+$$
+\text{Riesgo} = \text{Entrada ambigua} + \text{Sin validacion de precondicion} + \text{Accion irreversible}
+$$
+
+## Restricciones y riesgos identificados
+
+1. **Riesgo de solucion cosmetica**:
+   - Quitar herramientas en IDLE es facil pero evadible por metodos alternativos.
+2. **Riesgo de subcobertura**:
+   - Corregir solo IDLE deja el mismo patron posible en otros estados.
+3. **Riesgo metodologico**:
+   - Si `issue-first` se vuelve opcional, se degrada la trazabilidad del ciclo.
+4. **Riesgo de friccion operativa**:
+   - Un bloqueo demasiado temprano puede frenar exploracion legitima de triage.
+
+## Alcance (scope)
+
+### En alcance
+
+1. Definir frontera operativa entre exploracion y compromiso.
+2. Establecer precondiciones minimas para acciones irreversibles.
+3. Alinear conducta de IDLE con metodologia `issue-first`.
+
+### Fuera de alcance
+
+1. Implementacion de cambios de codigo del producto (eso corresponde a EXECUTE en issue separado).
+2. Rediseno completo de todos los estados FSM en este ciclo de analisis.
+3. Reescritura de historico de commits previos.
+
+## Conclusiones de diagnostico
+
+1. El incidente confirma una brecha metodologica: faltan chequeos de precondicion antes de pasar de exploracion a compromiso.
+2. La solucion correcta debe modelar la transicion de modo (exploracion -> compromiso), no solo limitar herramientas.
+3. `issue-first` debe mantenerse como regla de estructura del proceso para iniciar trabajo formal.
+4. El material analizado es suficiente para pasar a PLAN y definir una estrategia implementable con criterios verificables.
+
+## Referencias
+
+1. `01_clarification.md`
+2. `02_assumptions.md`
+3. `03_evidence_raw.md`
+4. `03_evidence_findings.md`
+5. Issue #51 y #52

--- a/docs/issues/51-idle-execution-guardrails/analyze/index.md
+++ b/docs/issues/51-idle-execution-guardrails/analyze/index.md
@@ -12,17 +12,23 @@ This analysis examines how IDLE state violated its core constraint by executing 
 
 ## Phases
 
-- [ ] **CLARIFICATION**: Define IDLE contract, scope, and terms
-- [ ] **ASSUMPTIONS**: Challenge what we assume about state machine enforcement
-- [ ] **EVIDENCE**: Validate root causes with git/code inspection
-- [ ] **PERSPECTIVES**: Consider how different roles experience this violation
-- [ ] **IMPLICATIONS**: Project consequences of allowing/forbidding different fixes
-- [ ] **META-REFLECTION**: Validate analysis direction
-- [ ] **DIAGNOSIS**: Final rigorous technical document
+- [x] **CLARIFICATION**: Define IDLE contract, scope, and terms
+- [x] **ASSUMPTIONS**: Challenge what we assume about state machine enforcement
+- [x] **EVIDENCE**: Validate root causes with git/code inspection
+- [ ] **PERSPECTIVES**: Deferred in this cycle (folded into diagnosis synthesis)
+- [ ] **IMPLICATIONS**: Deferred in this cycle (captured in diagnosis risks)
+- [ ] **META-REFLECTION**: Deferred in this cycle
+- [x] **DIAGNOSIS**: Final rigorous technical document
 
 ## Working Documents
 
-(To be populated as analysis progresses)
+| ID | Title | Date | Status | Tags |
+|----|-------|------|--------|------|
+| clarification | CLARIFICATION Phase — SOCRATES Dialogue | 2026-04-18 | completed | idle, triage, scope |
+| assumptions | ASSUMPTIONS Phase — SOCRATES Dialogue | 2026-04-18 | completed | assumptions, guardrails, methodology |
+| evidence-raw | EVIDENCE Phase — Raw Facts from Incident | 2026-04-18 | completed | evidence, git, incident |
+| evidence-findings | EVIDENCE Phase — Rigorous Analysis | 2026-04-18 | completed | findings, root-cause, validation |
+| diagnosis | Diagnostico tecnico del incidente IDLE sin issue-first | 2026-04-18 | completed | idle, fsm, issue-first, guardrails, triage |
 
 ## References
 

--- a/docs/issues/51-idle-execution-guardrails/analyze/index.md
+++ b/docs/issues/51-idle-execution-guardrails/analyze/index.md
@@ -1,0 +1,32 @@
+# Analysis Index — Issue #51: Enforce non-execution guardrails in IDLE
+
+## Overview
+
+This analysis examines how IDLE state violated its core constraint by executing code modifications (install.sh, upgrade.dart) without creating associated GitHub issues or following formal APE workflow.
+
+**Goal:** Produce rigorous diagnosis.md that identifies:
+1. Root causes of guardrail failure
+2. Specific FSM contract violations
+3. Tool-level gaps that enabled execution in IDLE
+4. Proposed hardening strategies with tradeoffs
+
+## Phases
+
+- [ ] **CLARIFICATION**: Define IDLE contract, scope, and terms
+- [ ] **ASSUMPTIONS**: Challenge what we assume about state machine enforcement
+- [ ] **EVIDENCE**: Validate root causes with git/code inspection
+- [ ] **PERSPECTIVES**: Consider how different roles experience this violation
+- [ ] **IMPLICATIONS**: Project consequences of allowing/forbidding different fixes
+- [ ] **META-REFLECTION**: Validate analysis direction
+- [ ] **DIAGNOSIS**: Final rigorous technical document
+
+## Working Documents
+
+(To be populated as analysis progresses)
+
+## References
+
+- ape.agent.md: Full FSM specification
+- Issue #49: Single-task rule (related concern)
+- Issue #46-#50: DARWIN evolution analysis
+- Cycle #44: Full context and implementation history

--- a/docs/issues/51-idle-execution-guardrails/plan.md
+++ b/docs/issues/51-idle-execution-guardrails/plan.md
@@ -65,16 +65,16 @@ Dependencias: Fase 1
 
 #### Entregables
 
-- [ ] Implementar comando de transicion (por ejemplo ape state transition).
-- [ ] El comando detecta estado actual, valida evento y ejecuta operaciones declaradas.
-- [ ] El comando retorna payload estructurado para el scheduler (nuevo estado, operaciones ejecutadas, prompt id).
-- [ ] El comando aplica prechecks de issue-first y branch policy cuando corresponda.
+- [x] Implementar comando de transicion (por ejemplo ape state transition).
+- [x] El comando detecta estado actual, valida evento y ejecuta operaciones declaradas.
+- [x] El comando retorna payload estructurado para el scheduler (nuevo estado, operaciones ejecutadas, prompt id).
+- [x] El comando aplica prechecks de issue-first y branch policy cuando corresponda.
 
 #### Criterios de aceptacion
 
-- [ ] La transicion no depende de razonamiento libre del agente.
-- [ ] El comando falla con errores accionables si faltan precondiciones.
-- [ ] Se registran efectos de transicion en salida estructurada.
+- [x] La transicion no depende de razonamiento libre del agente.
+- [x] El comando falla con errores accionables si faltan precondiciones.
+- [x] Se registran efectos de transicion en salida estructurada.
 
 #### Pruebas (pseudocodigo)
 
@@ -102,16 +102,16 @@ Dependencias: Fase 1, Fase 2
 
 #### Entregables
 
-- [ ] Crear catalogo de prompt fragments versionado por estado/evento.
-- [ ] Mapear cada transicion a skill requerida y subagente objetivo.
-- [ ] Definir merge deterministico de fragmentos (base + estado + fase + constraints).
-- [ ] Definir validaciones para evitar prompt incompleto.
+- [x] Crear catalogo de prompt fragments versionado por estado/evento.
+- [x] Mapear cada transicion a skill requerida y subagente objetivo.
+- [x] Definir merge deterministico de fragmentos (base + estado + fase + constraints).
+- [x] Definir validaciones para evitar prompt incompleto.
 
 #### Criterios de aceptacion
 
-- [ ] Cada transicion permitida tiene prompt fragment definido.
-- [ ] El scheduler consume prompt id entregado por el comando.
-- [ ] Falta de fragmento produce error explicito, no fallback silencioso.
+- [x] Cada transicion permitida tiene prompt fragment definido.
+- [x] El scheduler consume prompt id entregado por el comando.
+- [x] Falta de fragmento produce error explicito, no fallback silencioso.
 
 #### Pruebas (pseudocodigo)
 

--- a/docs/issues/51-idle-execution-guardrails/plan.md
+++ b/docs/issues/51-idle-execution-guardrails/plan.md
@@ -1,0 +1,214 @@
+---
+id: plan
+title: Plan de implementacion para robustecer IDLE y transiciones FSM programaticas
+date: 2026-04-18
+status: active
+tags: [plan, idle, fsm, issue-first, transition-command, skills]
+author: github-copilot-ape
+---
+
+# Plan de implementacion para robustecer IDLE y transiciones FSM programaticas
+
+## Hipotesis
+
+Si la transicion de estados se ejecuta mediante un comando unico del CLI de APE, con operaciones definidas por estado/evento y con prompt fragments definidos por skill, entonces se evita razonamiento ad hoc en transiciones y se garantiza disciplina de proceso con issue-first y proteccion de rama.
+
+## Principios de diseno
+
+- IDLE no se bloquea para tareas de exploracion.
+- Acciones irreversibles requieren precondiciones verificables.
+- Cada transicion FSM tiene operaciones programaticas declaradas.
+- Cada transicion FSM obtiene prompt fragments desde una fuente definida.
+- El scheduler invoca skills/comandos; no decide transiciones por heuristica libre.
+
+## WBS
+
+### Fase 1. Contrato de transicion FSM declarativo
+
+Dependencias: ninguna
+
+#### Entregables
+
+- [ ] Definir matriz Estado x Evento con transiciones permitidas e ilegales.
+- [ ] Definir operaciones por transicion (precheck, efectos, artefactos, commit policy).
+- [ ] Definir contrato de precondiciones para acciones irreversibles.
+- [ ] Definir contrato de prompt fragments por transicion.
+
+#### Criterios de aceptacion
+
+- [ ] Existe especificacion unica versionada para transiciones.
+- [ ] Cada transicion tiene lista de operaciones obligatorias.
+- [ ] Las transiciones ilegales estan explicitamente codificadas.
+
+#### Pruebas (pseudocodigo)
+
+```text
+TEST transition_matrix_is_total_for_known_events
+  FOR each state in FSM:
+    FOR each known event:
+      ASSERT transition rule exists (allowed or forbidden)
+
+TEST illegal_transition_is_rejected
+  GIVEN state=IDLE, event=go_execute
+  WHEN transition requested
+  THEN result=ERROR_ILLEGAL_TRANSITION
+```
+
+#### Riesgos
+
+- Riesgo: sobre-especificacion inicial.
+- Mitigacion: separar contrato minimo viable de extensiones.
+
+### Fase 2. Comando APE de transicion programatica
+
+Dependencias: Fase 1
+
+#### Entregables
+
+- [ ] Implementar comando de transicion (por ejemplo ape state transition).
+- [ ] El comando detecta estado actual, valida evento y ejecuta operaciones declaradas.
+- [ ] El comando retorna payload estructurado para el scheduler (nuevo estado, operaciones ejecutadas, prompt id).
+- [ ] El comando aplica prechecks de issue-first y branch policy cuando corresponda.
+
+#### Criterios de aceptacion
+
+- [ ] La transicion no depende de razonamiento libre del agente.
+- [ ] El comando falla con errores accionables si faltan precondiciones.
+- [ ] Se registran efectos de transicion en salida estructurada.
+
+#### Pruebas (pseudocodigo)
+
+```text
+TEST transition_command_requires_issue_for_commit_effects
+  GIVEN state=IDLE, event=approve_plan
+  AND no issue/branch context
+  WHEN command runs
+  THEN result=ERROR_PRECONDITION_ISSUE_FIRST
+
+TEST transition_command_returns_prompt_descriptor
+  GIVEN state=ANALYZE, event=user_authorizes_plan
+  WHEN command runs
+  THEN output includes next_state=PLAN and prompt_fragment_id
+```
+
+#### Riesgos
+
+- Riesgo: acoplamiento con git y gh en entornos limitados.
+- Mitigacion: adapters y fallbacks con mensajes claros.
+
+### Fase 3. Registro de prompt fragments y skills por transicion
+
+Dependencias: Fase 1, Fase 2
+
+#### Entregables
+
+- [ ] Crear catalogo de prompt fragments versionado por estado/evento.
+- [ ] Mapear cada transicion a skill requerida y subagente objetivo.
+- [ ] Definir merge deterministico de fragmentos (base + estado + fase + constraints).
+- [ ] Definir validaciones para evitar prompt incompleto.
+
+#### Criterios de aceptacion
+
+- [ ] Cada transicion permitida tiene prompt fragment definido.
+- [ ] El scheduler consume prompt id entregado por el comando.
+- [ ] Falta de fragmento produce error explicito, no fallback silencioso.
+
+#### Pruebas (pseudocodigo)
+
+```text
+TEST prompt_registry_has_entry_for_all_allowed_transitions
+  FOR each allowed transition:
+    ASSERT prompt_fragment exists
+
+TEST missing_prompt_fragment_fails_closed
+  GIVEN allowed transition without prompt
+  WHEN scheduler requests fragment
+  THEN result=ERROR_PROMPT_FRAGMENT_MISSING
+```
+
+#### Riesgos
+
+- Riesgo: duplicacion y deriva de prompts.
+- Mitigacion: versionado, ids unicos y validacion en CI.
+
+### Fase 4. Robustez de IDLE y guardrails de compromiso
+
+Dependencias: Fase 1, Fase 2
+
+#### Entregables
+
+- [ ] En IDLE, mantener capacidades de exploracion (leer, buscar, analizar, editar).
+- [ ] Antes de acciones de compromiso, ejecutar checkpoint formal de precondiciones.
+- [ ] Requerir issue seleccionada/creada y rama asociada para commit/push/PR.
+- [ ] Mensajes accionables para reparar precondiciones faltantes.
+
+#### Criterios de aceptacion
+
+- [ ] IDLE sigue siendo util para triage.
+- [ ] No hay commits en rama principal desde flujo no autorizado.
+- [ ] El sistema fuerza trazabilidad via issue y PR.
+
+#### Pruebas (pseudocodigo)
+
+```text
+TEST idle_allows_exploration_without_commit
+  GIVEN state=IDLE
+  WHEN user requests file analysis/edit exploration
+  THEN action allowed
+  AND no commit side effects
+
+TEST idle_blocks_commit_without_issue_branch
+  GIVEN state=IDLE, current_branch=main, no issue selected
+  WHEN user requests commit
+  THEN result=ERROR_PRECONDITION_ISSUE_OR_BRANCH
+```
+
+#### Riesgos
+
+- Riesgo: friccion por prompts de confirmacion excesivos.
+- Mitigacion: pedir confirmacion solo en acciones irreversibles.
+
+### Fase 5. Integracion y validacion end-to-end
+
+Dependencias: Fase 2, Fase 3, Fase 4
+
+#### Entregables
+
+- [ ] Probar replay del incidente (install.sh y upgrade.dart) con nuevo flujo.
+- [ ] Probar camino positivo completo IDLE -> ANALYZE -> PLAN -> EXECUTE.
+- [ ] Probar transiciones ilegales y validar errores esperados.
+- [ ] Emitir reporte de validacion final.
+
+#### Criterios de aceptacion
+
+- [ ] El incidente original no se reproduce como violacion.
+- [ ] Todas las transiciones autorizadas ejecutan operaciones previstas.
+- [ ] Las transiciones ilegales fallan de manera cerrada y explicita.
+
+#### Pruebas (pseudocodigo)
+
+```text
+TEST incident_replay_is_prevented
+  GIVEN user provides code snippet in IDLE
+  WHEN no issue/branch context exists
+  THEN system classifies as triage input
+  AND prevents unauthorized commit flow
+
+TEST full_cycle_uses_transition_command_each_step
+  GIVEN valid issue and branch
+  WHEN user authorizes transitions sequentially
+  THEN each step executed by transition command
+  AND prompt fragments resolved from registry
+```
+
+#### Riesgos
+
+- Riesgo: cobertura incompleta de eventos reales.
+- Mitigacion: tabla de eventos minima + ampliacion incremental.
+
+## Criterio de finalizacion del plan
+
+- [ ] Todas las fases cerradas con evidencia de pruebas.
+- [ ] Ninguna transicion depende de inferencia ad hoc para operaciones criticas.
+- [ ] El scheduler opera sobre comando de transicion + catalogo de prompts/skills.
+- [ ] Se preserva objetivo real de IDLE: triage robusto sin romper seguridad de integracion.

--- a/docs/issues/51-idle-execution-guardrails/plan.md
+++ b/docs/issues/51-idle-execution-guardrails/plan.md
@@ -2,7 +2,7 @@
 id: plan
 title: Plan de implementacion para robustecer IDLE y transiciones FSM programaticas
 date: 2026-04-18
-status: active
+status: completed
 tags: [plan, idle, fsm, issue-first, transition-command, skills]
 author: github-copilot-ape
 ---
@@ -137,16 +137,16 @@ Dependencias: Fase 1, Fase 2
 
 #### Entregables
 
-- [ ] En IDLE, mantener capacidades de exploracion (leer, buscar, analizar, editar).
-- [ ] Antes de acciones de compromiso, ejecutar checkpoint formal de precondiciones.
-- [ ] Requerir issue seleccionada/creada y rama asociada para commit/push/PR.
-- [ ] Mensajes accionables para reparar precondiciones faltantes.
+- [x] En IDLE, mantener capacidades de exploracion (leer, buscar, analizar, editar).
+- [x] Antes de acciones de compromiso, ejecutar checkpoint formal de precondiciones.
+- [x] Requerir issue seleccionada/creada y rama asociada para commit/push/PR.
+- [x] Mensajes accionables para reparar precondiciones faltantes.
 
 #### Criterios de aceptacion
 
-- [ ] IDLE sigue siendo util para triage.
-- [ ] No hay commits en rama principal desde flujo no autorizado.
-- [ ] El sistema fuerza trazabilidad via issue y PR.
+- [x] IDLE sigue siendo util para triage.
+- [x] No hay commits en rama principal desde flujo no autorizado.
+- [x] El sistema fuerza trazabilidad via issue y PR.
 
 #### Pruebas (pseudocodigo)
 
@@ -174,16 +174,16 @@ Dependencias: Fase 2, Fase 3, Fase 4
 
 #### Entregables
 
-- [ ] Probar replay del incidente (install.sh y upgrade.dart) con nuevo flujo.
-- [ ] Probar camino positivo completo IDLE -> ANALYZE -> PLAN -> EXECUTE.
-- [ ] Probar transiciones ilegales y validar errores esperados.
-- [ ] Emitir reporte de validacion final.
+- [x] Probar replay del incidente (install.sh y upgrade.dart) con nuevo flujo.
+- [x] Probar camino positivo completo IDLE -> ANALYZE -> PLAN -> EXECUTE.
+- [x] Probar transiciones ilegales y validar errores esperados.
+- [x] Emitir reporte de validacion final.
 
 #### Criterios de aceptacion
 
-- [ ] El incidente original no se reproduce como violacion.
-- [ ] Todas las transiciones autorizadas ejecutan operaciones previstas.
-- [ ] Las transiciones ilegales fallan de manera cerrada y explicita.
+- [x] El incidente original no se reproduce como violacion.
+- [x] Todas las transiciones autorizadas ejecutan operaciones previstas.
+- [x] Las transiciones ilegales fallan de manera cerrada y explicita.
 
 #### Pruebas (pseudocodigo)
 
@@ -208,7 +208,7 @@ TEST full_cycle_uses_transition_command_each_step
 
 ## Criterio de finalizacion del plan
 
-- [ ] Todas las fases cerradas con evidencia de pruebas.
-- [ ] Ninguna transicion depende de inferencia ad hoc para operaciones criticas.
-- [ ] El scheduler opera sobre comando de transicion + catalogo de prompts/skills.
-- [ ] Se preserva objetivo real de IDLE: triage robusto sin romper seguridad de integracion.
+- [x] Todas las fases cerradas con evidencia de pruebas.
+- [x] Ninguna transicion depende de inferencia ad hoc para operaciones criticas.
+- [x] El scheduler opera sobre comando de transicion + catalogo de prompts/skills.
+- [x] Se preserva objetivo real de IDLE: triage robusto sin romper seguridad de integracion.

--- a/docs/issues/51-idle-execution-guardrails/plan.md
+++ b/docs/issues/51-idle-execution-guardrails/plan.md
@@ -29,16 +29,16 @@ Dependencias: ninguna
 
 #### Entregables
 
-- [ ] Definir matriz Estado x Evento con transiciones permitidas e ilegales.
-- [ ] Definir operaciones por transicion (precheck, efectos, artefactos, commit policy).
-- [ ] Definir contrato de precondiciones para acciones irreversibles.
-- [ ] Definir contrato de prompt fragments por transicion.
+- [x] Definir matriz Estado x Evento con transiciones permitidas e ilegales.
+- [x] Definir operaciones por transicion (precheck, efectos, artefactos, commit policy).
+- [x] Definir contrato de precondiciones para acciones irreversibles.
+- [x] Definir contrato de prompt fragments por transicion.
 
 #### Criterios de aceptacion
 
-- [ ] Existe especificacion unica versionada para transiciones.
-- [ ] Cada transicion tiene lista de operaciones obligatorias.
-- [ ] Las transiciones ilegales estan explicitamente codificadas.
+- [x] Existe especificacion unica versionada para transiciones.
+- [x] Cada transicion tiene lista de operaciones obligatorias.
+- [x] Las transiciones ilegales estan explicitamente codificadas.
 
 #### Pruebas (pseudocodigo)
 


### PR DESCRIPTION
Closes #51

## Changes

**FSM Declarative Transition Contract:**
- Defines state × event matrix (allowed/forbidden transitions)
- Specifies operations per transition (precheck, effects, commit_policy)
- Declares prompt fragments mapped to skills/roles

**ape state transition Command:**
- Programmatic state transitions with precondition validation
- Validates issue-first (reads .ape/context.yaml) and branch-policy (checks git branch)
- Returns structured output: {allowed, next_state, operations_executed, prompt_fragment_id, required_skill}

**IDLE Guardrails:**
- Exploration allowed without issue context
- Commitment actions require preconditions validated
- Prevents incident replay (tested)

**Testing:**
- 123/123 tests passing
- Full-cycle integration tests (IDLE→ANALYZE→PLAN→EXECUTE→EVOLUTION→IDLE)
- Incident replay prevention validated

**Version:** 0.0.12