### PR TITLE
fix(#61): sync site badge + web version sync test

### DIFF
--- a/code/cli/test/version_sync_test.dart
+++ b/code/cli/test/version_sync_test.dart
@@ -15,4 +15,17 @@ void main() {
         reason:
             'version.dart ($apeVersion) must match pubspec.yaml ($yamlVersion)');
   });
+
+  test('site index.html badge matches pubspec.yaml version', () {
+    final indexFile = File('../../code/site/index.html');
+    expect(indexFile.existsSync(), isTrue,
+        reason: 'code/site/index.html must exist');
+    final html = indexFile.readAsStringSync();
+    final match = RegExp(r'class="badge">v(\d+\.\d+\.\d+)').firstMatch(html);
+    expect(match, isNotNull, reason: 'index.html must contain a version badge');
+    final webVersion = match!.group(1)!;
+    expect(apeVersion, equals(webVersion),
+        reason:
+            'index.html badge (v$webVersion) must match version.dart ($apeVersion)');
+  });
 }

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -247,7 +247,7 @@
     <header>
       <h1>Finite <span class="ape">APE</span> Machine</h1>
       <p class="tagline">Infinite monkeys produce noise. Finite APEs produce software.</p>
-      <span class="badge">v0.0.11 — Windows &amp; Linux</span>
+      <span class="badge">v0.0.13 — Windows &amp; Linux</span>
     </header>
 
     <section>


### PR DESCRIPTION
- Update index.html badge from v0.0.11 to v0.0.13
- Add test in version_sync_test.dart that validates site badge matches apeVersion

Closes #61