### PR TITLE
fix(#58): routing catch-all, version sync, doctor cleanup

### DIFF
--- a/code/cli/lib/commands/doctor.dart
+++ b/code/cli/lib/commands/doctor.dart
@@ -1,6 +1,6 @@
 /// Doctor command — verifies prerequisites.
 ///
-/// Checks: ape version, git, gh, gh auth, gh copilot, vscode copilot extension.
+/// Checks: ape version, git, gh, gh auth.
 library;
 
 import 'dart:io';
@@ -153,62 +153,9 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
     checks.add(authCheck);
     if (!authCheck.passed) {
       allPassed = false;
-      return DoctorOutput(checks: checks, passed: false);
-    }
-
-    // Check 5: gh copilot --version
-    final copilotCheck = await _checkCommand(
-      name: 'gh copilot',
-      executable: 'gh',
-      arguments: ['copilot', '--version'],
-      versionExtractor: _extractCopilotVersion,
-    );
-    checks.add(copilotCheck);
-    if (!copilotCheck.passed) {
-      allPassed = false;
-    }
-
-    // Check 6: VS Code with GitHub Copilot extension
-    final vscodeCheck = await _checkVsCodeCopilot();
-    checks.add(vscodeCheck);
-    if (!vscodeCheck.passed) {
-      allPassed = false;
     }
 
     return DoctorOutput(checks: checks, passed: allPassed);
-  }
-
-  /// Checks that VS Code is installed and has the GitHub Copilot extension.
-  Future<DoctorCheck> _checkVsCodeCopilot() async {
-    try {
-      final result = await _runProcess('code', ['--list-extensions']);
-      if (result.exitCode != 0) {
-        return DoctorCheck(
-          name: 'vscode copilot',
-          passed: false,
-          error: 'VS Code CLI not found',
-        );
-      }
-      final extensions = result.stdout.toString();
-      final hasCopilot = extensions
-          .split('\n')
-          .any((line) => line.trim().toLowerCase() == 'github.copilot');
-      if (hasCopilot) {
-        return DoctorCheck(name: 'vscode copilot', passed: true);
-      } else {
-        return DoctorCheck(
-          name: 'vscode copilot',
-          passed: false,
-          error: 'GitHub Copilot extension not installed in VS Code',
-        );
-      }
-    } catch (e) {
-      return DoctorCheck(
-        name: 'vscode copilot',
-        passed: false,
-        error: e.toString(),
-      );
-    }
   }
 
   /// Runs a command and returns a [DoctorCheck] with the result.
@@ -244,12 +191,6 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
   /// Extracts version from "gh version X.Y.Z (...)".
   String? _extractGhVersion(String stdout) {
     final match = RegExp(r'gh version (\d+\.\d+\.\d+)').firstMatch(stdout);
-    return match?.group(1);
-  }
-
-  /// Extracts version from "gh copilot version X.Y.Z".
-  String? _extractCopilotVersion(String stdout) {
-    final match = RegExp(r'copilot version (\d+\.\d+\.\d+)').firstMatch(stdout);
     return match?.group(1);
   }
 }

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String apeVersion = '0.0.11';
+const String apeVersion = '0.0.13';

--- a/code/cli/pubspec.lock
+++ b/code/cli/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: "direct main"
     description:
       name: cli_router
-      sha256: f99d8d185a2680edcb6fc296605892db3bcc63539ef3771b5093a5210e9a5080
+      sha256: "0720f477ba4912511374b8a255eb9edfa34ddcfca94dbee096a64cf1299751d4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.2"
+    version: "0.0.3"
   collection:
     dependency: transitive
     description:

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,12 +1,12 @@
 name: ape_cli
 description: >
   CLI for the finite ape machine — workspace initialization and orchestration.
-version: 0.0.12
+version: 0.0.13
 
 environment:
   sdk: ^3.8.1
 dependencies:
-  cli_router: ^0.0.2
+  cli_router: ^0.0.3
   modular_cli_sdk: ^0.2.1
   path: ^1.9.1
   yaml: ^3.1.3

--- a/code/cli/test/doctor_test.dart
+++ b/code/cli/test/doctor_test.dart
@@ -10,8 +10,6 @@ void main() {
       bool gitFails = false,
       bool ghFails = false,
       bool ghAuthFails = false,
-      bool copilotFails = false,
-      bool vscodeFails = false,
     }) {
       return (
         String executable,
@@ -24,19 +22,6 @@ void main() {
             return ProcessResult(1, 1, '', 'git: command not found');
           }
           return ProcessResult(0, 0, 'git version 2.43.0', '');
-        }
-
-        // gh copilot --version (check before gh --version!)
-        if (executable == 'gh' && arguments.contains('copilot')) {
-          if (copilotFails) {
-            return ProcessResult(
-              1,
-              1,
-              '',
-              'gh: "copilot" is not a gh command.',
-            );
-          }
-          return ProcessResult(0, 0, 'gh copilot version 1.0.0', '');
         }
 
         // gh auth status
@@ -57,25 +42,12 @@ void main() {
           );
         }
 
-        // gh --version (after copilot and auth checks)
+        // gh --version
         if (executable == 'gh' && arguments.contains('--version')) {
           if (ghFails) {
             return ProcessResult(1, 1, '', 'gh: command not found');
           }
           return ProcessResult(0, 0, 'gh version 2.45.0 (2024-03-01)', '');
-        }
-
-        // code --list-extensions
-        if (executable == 'code' && arguments.contains('--list-extensions')) {
-          if (vscodeFails) {
-            return ProcessResult(1, 1, '', 'code: command not found');
-          }
-          return ProcessResult(
-            0,
-            0,
-            'GitHub.copilot\nGitHub.copilot-chat\nms-python.python\n',
-            '',
-          );
         }
 
         // Default: success
