### PR TITLE
fix(#64): FSM backward transitions + EVOLUTION block illegal

### DIFF
--- a/code/cli/assets/fsm/fsm-diagram.md
+++ b/code/cli/assets/fsm/fsm-diagram.md
@@ -1,0 +1,57 @@
+# APE FSM — Transition Diagram
+
+> Auto-generated from `transition_contract.yaml`. Only **allowed** transitions shown.
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+
+    IDLE --> ANALYZE : start_analyze
+    IDLE --> IDLE : block
+
+    ANALYZE --> ANALYZE : start_analyze
+    ANALYZE --> PLAN : complete_analysis
+    ANALYZE --> IDLE : block
+
+    PLAN --> ANALYZE : start_analyze
+    PLAN --> EXECUTE : approve_plan
+    PLAN --> EXECUTE : go_execute
+    PLAN --> IDLE : block
+
+    EXECUTE --> ANALYZE : start_analyze
+    EXECUTE --> EVOLUTION : finish_execute
+    EXECUTE --> EXECUTE : go_execute
+    EXECUTE --> IDLE : block
+
+    EVOLUTION --> IDLE : finish_evolution
+
+    note right of IDLE
+        Triage + infrastructure
+        No prechecks required
+    end note
+
+    note right of ANALYZE
+        Prechecks for → PLAN:
+        issue_selected_or_created
+        diagnosis_exists
+    end note
+
+    note right of PLAN
+        Prechecks for → EXECUTE:
+        issue_selected
+        feature_branch_selected
+        plan_approved
+    end note
+
+    note right of EXECUTE
+        Prechecks for → EVOLUTION:
+        issue_selected
+        feature_branch_selected
+        pr_created
+    end note
+
+    note right of EVOLUTION
+        Prechecks for → IDLE:
+        retrospective_recorded
+    end note
+```

--- a/code/cli/assets/fsm/transition_contract.yaml
+++ b/code/cli/assets/fsm/transition_contract.yaml
@@ -130,9 +130,14 @@ transitions:
 
   - from: PLAN
     event: start_analyze
-    to: ILLEGAL
-    allowed: false
-    reason: "PLAN cannot start analyze"
+    to: ANALYZE
+    allowed: true
+    operations:
+      prechecks: []
+      effects: [reopen_analysis]
+      artifacts: []
+      commit_policy: none
+      prompt_fragment_id: plan_to_analyze
 
   - from: PLAN
     event: complete_analysis
@@ -187,9 +192,14 @@ transitions:
 
   - from: EXECUTE
     event: start_analyze
-    to: ILLEGAL
-    allowed: false
-    reason: "EXECUTE cannot start analyze"
+    to: ANALYZE
+    allowed: true
+    operations:
+      prechecks: []
+      effects: [reopen_analysis]
+      artifacts: []
+      commit_policy: none
+      prompt_fragment_id: execute_to_analyze
 
   - from: EXECUTE
     event: complete_analysis
@@ -279,14 +289,9 @@ transitions:
 
   - from: EVOLUTION
     event: block
-    to: IDLE
-    allowed: true
-    operations:
-      prechecks: []
-      effects: [pause_evolution]
-      artifacts: []
-      commit_policy: none
-      prompt_fragment_id: evolution_to_idle
+    to: ILLEGAL
+    allowed: false
+    reason: "EVOLUTION is automatic and one-shot — cannot be paused"
 
   - from: EVOLUTION
     event: go_execute
@@ -358,6 +363,14 @@ prompt_fragments:
     role: BASHO
     skill: issue-start
     template: "execute.continue"
+  plan_to_analyze:
+    role: SOCRATES
+    skill: memory-read
+    template: "analyze.reopen"
+  execute_to_analyze:
+    role: SOCRATES
+    skill: memory-read
+    template: "analyze.reopen"
   evolution_to_idle:
     role: APE
     skill: memory-read


### PR DESCRIPTION
1. **PLAN → ANALYZE** (start_analyze) — enabled, no prechecks
2. **EXECUTE → ANALYZE** (start_analyze) — enabled, no prechecks
3. **EVOLUTION + block** — now ILLEGAL (one-shot, no pause/resume)
4. **FSM diagram** — new Mermaid diagram in fsm-diagram.md

13 FSM tests green.

Closes #64