@@ -94,26 +66,8 @@ void main() {
 
       expect(output.passed, isTrue);
       expect(output.exitCode, 0);
-      expect(output.checks.length, 6);
+      expect(output.checks.length, 4);
       expect(output.checks.every((c) => c.passed), isTrue);
-    });
-
-    test('vscode copilot missing → exit 1', () async {
-      final cmd = DoctorCommand(
-        DoctorInput(),
-        runProcess: fakeRunner(vscodeFails: true),
-        apeVersionOverride: '0.0.9',
-      );
-
-      final output = await cmd.execute();
-
-      expect(output.passed, isFalse);
-      expect(output.exitCode, 1);
-
-      final vscodeCheck = output.checks.firstWhere(
-        (c) => c.name == 'vscode copilot',
-      );
-      expect(vscodeCheck.passed, isFalse);
     });
 
     test('git missing → exit 1, stopped at git', () async {
@@ -165,24 +119,6 @@ void main() {
       expect(authCheck.passed, isFalse);
     });
 
-    test('copilot missing → exit 1', () async {
-      final cmd = DoctorCommand(
-        DoctorInput(),
-        runProcess: fakeRunner(copilotFails: true),
-        apeVersionOverride: '0.0.9',
-      );
-
-      final output = await cmd.execute();
-
-      expect(output.passed, isFalse);
-      expect(output.exitCode, 1);
-
-      final copilotCheck = output.checks.firstWhere(
-        (c) => c.name == 'gh copilot',
-      );
-      expect(copilotCheck.passed, isFalse);
-    });
-
     test('toJson() returns correct structure', () async {
       final cmd = DoctorCommand(
         DoctorInput(),
@@ -195,7 +131,7 @@ void main() {
 
       expect(json, containsPair('passed', true));
       expect(json['checks'], isList);
-      expect((json['checks'] as List).length, 6);
+      expect((json['checks'] as List).length, 4);
 
       final firstCheck = (json['checks'] as List).first as Map<String, dynamic>;
       expect(firstCheck, containsPair('name', 'ape'));

--- a/code/cli/test/version_sync_test.dart
+++ b/code/cli/test/version_sync_test.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:ape_cli/commands/version.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  test('version.dart matches pubspec.yaml', () {
+    final pubspecFile = File('pubspec.yaml');
+    expect(pubspecFile.existsSync(), isTrue,
+        reason: 'pubspec.yaml must exist — run tests from code/cli/');
+    final pubspec = loadYaml(pubspecFile.readAsStringSync()) as Map;
+    final yamlVersion = pubspec['version'].toString();
+    expect(apeVersion, equals(yamlVersion),
+        reason:
+            'version.dart ($apeVersion) must match pubspec.yaml ($yamlVersion)');
+  });
+}

--- a/docs/issues/58-routing-version-doctor-fix/analyze/diagnosis.md
+++ b/docs/issues/58-routing-version-doctor-fix/analyze/diagnosis.md
@@ -1,0 +1,136 @@
+---
+id: diagnosis
+title: "Diagnóstico final — routing catch-all, version desync, doctor checks"
+date: 2026-04-18
+status: active
+tags: [routing, catch-all, version-desync, doctor, cli-router, dispatch, diagnosis]
+author: socrates
+---
+
+# Diagnóstico final — Issue #58
+
+Resultado de 6 rondas de análisis socrático sobre los tres bugs reportados en issue #58.
+
+## Bug 1 — Routing catch-all rompe módulos y --help
+
+### Síntoma
+
+La ruta vacía `''` registrada para el banner/TUI actúa como catch-all. Ningún módulo montado es alcanzable. `ape --help` muestra el banner en vez de la lista de comandos.
+
+### Causa raíz
+
+En `cli_router/lib/src/cli_router.dart`, el método `_dispatch` itera:
+
+```dart
+for (int j = maxRouteTokens; j >= 0; j--)
+```
+
+Cuando `j` llega a `0`, el candidato `[]` (0 segmentos) siempre hace match con la ruta vacía `''`. Esto ocurre **antes** de evaluar los mounts, por lo que:
+
+- `ape target get` → match con `''` → banner (en vez del módulo `target`)
+- `ape --help` → flags se extraen, `maxRouteTokens=0`, match inmediato con `''` → banner
+- Ningún mount es alcanzable porque `''` intercepta todo
+
+### Fix decidido
+
+En `cli_router`, la ruta vacía `''` debe hacer match **solo** cuando `args` está genuinamente vacío (`args.isEmpty`). Cuando args no está vacío pero el loop llega a `j=0`, la ruta vacía **no** debe hacer match. Es un fix de una condición en `_dispatch`.
+
+### Dónde vive el fix
+
+En **cli_router** (no en ape_cli). La ruta vacía actuando como catch-all es objetivamente un bug en la lógica de dispatch. cli_router es parte del ecosistema y debe corregirse en origen.
+
+## Bug 2 — version.dart desincronizado
+
+### Síntoma
+
+`pubspec.yaml` dice `0.0.12` pero `lib/src/version.dart` tiene `'0.0.11'`. El binario compilado reporta versión incorrecta. `ape upgrade` descarga correctamente pero el binario nuevo muestra `0.0.11`.
+
+### Causa raíz
+
+Al hacer bump a `0.0.12`, `lib/src/version.dart` no fue actualizado. Omisión en el proceso de release.
+
+### Fix decidido
+
+Sincronizar ambos archivos. Bump a `0.0.13` ya que esta corrección constituye una nueva release.
+
+## Bug 3 — Doctor checks no solicitados
+
+### Síntoma
+
+`ape doctor` valida `gh copilot` y VS Code Copilot. El check de VS Code ejecuta `code --list-extensions` que abre VS Code innecesariamente y la detección no funciona correctamente.
+
+### Causa raíz
+
+Ambos checks fueron añadidos sin haberlos solicitado. No cumplen el criterio de alcance.
+
+### Fix decidido
+
+Eliminar ambos checks. Criterio de alcance: **doctor valida solo herramientas que APE invoca directamente**: `ape`, `git`, `gh`, `gh auth`.
+
+## Decisiones de diseño
+
+1. **`--help` es un modificador** (ADR-0003), no output independiente — no requiere ruta propia
+2. **Criterio de alcance de doctor**: "herramientas que APE invoca directamente"
+3. **El fix vive en cli_router**, no es un parche en ape_cli — es un bug real en la lógica de dispatch
+4. **El concepto de "módulo global"** fue explorado pero **no es necesario** para este fix — es un enhancement futuro separado
+
+## Orden de ejecución (cadena de dependencias)
+
+### Fase 1 — cli_router
+
+1. Crear issue en repo `macss-dev/cli_router`
+2. Fix con TDD (testear comportamiento de ruta vacía con args vacíos y no vacíos)
+3. Bump versión de cli_router
+4. Crear PR, merge, publicar en pub.dev
+
+### Fase 2 — ape_cli
+
+1. Bump dependencia de cli_router
+2. Corregir `version.dart`
+3. Eliminar checks de doctor (`gh copilot` + VS Code Copilot)
+4. Bump a `0.0.13`
+5. Tests
+6. PR, merge, compilar + release
+
+## Alcance
+
+### Dentro del alcance
+
+- cli_router: guard para ruta vacía en dispatch
+- ape_cli: sincronizar `version.dart`
+- ape_cli: eliminar checks de doctor (gh copilot + vscode copilot)
+- Tests para todos los cambios
+- Version bumps y releases
+
+### Fuera del alcance
+
+- Concepto de módulo global (enhancement futuro, issue separado)
+- Sistema de aliases para cli_router (enhancement futuro)
+- Cualquier refactoring más allá de los 3 bugs
+- Cambios en modular_cli_sdk (no necesario — el fix de cli_router es transparente)
+
+## Riesgos
+
+| Riesgo | Mitigación |
+|--------|------------|
+| cli_router publish rompe otros consumidores que dependan de `''` matching en j=0 | `''` matcheando args no vacíos es objetivamente un bug (catch-all no intencionado) |
+| Coordinación de version bumps entre cli_router y ape_cli | Ejecución secuencial: cli_router primero, ape_cli después |
+
+## Criterios de aceptación (issue #58)
+
+- [ ] Módulos montados (`target get`, `target clean`, `state transition`) son alcanzables
+- [ ] `ape --help` muestra lista de comandos disponibles
+- [ ] `ape` (sin args) sigue mostrando el banner FSM
+- [ ] `version.dart` y `pubspec.yaml` sincronizados
+- [ ] Doctor solo valida: `ape`, `git`, `gh`, `gh auth`
+- [ ] Tests verdes
+
+## Referencias
+
+| Archivo | Relevancia |
+|---------|------------|
+| `cli_router/lib/src/cli_router.dart` (líneas 110-185) | Dispatch loop donde vive el bug |
+| `code/cli/lib/ape_cli.dart` | Registro de rutas y módulos |
+| `code/cli/lib/src/version.dart` | Constante de versión desincronizada |
+| `code/cli/lib/commands/doctor.dart` | Checks a eliminar |
+| `docs/adr/0003-subcommands-over-flags-for-output.md` | `--help` como modificador |

--- a/docs/issues/58-routing-version-doctor-fix/analyze/index.md
+++ b/docs/issues/58-routing-version-doctor-fix/analyze/index.md
@@ -1,0 +1,6 @@
+| ID | Title | Date | Status | Tags |
+|----|-------|------|--------|------|
+| initial-analysis | Análisis inicial — routing catch-all, version desync, doctor scope | 2026-04-18 | draft | routing, catch-all, version, doctor, cli-router, dispatch |
+| socratic-round-2 | Ronda socrática 2: ¿Los aliases resuelven el dispatch, o lo renombran? | 2026-04-18 | draft | routing, aliases, dispatch, socratic-method |
+| socratic-round-4-meta | Ronda socrática 4: Meta-reflexión — ¿estamos preguntando lo correcto? | 2026-04-18 | draft | routing, meta-reflection, help-paradox, scope-creep, socratic-method |
+| diagnosis | Diagnóstico final — routing catch-all, version desync, doctor checks | 2026-04-18 | active | routing, catch-all, version-desync, doctor, cli-router, dispatch, diagnosis |

--- a/docs/issues/58-routing-version-doctor-fix/analyze/initial-analysis.md
+++ b/docs/issues/58-routing-version-doctor-fix/analyze/initial-analysis.md
@@ -1,0 +1,75 @@
+---
+id: initial-analysis
+title: Análisis inicial — routing catch-all, version desync, doctor scope
+date: 2026-04-18
+status: draft
+tags: [routing, catch-all, version, doctor, cli-router, dispatch]
+author: socrates
+---
+
+# Análisis inicial — Issue #58
+
+## Verificación de hechos reportados
+
+### Bug 1: Empty route como catch-all
+
+**Verificado en código.** La cadena de causalidad es:
+
+1. `ape_cli.dart:34` registra `cli.command<TuiInput, TuiOutput>('', ...)` — ruta vacía.
+2. `_PathPattern.parse('')` produce `segments = []` (0 segmentos).
+3. `_PathPattern.matches([], outParams)` retorna `true` — 0 segmentos == 0 tokens.
+4. En `_dispatch`, el loop `for (int j = maxRouteTokens; j >= 0; j--)` siempre llega a `j=0`.
+5. Con `j=0`, `candidate = args.take(0) = []`, que matchea `''`.
+6. La ruta vacía captura TODO antes de que se evalúen los mounts (paso 3 del dispatch).
+
+**Caso `ape target get`:**
+- `maxRouteTokens = 2` (no hay flags)
+- j=2 → `['target', 'get']` → no match (no hay ruta registrada con ese nombre)
+- j=1 → `['target']` → no match
+- j=0 → `[]` → match con `''` → ejecuta TUI → módulos inalcanzables ✓
+
+**Caso `ape --help`:**
+- `flagStart = 0` (primer arg empieza con `-`)
+- `maxRouteTokens = 0`
+- j=0 → `[]` → match con `''` → TUI inmediato ✓
+
+### Bug 2: version.dart desync
+
+**Verificado.** `pubspec.yaml` dice `0.0.12`, `version.dart` dice `'0.0.11'`.
+
+### Bug 3: Doctor checks
+
+**Verificado.** `doctor.dart` incluye:
+- Check 5: `gh copilot --version` (L161-169)
+- Check 6: `_checkVsCodeCopilot()` que ejecuta `code --list-extensions` (L183-210)
+
+## Preguntas abiertas
+
+### P1: ¿Dónde vive el fix del routing — cli_router o ape_cli?
+
+El bug es una **interacción emergente** entre dos decisiones independientes:
+- cli_router: el dispatch prueba j=0 (candidato vacío) antes de evaluar mounts
+- ape_cli: registra `''` como ruta válida
+
+Opciones identificadas:
+- **A) Fix en cli_router**: Cambiar prioridad del dispatch — evaluar mounts antes de probar j=0
+- **B) Fix en ape_cli**: No registrar `''` como ruta; manejar "sin argumentos" de otra forma
+- **C) Fix mixto**: Ambos cambios
+
+Cada opción tiene trade-offs no explorados aún.
+
+### P2: ¿Qué semántica debería tener la ruta vacía '' en cli_router?
+
+Actualmente `''` es un patrón válido que matchea "cero tokens". Pero el dispatch no distingue entre:
+- "El usuario no pasó argumentos" (caso legítimo para banner/TUI)
+- "El dispatch agotó candidatos y cayó a j=0" (caso espurio)
+
+¿Es la ruta vacía un concepto que cli_router debería soportar, o es un accidente de implementación?
+
+### P3: ¿Qué principio define el scope de doctor?
+
+El usuario dice "solo ape, git, gh, gh auth" — pero ¿por qué exactamente esos? ¿El criterio es "herramientas que APE invoca directamente en su ejecución normal"? Si APE evoluciona para usar más herramientas, ¿se agregan a doctor?
+
+## Estado
+
+Análisis técnico verificado contra código fuente. Quedan decisiones de diseño abiertas que afectan la solución.

--- a/docs/issues/58-routing-version-doctor-fix/analyze/socratic-round-2.md
+++ b/docs/issues/58-routing-version-doctor-fix/analyze/socratic-round-2.md
@@ -1,0 +1,155 @@
+---
+id: socratic-round-2
+title: "Ronda socrática 2: ¿Los aliases resuelven el dispatch, o lo renombran?"
+date: 2026-04-18
+status: draft
+tags: [routing, aliases, dispatch, socratic-method]
+author: socrates
+---
+
+# Ronda socrática 2: ¿Los aliases resuelven el dispatch, o solo lo renombran?
+
+## Recapitulación del modelo propuesto
+
+Tu propuesta:
+- Registrar un "root module" con `''` como alias y `tui` como nombre primario.
+- Dentro de él, un comando `tui` con `''` como alias.
+- `ape` (sin args) → match root module `''` → match command `''` → TUI.
+- `ape target get` → no match root module → pasa a mount `target` → funciona.
+
+Es un modelo elegante conceptualmente. Pero necesitamos ser rigurosos sobre **qué evidencia tenemos de que funciona a nivel de dispatch**.
+
+---
+
+## Pregunta 1: ¿El alias cambia el loop, o solo cambia el nombre del patrón?
+
+Tracemos el dispatch actual con tu propuesta implementada. El loop central es ([cli_router.dart L113-L118](../../../../../../../Code/macss-dev/cli_router/lib/src/cli_router.dart#L113-L118)):
+
+```dart
+for (int j = maxRouteTokens; j >= 0; j--) {
+  final candidate = args.take(j).toList();
+  final match = _matchRoute(candidate);
+  if (match != null) { ... }
+}
+```
+
+Caso `ape target get`:
+- `maxRouteTokens = 2`
+- j=2 → `['target', 'get']` → ¿match?
+- j=1 → `['target']` → ¿match?
+- j=0 → `[]` → ¿match?
+
+**Pregunta concreta:** En tu modelo de aliases, ¿qué hay registrado en `_routes` y `_mounts` cuando el dispatch evalúa estos candidatos?
+
+Si `''` es un **alias** de `tui`, hay dos interpretaciones posibles:
+
+### Interpretación A: `''` se registra como ruta independiente que delega a `tui`
+
+Entonces `_routes` contiene una entrada con `_PathPattern.parse('')` → `segments = []`. El dispatch llega a j=0, `candidate = []`, `_matchRoute([])` matchea contra `segments = []` → **true**. El catch-all persiste idénticamente.
+
+**Los aliases no resolvieron nada. El patrón vacío sigue matcheando todo a j=0.**
+
+### Interpretación B: Solo `tui` se registra como ruta; `''` es un lookup que redirige a `tui`
+
+Entonces `_routes` contiene una entrada con `_PathPattern.parse('tui')` → `segments = ['tui']`. El dispatch llega a j=0, `candidate = []`, `_matchRoute([])` busca match contra `['tui']` (1 segmento ≠ 0 tokens) → **false**. No hay catch-all. Los mounts se evalúan. `target get` funciona.
+
+**Pero entonces — ¿cómo llega `ape` (sin argumentos) a TUI?**
+
+- `args = []`, `maxRouteTokens = 0`
+- j=0 → `candidate = []` → `_matchRoute([])` → no matchea `'tui'` → **false**
+- No hay mounts que matcheen `[]`
+- Resultado: **"Command not found"** → exit 64
+
+El alias necesitaría que el router, al recibir `[]`, lo transforme en `['tui']` antes de hacer dispatch. Es decir, **el alias no es un atributo del patrón, sino una regla de reescritura de la entrada**. Eso es un concepto fundamentalmente distinto de "aliases para comandos".
+
+---
+
+## Pregunta 2: ¿Qué problema estamos resolviendo realmente?
+
+Reformulemos. El problema no es de **nomenclatura** (cómo se llama la ruta), sino de **prioridad de evaluación**:
+
+> Cuando el dispatch llega a j=0, ¿debería intentar rutas antes de mounts?
+
+El código actual dice sí: el paso 2 (rutas, j=maxRouteTokens..0) se agota completamente antes del paso 3 (mounts). Esto significa que cualquier ruta que matchee `[]` actúa como catch-all, porque j=0 siempre se alcanza.
+
+**La pregunta que los aliases no contestan:** ¿Cuál debería ser la semántica de j=0?
+
+Hay al menos tres lecturas posibles:
+
+| Lectura | Semántica de j=0 | Implicación |
+|---------|-------------------|-------------|
+| **"Default route"** | j=0 es una ruta legítima para "sin argumentos" | Requiere que no capture tráfico destinado a mounts |
+| **"Fallback"** | j=0 solo se intenta si no hay mounts | Cambia la prioridad del dispatch |
+| **"Prohibido"** | j=0 no debería existir; rutas vacías son inválidas | Rompe el caso de uso de TUI |
+
+Tu propuesta de aliases parece asumir la lectura "default route" pero quiere resolver el problema que solo se resuelve con la lectura "fallback".
+
+---
+
+## Pregunta 3: ¿Hay evidencia de que el alias funcione sin cambiar la lógica del loop?
+
+Busco en tu modelo un mecanismo concreto que evite que j=0 matchee cuando hay mounts disponibles. Encuentro tres posibilidades:
+
+1. **Reescritura de entrada** (`[] → ['tui']`): Funciona, pero no es un sistema de "aliases" — es un sistema de redirects/rewrites al estilo de servidores HTTP. El costo es alto: necesitas una tabla de reescritura evaluada antes del loop, con reglas de precedencia propias.
+
+2. **El alias expande los candidatos** (j=0 prueba `[]` y también `['tui']`): Esto podría funcionar para el TUI, pero no cambia que `[]` siga matcheando. Además, ¿a j=2 se expande `['target', 'get']` a todas las combinaciones de alias? La complejidad combinatoria explota.
+
+3. **El alias solo aplica a la ruta vacía como caso especial**: Entonces no es un sistema de aliases — es un hack para el caso vacío disfrazado de feature general.
+
+**¿Cuál de estos mecanismos es el que tenías en mente?** Sin especificarlo, no podemos evaluar si la propuesta resuelve el problema.
+
+---
+
+## Pregunta 4: ¿Existe un fix más simple que no requiera cambiar cli_router?
+
+Contrafactual: ¿qué pasa si **no registramos `''` como ruta** y manejamos "sin argumentos" de otra forma?
+
+```
+# Pseudocódigo — sin ruta vacía
+if (args.isEmpty || args.every((a) => a.startsWith('-'))) {
+  return tui(args);
+}
+return cli.run(args);
+```
+
+Esto resolvería los tres síntomas:
+- `ape` → TUI (por el check previo)
+- `ape --help` → pasa a `cli.run(['--help'])` → no hay ruta vacía → no hay match → help se muestra correctamente *(si el framework maneja --help)*
+- `ape target get` → pasa a `cli.run(...)` → mount `target` → funciona
+
+**No requiere cambios a cli_router. No introduce aliases. No cambia la semántica del dispatch.**
+
+La pregunta incómoda: **¿por qué necesitamos un sistema de aliases si el problema se puede resolver sin registrar la ruta vacía?**
+
+---
+
+## Pregunta 5: ¿Estamos resolviendo el bug de hoy o diseñando la arquitectura de mañana?
+
+Esta es la pregunta más importante.
+
+- Si el objetivo es **resolver el bug #58**, el fix más simple y verificable es no registrar `''` como ruta, y manejar el caso vacío antes del dispatch.
+- Si el objetivo es **que cli_router soporte aliases como feature del framework**, eso es una decisión arquitectural que merece su propio issue, con sus propios criterios de aceptación y tests.
+
+Mezclar ambos objetivos en un solo cambio introduce riesgo: el alias resuelve (quizás) el bug, pero también modifica cli_router para todos sus consumidores, con implicaciones no exploradas (colisiones de aliases, prioridad de resolución, interacción con wildcards y parámetros).
+
+---
+
+## Resumen de lagunas identificadas
+
+| # | Laguna | Estado |
+|---|--------|--------|
+| 1 | Mecanismo concreto por el cual el alias evita el catch-all a j=0 | Sin especificar |
+| 2 | Qué lectura de "j=0" asume el modelo de aliases | Implícita, no explícita |
+| 3 | Cómo interactúan aliases con wildcards, params, y mounts existentes | No explorado |
+| 4 | Si el bug se puede resolver sin cambiar cli_router | Contrafactual viable, no evaluado |
+| 5 | Si aliases es un requisito del bug o una preferencia arquitectural | No distinguido |
+
+---
+
+## Preguntas para la siguiente ronda
+
+1. **Mecanismo**: De las tres interpretaciones (reescritura, expansión, caso especial), ¿cuál describe mejor tu intención con aliases? ¿O hay una cuarta que no estoy viendo?
+
+2. **Contrafactual**: Si pudiéramos resolver el catch-all sin tocar cli_router (manejando args vacíos antes del dispatch), ¿seguirías queriendo aliases? ¿Por qué?
+
+3. **Scope**: ¿Estamos en el issue #58 (fix del bug) o estamos abriendo un issue nuevo (aliases como feature de cli_router)?

--- a/docs/issues/58-routing-version-doctor-fix/analyze/socratic-round-4-meta.md
+++ b/docs/issues/58-routing-version-doctor-fix/analyze/socratic-round-4-meta.md
@@ -1,0 +1,154 @@
+---
+id: socratic-round-4-meta
+title: "Ronda socrática 4: Meta-reflexión — ¿estamos preguntando lo correcto?"
+date: 2026-04-18
+status: draft
+tags: [routing, meta-reflection, help-paradox, scope-creep, socratic-method]
+author: socrates
+---
+
+# Ronda socrática 4: Meta-reflexión
+
+Llevamos cuatro rondas. El análisis técnico del bug está verificado desde la ronda 1. Las rondas 2 y 3 exploraron soluciones (aliases, root module, global module). Cada ronda amplió el scope en lugar de convergerlo.
+
+Es momento de examinar las preguntas mismas.
+
+---
+
+## I. La paradoja de --help
+
+El acceptance criteria #2 del issue dice:
+
+> `ape --help` muestra lista de comandos disponibles
+
+La propuesta actual dice:
+
+> `ape --help` → se reescribe a `ape global global --help`
+
+Tracemos qué pasa con esa reescritura:
+
+1. `ape --help` llega al dispatch
+2. La reescritura transforma `['--help']` en `['global', 'global', '--help']`
+3. El dispatch matchea el módulo `global`, el comando `global`, con flag `--help`
+4. `--help` decora **ese comando** — muestra la ayuda del comando global (TUI/banner)
+
+El resultado: el usuario ve la ayuda del TUI. **No** ve la lista de todos los comandos disponibles.
+
+Para que `ape --help` muestre la lista de todos los comandos, necesitaría:
+
+- **O** que `--help` sea interceptado **antes** de la reescritura (pero entonces la reescritura no aplica, y necesitamos otro mecanismo)
+- **O** que el comando `global` implemente su help como "listar todos los comandos" (pero entonces no es un comando normal — es un meta-comando que necesita conocer el registro completo del CLI)
+- **O** que `--help` a nivel raíz **no** se reescriba (caso especial que contradice la regla general)
+
+Cualquiera de las tres opciones introduce complejidad que la propuesta de reescritura no contempla. **La reescritura y el acceptance criteria se contradicen mutuamente.**
+
+Esta pregunta se planteó en la ronda 3, sección I. No fue respondida. Sigue sin responderse. Y no es una pregunta menor — es un criterio de aceptación del issue.
+
+---
+
+## II. ¿Estamos preguntando lo correcto?
+
+Las preguntas que hemos hecho en 4 rondas:
+
+| Ronda | Pregunta central |
+|-------|-----------------|
+| 1 | ¿Cómo funciona el dispatch y por qué '' es catch-all? |
+| 2 | ¿Los aliases resuelven el catch-all? |
+| 3 | ¿Un root/global module es la abstracción correcta? |
+| 4 (propuesta) | ¿Cómo implementamos el módulo global con reescritura? |
+
+Nota el patrón: cada ronda asume que la solución es **más arquitectura** y pregunta cómo implementarla. Ninguna ronda después de la primera preguntó: **¿cuál es la solución más simple que satisface los 6 criterios de aceptación?**
+
+Los criterios son:
+
+1. Módulos montados (target get, target clean, state transition) son alcanzables
+2. `ape --help` muestra lista de comandos disponibles
+3. `ape` (sin args) sigue mostrando el banner FSM
+4. version.dart y pubspec.yaml sincronizados
+5. Doctor solo valida: ape, git, gh, gh auth
+6. Tests verdes
+
+Los criterios 4 y 5 son fixes triviales. Están listos desde la ronda 1. El criterio 6 es consecuencia.
+
+Los criterios 1, 2 y 3 son el problema de routing. Pero fíjate: ninguno dice "cli_router debe soportar módulos globales", "el dispatch debe usar reescritura", ni "necesitamos aliases". Los criterios hablan de **comportamiento observable**, no de mecanismo.
+
+La pregunta que no hemos hecho:
+
+> **¿Existe una solución que satisfaga los 3 criterios de routing sin modificar cli_router?**
+
+La ronda 2 (pregunta 4) propuso un contrafactual exactamente sobre esto. No fue evaluado. El análisis pivotó hacia más arquitectura.
+
+---
+
+## III. El patrón de las 4 rondas
+
+Observo algo que vale la pena nombrar:
+
+```
+Ronda 1: Identificar el bug          → verificado, claro
+Ronda 2: Solución A (aliases)        → demostrada insuficiente
+Ronda 3: Solución B (root module)    → pregunta de scope abierta
+Ronda 4: Solución C (global module)  → paradoja de --help no resuelta
+```
+
+Cada solución propuesta es más elaborada que la anterior. Cada una requiere más cambios a más paquetes. Ninguna ha sido evaluada contra **todos** los criterios de aceptación simultáneamente.
+
+Esto es un antipatrón conocido: **escalada de complejidad sin validación incremental**. La solución crece, pero no se verifica contra los requisitos. Cuando finalmente se verifica (como hice con --help), resulta que no encaja.
+
+No estoy diciendo que la arquitectura del módulo global sea mala idea. Estoy diciendo que no hemos demostrado que sea **necesaria** para resolver el issue #58.
+
+---
+
+## IV. Las preguntas que deberíamos estar haciendo
+
+En lugar de "¿cómo implementamos el módulo global?", propongo:
+
+### 1. ¿Qué es lo mínimo que necesita cambiar para que los 6 criterios pasen?
+
+Concretamente: ¿qué pasa si `ape_cli.dart` simplemente no registra `''` como ruta y maneja `args.isEmpty` antes de llamar a `cli.run()`? ¿Cuántos criterios se satisfacen?
+
+### 2. ¿Quién es responsable de `--help` global?
+
+Esto es anterior a cualquier solución de routing. ¿Es el framework (cli_router/modular_cli_sdk) quien genera el listado de comandos para `--help`, o es ape_cli? Si es el framework, ¿ya lo soporta? Si no, ese es un feature request separado.
+
+### 3. ¿Estamos usando el issue #58 como vehículo para trabajo de diseño que debería ser su propio issue?
+
+El módulo global, la reescritura, los aliases — cada uno de estos es una decisión arquitectural de cli_router que afecta a todos sus consumidores. Mezclarlos con un bugfix de 3 líneas en ape_cli es poner en riesgo ambos: el bugfix se retrasa y el diseño no recibe la atención que merece.
+
+---
+
+## V. El dilema concreto
+
+Estás en una bifurcación:
+
+**Camino A — Fix mínimo (ape_cli solamente):**
+- No registrar `''` como ruta
+- Manejar args vacíos antes del dispatch
+- version.dart: cambiar '0.0.11' → '0.0.12'
+- doctor.dart: eliminar checks de copilot
+- Criterios 1, 3, 4, 5, 6: satisfechos directamente
+- Criterio 2 (--help): depende de qué hace el framework cuando no hay match y hay --help
+
+**Camino B — Rediseño (cli_router + modular_cli_sdk + ape_cli):**
+- Implementar concepto de módulo global en cli_router
+- Implementar reescritura de entrada
+- Resolver la paradoja de --help (mecanismo aún no definido)
+- Modificar modular_cli_sdk para exponer la nueva API
+- Adaptar ape_cli
+- Más código, más riesgo, más paquetes afectados, release cycle más largo
+
+El camino B puede ser el diseño correcto a largo plazo. Pero la pregunta para **este issue** es: ¿necesitas el camino B para cerrar los 6 criterios de aceptación, o estás resolviendo un problema futuro con el presupuesto de un bugfix?
+
+---
+
+## Punto de convergencia
+
+Cuatro rondas es suficiente exploración para un bugfix de 3 problemas concretos. El análisis necesita converger. Sugiero que respondas, en orden:
+
+1. **La paradoja de --help**: ¿Cómo muestra `ape --help` la lista de todos los comandos si se reescribe a `ape global global --help`? Necesito un mecanismo concreto, no una intención.
+
+2. **El contrafactual**: ¿Has evaluado qué pasa si simplemente no registras `''` y manejas el caso vacío fuera del dispatch? ¿Lo descartaste por alguna razón técnica concreta?
+
+3. **La decisión de scope**: ¿Es este issue un bugfix o un rediseño? Ambos son válidos, pero necesitan planes distintos.
+
+Sin respuesta a estas tres preguntas, cualquier plan que escribamos estará construido sobre supuestos no validados.

--- a/docs/issues/58-routing-version-doctor-fix/plan.md
+++ b/docs/issues/58-routing-version-doctor-fix/plan.md
@@ -1,0 +1,285 @@
+---
+id: plan
+title: "Plan — fix routing catch-all, version desync, doctor checks"
+date: 2026-04-18
+status: draft
+tags: [routing, catch-all, version-desync, doctor, cli-router, plan]
+author: descartes
+---
+
+# Plan — Issue #58
+
+## Hypothesis
+
+If we (1) guard the empty-route match in cli_router's `_dispatch` so `''` only matches when `args` is genuinely empty, (2) synchronize version.dart with pubspec.yaml and add a regression test, and (3) remove the two unsolicited doctor checks — in that order, respecting the dependency chain — then all six acceptance criteria will be satisfied.
+
+## Scope
+
+### In scope
+
+- cli_router: guard empty-route match in `_dispatch`
+- cli_router: tests for the empty-route guard
+- cli_router: version bump + publish
+- ape_cli: bump cli_router dependency
+- ape_cli: sync version.dart ↔ pubspec.yaml to 0.0.13
+- ape_cli: add version-sync regression test
+- ape_cli: remove doctor checks 5 (gh copilot) and 6 (vscode copilot)
+- ape_cli: update doctor tests
+- ape_cli: PR for issue #58
+
+### Out of scope
+
+- Global module concept (future enhancement)
+- cli_router alias system (future enhancement)
+- Any refactoring beyond the three bugs
+- Changes to modular_cli_sdk
+
+## Phases
+
+### Phase 1 — cli_router: fix empty-route catch-all
+
+**Entry criteria:** cli_router repo clean, `dart test` green.
+
+**Dependency:** None. This is the foundation — ape_cli depends on the fixed cli_router.
+
+#### 1.1 Create branch
+
+- [ ] `git checkout -b fix/empty-route-catchall` in `cli_router/`
+
+#### 1.2 Write failing tests (TDD red)
+
+- [ ] Add test file `test/empty_route_test.dart` in cli_router
+- [ ] Test: empty route with empty args → matches (exit 0, handler runs)
+- [ ] Test: empty route with flag-only args `['--help']` → does NOT match (exit 64)
+- [ ] Test: empty route with positional args `['target', 'get']` → does NOT match (exit 64)
+- [ ] Test: empty route registered alongside mount → mount is reachable for `['target', 'get']`
+- [ ] Run `dart test` → confirm new tests fail
+
+```
+// Pseudocode for tests
+test('empty route matches when args is empty', () {
+  router.cmd('', handler(() => banner()));
+  router.cmd('help', handler(() => help()));
+  exit = router.run([]);
+  expect(exit, 0);  // handler ran
+});
+
+test('empty route does NOT match when args has flags', () {
+  router.cmd('', handler(() => banner()));
+  exit = router.run(['--help']);
+  expect(exit, 64);  // no match → usage error
+});
+
+test('empty route does NOT match when args has positionals', () {
+  router.cmd('', handler(() => banner()));
+  exit = router.run(['target', 'get']);
+  expect(exit, 64);  // no match
+});
+
+test('mount is reachable when empty route is registered', () {
+  router.cmd('', handler(() => banner()));
+  sub = CliRouter()..cmd('get', handler(() => getTarget()));
+  router.mount('target', sub);
+  exit = router.run(['target', 'get']);
+  expect(exit, 0);  // mount handler ran, not banner
+});
+```
+
+#### 1.3 Implement fix (TDD green)
+
+- [ ] In `cli_router/lib/src/cli_router.dart`, method `_dispatch`, inside the loop:
+  - When `j == 0` AND the original `args` is not empty, **skip** the `_matchRoute` call
+  - This prevents `''` from matching `['--help']`, `['target', 'get']`, etc.
+  - The empty route only matches when `args.isEmpty` (which means `maxRouteTokens == 0` AND no flags)
+
+```dart
+// Current (line ~113-118):
+for (int j = maxRouteTokens; j >= 0; j--) {
+  final candidate = args.take(j).toList();
+  final match = _matchRoute(candidate);
+  if (match != null) { ... }
+}
+
+// Fixed:
+for (int j = maxRouteTokens; j >= 0; j--) {
+  if (j == 0 && args.isNotEmpty) continue;  // ← guard
+  final candidate = args.take(j).toList();
+  final match = _matchRoute(candidate);
+  if (match != null) { ... }
+}
+```
+
+- [ ] Run `dart test` → all tests green (new + existing)
+- [ ] Run `dart analyze` → no issues
+
+#### 1.4 Version bump
+
+- [ ] Bump `pubspec.yaml` version: `0.0.2` → `0.0.3`
+- [ ] Update CHANGELOG.md with fix description
+
+#### 1.5 Publish
+
+- [ ] Commit: `fix: empty route must not act as catch-all (#issue)`
+- [ ] Create PR, review, merge
+- [ ] `dart pub publish`
+
+**Exit criteria:** cli_router 0.0.3 published on pub.dev with the fix. All tests green.
+
+---
+
+### Phase 2 — ape_cli: bump cli_router dependency
+
+**Entry criteria:** Phase 1 complete (cli_router 0.0.3 published).
+
+**Dependency:** Phase 1.
+
+#### 2.1 Create branch
+
+- [ ] `git checkout -b fix/58-routing-version-doctor` in ape_cli repo
+
+#### 2.2 Bump dependency
+
+- [ ] In `code/cli/pubspec.yaml`, change `cli_router: ^0.0.2` → `cli_router: ^0.0.3`
+- [ ] Run `dart pub get`
+
+#### 2.3 Verify routing fix propagates
+
+- [ ] Run existing tests: `dart test` — modules should now be reachable if there are integration tests
+- [ ] Manual smoke test: `dart run bin/ape.dart target get` should NOT show banner
+- [ ] Manual smoke test: `dart run bin/ape.dart` (no args) should still show banner
+
+**Exit criteria:** cli_router 0.0.3 resolved in ape_cli. Routing fix confirmed working.
+
+---
+
+### Phase 3 — ape_cli: fix version desync + regression test
+
+**Entry criteria:** Phase 2 complete (branch exists, dependency bumped).
+
+**Dependency:** Phase 2 (same branch).
+
+#### 3.1 Sync version constants
+
+- [ ] `code/cli/lib/src/version.dart`: change `'0.0.11'` → `'0.0.13'`
+- [ ] `code/cli/pubspec.yaml`: change `0.0.12` → `0.0.13`
+
+#### 3.2 Add version-sync regression test
+
+- [ ] In `code/cli/test/version_test.dart`, add a test that reads `pubspec.yaml` and compares to `apeVersion`
+
+```
+// Pseudocode
+test('version.dart matches pubspec.yaml', () {
+  pubspec = File('pubspec.yaml').readAsString();
+  yamlVersion = loadYaml(pubspec)['version'];
+  expect(apeVersion, equals(yamlVersion));
+});
+```
+
+- [ ] Run `dart test test/version_test.dart` → green
+
+**Exit criteria:** version.dart == pubspec.yaml == 0.0.13. Regression test prevents future desync.
+
+---
+
+### Phase 4 — ape_cli: remove unwanted doctor checks
+
+**Entry criteria:** Phase 3 complete (same branch).
+
+**Dependency:** Phase 3 (same branch).
+
+#### 4.1 Remove checks from doctor.dart
+
+- [ ] Remove Check 5 block: `gh copilot --version` (lines ~159-169)
+- [ ] Remove Check 6 block: `_checkVsCodeCopilot()` call and the entire method (lines ~171-210)
+- [ ] Remove `_extractCopilotVersion` helper if it exists and is now unused
+- [ ] Update file docstring (line 3): remove `gh copilot, vscode copilot extension`
+- [ ] Verify `execute()` returns after Check 4 (gh auth) with `passed: allPassed`
+
+#### 4.2 Update doctor tests
+
+- [ ] In `code/cli/test/doctor_test.dart`:
+  - Remove `copilotFails` and `vscodeFails` parameters from `fakeRunner`
+  - Remove the `gh copilot` branch from the fake runner
+  - Remove the `code --list-extensions` branch from the fake runner
+  - Remove any tests specific to copilot/vscode checks
+  - Verify "all pass" test expects exactly 4 checks: ape, git, gh, gh auth
+- [ ] Run `dart test test/doctor_test.dart` → green
+
+#### 4.3 Run full test suite
+
+- [ ] `dart analyze` → no issues
+- [ ] `dart test` → all green
+
+**Exit criteria:** Doctor validates only: ape, git, gh, gh auth. No references to copilot/vscode remain. All tests green.
+
+---
+
+### Phase 5 — ape_cli: PR and merge
+
+**Entry criteria:** Phases 2-4 complete. All tests green. `dart analyze` clean.
+
+**Dependency:** Phase 4.
+
+#### 5.1 Final verification
+
+- [ ] `dart analyze` clean
+- [ ] `dart test` all green
+- [ ] Manual smoke tests:
+  - `ape` (no args) → banner
+  - `ape --help` → command list
+  - `ape target get` → target module responds (not banner)
+  - `ape doctor` → 4 checks only
+  - `ape version` → 0.0.13
+
+#### 5.2 Commit and PR
+
+- [ ] Commit changes with message: `fix(#58): routing catch-all, version sync, doctor cleanup`
+- [ ] Push branch, create PR referencing issue #58
+- [ ] PR description lists the three fixes and acceptance criteria
+
+#### 5.3 Merge
+
+- [ ] Review PR
+- [ ] Merge and delete branch
+- [ ] Verify issue #58 acceptance criteria:
+  - [AC1] Mounted modules reachable
+  - [AC2] `ape --help` shows command list
+  - [AC3] `ape` (no args) shows banner
+  - [AC4] version.dart and pubspec.yaml synchronized at 0.0.13
+  - [AC5] Doctor validates: ape, git, gh, gh auth only
+  - [AC6] Tests green
+
+**Exit criteria:** PR merged. Issue #58 closeable.
+
+---
+
+## Risk notes
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| cli_router 0.0.3 publish breaks other consumers relying on `''` as catch-all | Low — `''` matching non-empty args is objectively a bug | The fix is a bugfix, not a breaking change. No consumer should depend on broken behavior. |
+| `dart pub publish` blocked (auth, score) | Medium — blocks Phase 2+ | Ensure pub.dev credentials are valid before starting. Pre-check with `dart pub publish --dry-run`. |
+| Existing ape_cli tests depend on the old routing behavior | Medium — tests may break in unexpected ways | Run full test suite immediately after bumping cli_router (Phase 2.3). |
+| ESET/Defender deletes dart.exe mid-execution | Low — known issue on this machine | Verify `dart --version` before each phase. Restore from backup if needed. |
+| Version 0.0.13 collides with a hotfix release | Low | Check that no release branch exists for 0.0.13 before starting Phase 3. |
+
+## Dependencies graph
+
+```
+Phase 1 (cli_router fix + publish)
+    │
+    ▼
+Phase 2 (ape_cli: bump cli_router)
+    │
+    ▼
+Phase 3 (ape_cli: version sync)  ─── can run in parallel with Phase 4
+    │                                  but sequential is safer on same branch
+    ▼
+Phase 4 (ape_cli: doctor cleanup)
+    │
+    ▼
+Phase 5 (ape_cli: PR + merge)
+```
+
+Phases 3 and 4 are independent in code (different files) but share the same branch. Sequential execution is preferred to keep commits atomic and reviewable.


### PR DESCRIPTION
## Fixes

1. **Routing catch-all** — bump cli_router ^0.0.3 (empty route '' no longer intercepts flag-only or positional args before mounts)
2. **Version sync** — version.dart + pubspec.yaml at 0.0.13, regression test added
3. **Doctor cleanup** — removed gh copilot and vscode copilot checks

## Validation

- 126 tests passing
- dart analyze clean

Closes #58