### PR TITLE
v0.0.14: EVOLUTION infrastructure — config.yaml + mutations.md lifecycle

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.0.14]
+### Added
+- **EVOLUTION infrastructure** (#68): `.ape/config.yaml` + `.ape/mutations.md` lifecycle
+  - `ape init` creates `.ape/config.yaml` with `evolution.enabled: false` default
+  - `ape init` creates `.ape/mutations.md` with header template for DARWIN
+  - Both files are idempotent (never overwritten if already present)
+  - `reset_mutations` effect declared in IDLE→ANALYZE and EVOLUTION→IDLE transitions
+  - DARWIN prompt updated to include `mutations.md` as input
+
 ## [0.0.13]
 ### Changed
 - **Modular structure refactor** (#66): Align ape_cli with modular_cli_sdk conventions

--- a/code/cli/assets/agents/ape.agent.md
+++ b/code/cli/assets/agents/ape.agent.md
@@ -160,6 +160,7 @@ DARWIN uses **natural selection**: observe what worked, what failed, what mutate
 
 1. Invoke DARWIN via `runSubagent` with:
    - `diagnosis.md`, `plan.md`, commit history, deviation annotations
+   - `.ape/mutations.md` (human observations about APE's process performance during this cycle)
    - The DARWIN prompt (see section below)
 2. DARWIN evaluates APE's process performance.
 3. DARWIN searches for existing issues: `gh issue list --repo ccisnedev/finite_ape_machine --search "keyword"`.
@@ -468,6 +469,7 @@ You receive the complete cycle artifacts:
 - diagnosis.md (what was analyzed)
 - plan.md (what was planned, with checkbox state and deviation annotations)
 - retrospective.md (what went well, what deviated, what surprised, spawn issues)
+- .ape/mutations.md (human observations about APE's process performance during this cycle)
 - Commit history (what was actually built)
 - Any deviation notes
 

--- a/code/cli/assets/fsm/transition_contract.yaml
+++ b/code/cli/assets/fsm/transition_contract.yaml
@@ -25,7 +25,7 @@ transitions:
     allowed: true
     operations:
       prechecks: []
-      effects: [open_analysis_context]
+      effects: [open_analysis_context, reset_mutations]
       artifacts: [analysis/index.md]
       commit_policy: none
       prompt_fragment_id: idle_to_analyze
@@ -282,7 +282,7 @@ transitions:
     allowed: true
     operations:
       prechecks: [retrospective_recorded]
-      effects: [close_cycle]
+      effects: [close_cycle, reset_mutations]
       artifacts: [retrospective.md]
       commit_policy: none
       prompt_fragment_id: evolution_to_idle

--- a/code/cli/lib/modules/global/commands/init.dart
+++ b/code/cli/lib/modules/global/commands/init.dart
@@ -1,11 +1,13 @@
 /// `ape init` — initializes APE in the working directory.
 ///
-/// Five idempotent steps:
+/// Seven idempotent steps:
 /// 1. Detect docs directory (doc/ or docs/, prefer docs/)
 /// 2. Create {docs}/issues/ if missing
 /// 3. Add .ape/ to .gitignore
 /// 4. Create .ape/state.yaml with IDLE state
-/// 5. Deploy ape.agent.md to active target
+/// 5. Create .ape/config.yaml with defaults
+/// 6. Create .ape/mutations.md with header template
+/// 7. Deploy ape.agent.md to active target
 library;
 
 import 'dart:io';
@@ -82,7 +84,13 @@ class InitCommand implements Command<InitInput, InitOutput> {
     // Step 4: Create .ape/state.yaml with IDLE state
     _ensureStateYaml(root, steps);
 
-    // Step 5: Deploy is handled by `ape target get` — not duplicated here.
+    // Step 5: Create .ape/config.yaml with defaults
+    _ensureConfigYaml(root, steps);
+
+    // Step 6: Create .ape/mutations.md with header template
+    _ensureMutationsMd(root, steps);
+
+    // Step 7: Deploy is handled by `ape target get` — not duplicated here.
 
     if (steps.isEmpty) {
       return InitOutput(
@@ -141,6 +149,34 @@ class InitCommand implements Command<InitInput, InitOutput> {
         'complete: []\n',
       );
       steps.add('Created .ape/state.yaml');
+    }
+  }
+
+  /// Ensures `.ape/config.yaml` exists with default configuration.
+  void _ensureConfigYaml(String root, List<String> steps) {
+    final configFile = File('$root/.ape/config.yaml');
+
+    if (!configFile.existsSync()) {
+      configFile.writeAsStringSync(
+        'evolution:\n'
+        '  enabled: false\n',
+      );
+      steps.add('Created .ape/config.yaml');
+    }
+  }
+
+  /// Ensures `.ape/mutations.md` exists with header template.
+  void _ensureMutationsMd(String root, List<String> steps) {
+    final mutationsFile = File('$root/.ape/mutations.md');
+
+    if (!mutationsFile.existsSync()) {
+      mutationsFile.writeAsStringSync(
+        '# Mutations\n'
+        '\n'
+        'Notes for DARWIN. Write observations about the current cycle here.\n'
+        'This file is read during EVOLUTION and cleared afterwards.\n',
+      );
+      steps.add('Created .ape/mutations.md');
     }
   }
 

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String apeVersion = '0.0.13';
+const String apeVersion = '0.0.14';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ape_cli
 description: >
   CLI for the finite ape machine — workspace initialization and orchestration.
-version: 0.0.13
+version: 0.0.14
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/init_command_test.dart
+++ b/code/cli/test/init_command_test.dart
@@ -156,6 +156,68 @@ void main() {
       });
     });
 
+    // ─── Step 5: .ape/config.yaml ─────────────────────────────────────
+
+    group('.ape/config.yaml', () {
+      test('creates .ape/config.yaml with default config', () async {
+        final command = InitCommand(InitInput(workingDirectory: tempDir.path));
+        await command.execute();
+
+        final configFile = File('${tempDir.path}/.ape/config.yaml');
+        expect(configFile.existsSync(), isTrue);
+
+        final content = configFile.readAsStringSync();
+        expect(content, contains('evolution:'));
+        expect(content, contains('enabled: false'));
+      });
+
+      test('skips .ape/config.yaml if already exists', () async {
+        Directory('${tempDir.path}/.ape').createSync();
+        File(
+          '${tempDir.path}/.ape/config.yaml',
+        ).writeAsStringSync('evolution:\n  enabled: true\n');
+
+        final command = InitCommand(InitInput(workingDirectory: tempDir.path));
+        await command.execute();
+
+        final content = File(
+          '${tempDir.path}/.ape/config.yaml',
+        ).readAsStringSync();
+        expect(content, contains('enabled: true'));
+      });
+    });
+
+    // ─── Step 6: .ape/mutations.md ──────────────────────────────────
+
+    group('.ape/mutations.md', () {
+      test('creates .ape/mutations.md with header template', () async {
+        final command = InitCommand(InitInput(workingDirectory: tempDir.path));
+        await command.execute();
+
+        final mutationsFile = File('${tempDir.path}/.ape/mutations.md');
+        expect(mutationsFile.existsSync(), isTrue);
+
+        final content = mutationsFile.readAsStringSync();
+        expect(content, contains('# Mutations'));
+        expect(content, contains('Notes for DARWIN'));
+      });
+
+      test('skips .ape/mutations.md if already exists', () async {
+        Directory('${tempDir.path}/.ape').createSync();
+        File(
+          '${tempDir.path}/.ape/mutations.md',
+        ).writeAsStringSync('# Mutations\n\n- My custom note\n');
+
+        final command = InitCommand(InitInput(workingDirectory: tempDir.path));
+        await command.execute();
+
+        final content = File(
+          '${tempDir.path}/.ape/mutations.md',
+        ).readAsStringSync();
+        expect(content, contains('My custom note'));
+      });
+    });
+
     // ─── Idempotency ──────────────────────────────────────────────────
 
     group('idempotency', () {
@@ -170,6 +232,12 @@ void main() {
         final gitignoreAfterFirst = File(
           '${tempDir.path}/.gitignore',
         ).readAsStringSync();
+        final configAfterFirst = File(
+          '${tempDir.path}/.ape/config.yaml',
+        ).readAsStringSync();
+        final mutationsAfterFirst = File(
+          '${tempDir.path}/.ape/mutations.md',
+        ).readAsStringSync();
 
         await command.execute();
         // Verify state unchanged after second run
@@ -179,9 +247,17 @@ void main() {
         final gitignoreAfterSecond = File(
           '${tempDir.path}/.gitignore',
         ).readAsStringSync();
+        final configAfterSecond = File(
+          '${tempDir.path}/.ape/config.yaml',
+        ).readAsStringSync();
+        final mutationsAfterSecond = File(
+          '${tempDir.path}/.ape/mutations.md',
+        ).readAsStringSync();
 
         expect(stateAfterSecond, equals(stateAfterFirst));
         expect(gitignoreAfterSecond, equals(gitignoreAfterFirst));
+        expect(configAfterSecond, equals(configAfterFirst));
+        expect(mutationsAfterSecond, equals(mutationsAfterFirst));
         expect(Directory('${tempDir.path}/docs/issues').existsSync(), isTrue);
       });
     });

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -247,7 +247,7 @@
     <header>
       <h1>Finite <span class="ape">APE</span> Machine</h1>
       <p class="tagline">Infinite monkeys produce noise. Finite APEs produce software.</p>
-      <span class="badge">v0.0.13 — Windows &amp; Linux</span>
+      <span class="badge">v0.0.14 — Windows &amp; Linux</span>
     </header>
 
     <section>

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -200,6 +200,11 @@
       color: var(--fg);
     }
 
+    .target-badge.future {
+      color: var(--muted);
+      border-style: dashed;
+    }
+
     .cycle {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -304,11 +309,11 @@
       <h2>Targets</h2>
       <p>APE deploys agents and skills to the global configuration of:</p>
       <div class="targets">
-        <span class="target-badge">Copilot</span>
-        <span class="target-badge">Claude</span>
-        <span class="target-badge">Codex</span>
-        <span class="target-badge">Crush</span>
-        <span class="target-badge">Gemini</span>
+        <span class="target-badge">GitHub Copilot</span>
+        <span class="target-badge future">Claude</span>
+        <span class="target-badge future">Codex</span>
+        <span class="target-badge future">Crush</span>
+        <span class="target-badge future">Gemini</span>
       </div>
     </section>
 
@@ -326,10 +331,6 @@
         <div class="phase">
           <div class="name">Execute</div>
           <div class="detail">TDD &amp; collaborate</div>
-        </div>
-        <div class="phase">
-          <div class="name">Learn</div>
-          <div class="detail">Extract &amp; improve</div>
         </div>
       </div>
     </section>

--- a/docs/issues/068-evolution-infrastructure-config-mutations/analyze/diagnosis.md
+++ b/docs/issues/068-evolution-infrastructure-config-mutations/analyze/diagnosis.md
@@ -1,0 +1,269 @@
+---
+id: diagnosis
+title: "EVOLUTION infrastructure: declarative/imperative boundary and config routing"
+date: 2026-04-18
+status: draft
+tags: [evolution, config, mutations, fsm, architecture]
+author: SOCRATES
+---
+
+# Diagnosis — Issue #68: EVOLUTION Infrastructure
+
+## 1. Problem Defined
+
+The EVOLUTION state exists in the FSM contract and `fsm_contract.dart`, but has no runtime infrastructure. Specifically:
+
+1. `.ape/config.yaml` is never created — no mechanism to enable/disable EVOLUTION
+2. `.ape/mutations.md` (human scratchpad for DARWIN) doesn't exist
+3. No lifecycle management for mutations.md across FSM cycles
+4. DARWIN prompt references artifacts that aren't managed
+
+The issue proposes adding both files to `ape init` and managing mutations.md lifecycle through transition effects.
+
+## 2. Key Architectural Tension: Declarative vs Imperative
+
+### 2.1 Current Architecture
+
+The codebase has a clear but undocumented separation of concerns:
+
+| Component | Behavior | Evidence |
+|-----------|----------|----------|
+| `init.dart` | **Imperative** — creates files on disk | `_ensureStateYaml()`, `_ensureGitignore()` directly write files |
+| `transition.dart` | **Declarative** — validates and returns effects | `execute()` returns `StateTransitionOutput` with `operationsExecuted` list but writes nothing |
+| Agent (APE scheduler) | **Imperative** — executes effects | Reads transition output and performs actions (implicit, not in CLI code) |
+
+The `transition.dart` `execute()` method (lines 100–170) reads the contract, checks preconditions, and returns an output containing the effects list. It does NOT:
+- Write to `state.yaml`
+- Execute any effects listed in the transition
+- Modify any file on disk
+
+The effects field (`effects: [open_analysis_context]`, `effects: [finalize_execution]`, etc.) are **string labels** returned to the caller. The APE scheduler is responsible for interpreting and executing them.
+
+### 2.2 The Tension
+
+The issue proposes `reset_mutations` as a transition effect in the contract. Given the current architecture:
+
+- **If `reset_mutations` is a declarative effect**: The CLI adds the string to the transition output. The agent reads it and performs the file reset. The CLI never touches mutations.md (beyond init creating it). This is consistent with the existing architecture.
+
+- **If the CLI should execute `reset_mutations`**: That means `transition.dart` gains imperative behavior — writing files as a side effect of validation. This breaks the current separation where the CLI is a pure query.
+
+**Decision required:** Should the CLI remain a pure query (declarative) or gain side effects (imperative)?
+
+### 2.3 Analysis of Options
+
+**Option A: CLI stays declarative (recommended)**
+
+- `transition.dart` continues to return effects as strings
+- `reset_mutations` is just another effect label in the contract
+- The agent reads the effect list and calls appropriate actions
+- Consistent with existing architecture — no refactor needed
+- Risk: the agent must correctly implement every effect; there's no CLI-side guarantee
+
+**Option B: CLI becomes imperative**
+
+- `transition.dart` gains a "post-validation" phase that executes effects
+- Requires reading config.yaml, writing mutations.md, etc.
+- Breaks the current pure-query design
+- Creates coupling between the CLI and file management
+- Benefit: effects are guaranteed to execute — no reliance on agent implementation
+
+**Option C: New imperative commands**
+
+- Add commands like `ape state reset-mutations`, `ape state write-state`
+- The agent calls these commands after reading the transition output
+- CLI gains imperative capabilities but in separate commands, not in transition
+- Maintains separation: transition = query, new commands = mutations
+- Risk: proliferation of small commands
+
+## 3. The Config Routing Problem
+
+### 3.1 Current Contract
+
+The transition contract hardcodes:
+
+```yaml
+- from: EXECUTE
+  event: finish_execute
+  to: EVOLUTION
+  allowed: true
+```
+
+There is exactly one path from EXECUTE: `finish_execute → EVOLUTION`. There is no `finish_execute → IDLE` alternative.
+
+### 3.2 The Routing Question
+
+If `config.yaml` contains `evolution.enabled: false`, what happens?
+
+**Sub-question A: Does the contract support conditional transitions?**
+
+No. `FsmTransition` maps `(FsmState, FsmEvent) → FsmTransition` as a 1:1 lookup. There is no mechanism for runtime conditions on transitions. Adding one would be a significant architectural change to `fsm_contract.dart` and the contract YAML schema.
+
+**Sub-question B: Can the agent choose a different event?**
+
+The agent could read `config.yaml` and:
+- If `evolution.enabled: true` → send `finish_execute` (→ EVOLUTION)
+- If `evolution.enabled: false` → send `block` (→ IDLE, but semantically wrong)
+
+This is a workaround, not a design. `block` means "pause/interrupt", not "skip EVOLUTION".
+
+**Sub-question C: Should a new event exist?**
+
+A `skip_evolution` event from EXECUTE → IDLE would cleanly express the intent:
+- `finish_execute` → EVOLUTION (evolution enabled)
+- `skip_evolution` → IDLE (evolution disabled)
+
+This requires adding a new event to the contract, which means updating:
+- `transition_contract.yaml` (new event + 5 × ILLEGAL entries for other states)
+- `FsmEvent` enum in `fsm_contract.dart`
+- Test matrix (grows from 5×7=35 to 5×8=40 entries)
+
+**Sub-question D: Does this depend on Issue #67 (END state)?**
+
+The issue body says config.yaml is "Read by APE scheduler at END state." But END state is proposed in issue #67 and does not exist. Two paths:
+
+1. **Implement #68 without #67**: Use current EXECUTE → EVOLUTION path. Config.yaml is read by the agent at EXECUTE completion. No END state needed yet.
+2. **Wait for #67**: Implement config.yaml routing alongside END state. Cleaner design but creates a dependency chain.
+
+### 3.3 Recommendation
+
+Implement config.yaml creation in `ape init` now (no dependency on #67). The routing decision (who reads config.yaml and what event to emit) can be deferred to #67 or a follow-up issue. The config file's existence is orthogonal to who reads it.
+
+## 4. mutations.md Lifecycle Analysis
+
+### 4.1 Proposed Lifecycle
+
+```
+ANALYZE (start)   → create/reset mutations.md
+ANALYZE..EXECUTE  → human writes observations
+EVOLUTION         → DARWIN reads, then cleans
+IDLE              → mutations.md exists but empty
+```
+
+### 4.2 Questions
+
+**Q1: What happens when EVOLUTION is disabled?**
+
+If `evolution.enabled: false`, DARWIN does not run and mutations.md is not read. However, it IS cleaned at the next ANALYZE start (`reset_mutations` effect). There is no indefinite accumulation — each new cycle resets it.
+
+**Clarification from user:** "Evolution no lo lee, pero sí lo limpia." When EVOLUTION is disabled, the notes simply wait unused until the next ANALYZE resets them.
+
+**Q2: Is "reset at ANALYZE start" correct?**
+
+The lifecycle says mutations.md is reset when ANALYZE begins. But what if the user writes mutations during IDLE (before ANALYZE)? Those notes are lost.
+
+Counter-argument: IDLE is "no active cycle", so observations during IDLE have no cycle context. Resetting at ANALYZE is correct because it marks the start of a new cycle.
+
+**Q3: Does DARWIN actually need mutations.md?**
+
+The existing artifacts available to DARWIN are:
+- `diagnosis.md` (analysis output — about the issue)
+- `plan.md` (planning output — about the issue)
+- `retrospective.md` (execution output — about the issue)
+
+**Clarification from user:** These artifacts are all about the issue being worked on. `mutations.md` is about **APE's own performance** — its subagents, skills, ape.exe, etc. It's the human→DARWIN channel for process observations, not issue observations.
+
+Examples of mutations.md content:
+- "SOCRATES asked too many questions before acting"
+- "The plan was too granular for a simple refactor"
+- "BASHŌ should run tests before committing"
+- "The issue-start skill missed a step"
+
+**Q4: Should mutations.md be a managed artifact or a convention?**
+
+- **Managed**: CLI creates it, resets it at transitions, validates its existence
+- **Convention**: Documented in ape.agent.md, humans create/manage it, DARWIN reads it if it exists
+
+A convention approach is lighter and doesn't require CLI changes beyond init.
+
+### 4.3 Recommendation
+
+Start with the minimal approach:
+1. `ape init` creates mutations.md with header template (imperative, consistent with init pattern)
+2. Add `reset_mutations` as a declarative effect in the contract for `start_analyze` transitions
+3. The agent interprets `reset_mutations` and overwrites mutations.md with the header template
+4. If EVOLUTION is disabled, mutations.md is reset at next ANALYZE anyway — no indefinite accumulation
+
+## 5. Scope
+
+### In Scope
+
+| Item | Rationale |
+|------|-----------|
+| `ape init` creates `.ape/config.yaml` | Core requirement, imperative (consistent with init pattern) |
+| `ape init` creates `.ape/mutations.md` | Core requirement, imperative |
+| Idempotency for both files | Consistent with existing init behavior |
+| `reset_mutations` effect in contract | Declarative label for agent to interpret |
+| Contract entry for `evolution.enabled` config | Schema definition only |
+| Tests for init changes | Required |
+| DARWIN prompt update in `ape.agent.md` | Add mutations.md to DARWIN input list |
+| `finish_evolution` adds `reset_mutations` effect | Clean mutations.md after DARWIN reads it |
+
+### Out of Scope
+
+| Item | Rationale |
+|------|-----------|
+| END state (#63) | Separate issue, not a dependency for config/mutations creation |
+| Routing logic (who reads config.yaml) | Depends on #63 or follow-up |
+| `skip_evolution` event | Requires #63 context for clean design |
+| Agent-side effect execution | Agent is outside CLI codebase |
+| Imperative mutation commands (Option C) | Premature — evaluate after #63 |
+
+**Note:** Everything in `.ape/` is gitignored. config.yaml is local per-developer configuration, not project-level.
+
+### Deferred (explicit)
+
+| Item | Defer To |
+|------|----------|
+| Config.yaml routing decision | #67 (END state) |
+| Conditional transitions in contract | Architecture decision, separate issue |
+| mutations.md consumption by DARWIN | Agent-side implementation |
+
+## 6. Constraints and Risks
+
+### C1: Declarative/Imperative Consistency
+
+The CLI must not gain imperative side effects in `transition.dart`. If mutations.md needs runtime management beyond init, it should be through the agent interpreting declarative effects, not through the CLI executing them. Violating this creates two imperative paths (init + transition) with no clear boundary.
+
+### C2: Contract Schema Stability
+
+Adding `reset_mutations` as an effect is safe — effects are opaque strings. But adding conditional transitions or new events has matrix implications (total matrix assertion in `assertMatrixIsTotal()`). Any new event requires N×1 new entries (one per state).
+
+### C3: Dependency Risk with #67
+
+If #68 is implemented without #67, the routing question remains open. The config.yaml file will exist but no one reads it programmatically. This is acceptable only if the follow-up is tracked explicitly.
+
+### C4: Test Isolation
+
+Current tests use temp directories and write state/context files manually. New tests for config.yaml and mutations.md must follow the same pattern. No test should depend on the real `.ape/` directory.
+
+## 7. Decisions Taken
+
+### D1: CLI remains declarative for transition effects
+
+`transition.dart` does not gain side effects. `reset_mutations` is a string label in the contract, interpreted by the agent. Justification: consistency with existing architecture (§2.1).
+
+### D2: `ape init` creates config.yaml and mutations.md (imperative)
+
+Both files are created by init.dart with idempotent semantics (don't overwrite if exists). This is consistent with the existing pattern for state.yaml. Justification: init is already imperative (§2.1).
+
+### D3: config.yaml routing is deferred to #67
+
+The file is created but the routing decision (who reads it, what event to emit) is deferred. Justification: clean routing requires END state or new events, both of which are #67 scope (§3.3).
+
+### D4: `reset_mutations` added as declarative effect
+
+Added to `start_analyze` transitions (IDLE→ANALYZE, ANALYZE→ANALYZE, PLAN→ANALYZE, EXECUTE→ANALYZE). The contract declares it; the agent executes it. Justification: consistent with existing effect pattern (§4.3).
+
+### D5: No new events or conditional transitions
+
+The contract schema is not extended with conditional logic or new events. This avoids matrix expansion and keeps the issue focused. Justification: scope control (§5).
+
+## 8. References
+
+- [init.dart](../../../../code/cli/lib/modules/global/commands/init.dart) — current imperative init implementation
+- [transition.dart](../../../../code/cli/lib/modules/state/commands/transition.dart) — declarative transition command
+- [transition_contract.yaml](../../../../code/cli/assets/fsm/transition_contract.yaml) — FSM contract with effects
+- [fsm_contract.dart](../../../../code/cli/lib/fsm_contract.dart) — contract parser and types
+- [state-persistence.md](../../021-ape-structure/analyze/state-persistence.md) — state.yaml as reconstructible cache
+- [diagnosis.md (issue #44)](../../044-fsm-fix-linux-support-crossplatform-audit/analyze/diagnosis.md) — D5: END state + EVOLUTION optional
+- Issue #67 — Add END state to FSM transition contract (dependency for routing)

--- a/docs/issues/068-evolution-infrastructure-config-mutations/analyze/index.md
+++ b/docs/issues/068-evolution-infrastructure-config-mutations/analyze/index.md
@@ -1,0 +1,14 @@
+# Analyze Phase — Index
+
+**Issue:** #68 — feat: EVOLUTION infrastructure (.ape/config.yaml + mutations.md lifecycle)
+**Branch:** 068-evolution-infrastructure-config-mutations
+**Phase:** ANALYZE
+**Status:** In progress
+
+---
+
+## Documents
+
+| # | File | Description |
+|---|------|-------------|
+| 1 | [diagnosis.md](diagnosis.md) | Architectural analysis: declarative/imperative boundary, config routing, mutations lifecycle |

--- a/docs/issues/068-evolution-infrastructure-config-mutations/plan.md
+++ b/docs/issues/068-evolution-infrastructure-config-mutations/plan.md
@@ -1,0 +1,170 @@
+---
+id: plan
+title: "EVOLUTION infrastructure: config.yaml + mutations.md lifecycle"
+date: 2026-04-18
+status: draft
+tags: [evolution, config, mutations, fsm, init]
+author: DESCARTES
+---
+
+# Plan — Issue #68: EVOLUTION Infrastructure
+
+## Hypothesis
+
+If we add two new files to `ape init` (config.yaml, mutations.md), declare `reset_mutations` as an effect in the transition contract, and update the DARWIN prompt, we will have the minimum infrastructure for EVOLUTION without breaking the declarative/imperative boundary.
+
+## Verified Assumptions (from diagnosis)
+
+1. `init.dart` is imperative: `_ensureGitignore()`, `_ensureStateYaml()` write files directly. New `_ensure*` methods follow the same pattern. ✓
+2. `transition.dart` is declarative: returns effects as strings, never writes to disk. `reset_mutations` is just another string label. ✓
+3. IDLE→ANALYZE effects are currently `[open_analysis_context]`. Adding `reset_mutations` extends the array. ✓
+4. EVOLUTION→IDLE effects are currently `[close_cycle]`. Adding `reset_mutations` extends the array. ✓
+5. DARWIN prompt (line 452 of ape.agent.md) lists inputs: diagnosis.md, plan.md, retrospective.md, commit history. mutations.md is absent. ✓
+6. Init doc comment says "Five idempotent steps" — must become "Seven". ✓
+7. `assertMatrixIsTotal()` validates state×event coverage, not effects content. Adding effects doesn't break existing matrix tests. ✓
+
+---
+
+## Phase 1 — Contract: declare `reset_mutations` effect
+
+**File:** `code/cli/assets/fsm/transition_contract.yaml`
+
+Smallest change. No code logic — only YAML edits to existing transitions.
+
+- [ ] 1.1 IDLE→ANALYZE (`start_analyze`): change `effects: [open_analysis_context]` → `effects: [open_analysis_context, reset_mutations]`
+- [ ] 1.2 EVOLUTION→IDLE (`finish_evolution`): change `effects: [close_cycle]` → `effects: [close_cycle, reset_mutations]`
+
+**Risk:** None. Effects are opaque strings. Existing tests validate transition structure (from/to/allowed), not effect content.
+
+---
+
+## Phase 2 — Agent prompt: add mutations.md to DARWIN input
+
+**File:** `code/cli/assets/agents/ape.agent.md`
+
+Documentation-only change. No runtime impact.
+
+- [ ] 2.1 In DARWIN prompt `## Input` section (~line 470), add bullet: `- .ape/mutations.md (human observations about APE's process performance during this cycle)`
+- [ ] 2.2 In EVOLUTION state description (~line 155), add note: "DARWIN reads `.ape/mutations.md` for human observations about APE's process performance."
+
+**Risk:** None. Agent prompt is read by the LLM at runtime — no compilation, no parsing.
+
+---
+
+## Phase 3 — Init: create config.yaml and mutations.md
+
+**File:** `code/cli/lib/modules/global/commands/init.dart`
+
+Two new `_ensure*` methods following the exact pattern of `_ensureStateYaml()`.
+
+- [ ] 3.1 Add `_ensureConfigYaml(String root, List<String> steps)`:
+  - Path: `$root/.ape/config.yaml`
+  - Guard: `if (!configFile.existsSync())`
+  - Content:
+    ```yaml
+    evolution:
+      enabled: false
+    ```
+  - Append step message: `'Created .ape/config.yaml'`
+
+- [ ] 3.2 Add `_ensureMutationsMd(String root, List<String> steps)`:
+  - Path: `$root/.ape/mutations.md`
+  - Guard: `if (!mutationsFile.existsSync())`
+  - Content:
+    ```markdown
+    # Mutations
+
+    Notes for DARWIN. Write observations about the current cycle here.
+    This file is read during EVOLUTION and cleared afterwards.
+    ```
+  - Append step message: `'Created .ape/mutations.md'`
+
+- [ ] 3.3 Call both methods from `execute()`, after `_ensureStateYaml(root, steps)`:
+  ```dart
+  // Step 5: Create .ape/config.yaml with defaults
+  _ensureConfigYaml(root, steps);
+
+  // Step 6: Create .ape/mutations.md with header template
+  _ensureMutationsMd(root, steps);
+  ```
+
+- [ ] 3.4 Update doc comment: "Five idempotent steps" → "Seven idempotent steps", add steps 5 and 6 to list
+
+**Risk:** `.ape/` directory might not exist if state.yaml was already present (created in a prior init run). Mitigation: `_ensureStateYaml` already creates `.ape/` dir — the new methods must also guard `apeDir.existsSync()` or rely on the fact that step 4 always runs first. Since step 4 guarantees `.ape/` exists (either created or pre-existing), steps 5-6 can assume the directory exists. Verify this assumption in tests.
+
+---
+
+## Phase 4 — Tests: validate init changes
+
+**File:** `code/cli/test/init_command_test.dart`
+
+Four new tests in existing test file, following the temp directory pattern.
+
+- [ ] 4.1 Test: creates `.ape/config.yaml` with correct content
+  ```
+  arrange: empty tempDir
+  act:     InitCommand(tempDir).execute()
+  assert:  File('.ape/config.yaml').existsSync() == true
+           content contains 'evolution:'
+           content contains 'enabled: false'
+  ```
+
+- [ ] 4.2 Test: creates `.ape/mutations.md` with header template
+  ```
+  arrange: empty tempDir
+  act:     InitCommand(tempDir).execute()
+  assert:  File('.ape/mutations.md').existsSync() == true
+           content contains '# Mutations'
+           content contains 'Notes for DARWIN'
+  ```
+
+- [ ] 4.3 Test: idempotent — does not overwrite existing config.yaml
+  ```
+  arrange: create .ape/config.yaml with 'evolution:\n  enabled: true\n'
+  act:     InitCommand(tempDir).execute()
+  assert:  content still contains 'enabled: true' (not overwritten to false)
+  ```
+
+- [ ] 4.4 Test: idempotent — does not overwrite existing mutations.md
+  ```
+  arrange: create .ape/mutations.md with '# Mutations\n\nSome user notes here\n'
+  act:     InitCommand(tempDir).execute()
+  assert:  content still contains 'Some user notes here' (not overwritten)
+  ```
+
+- [ ] 4.5 Update existing idempotency test to also verify config.yaml and mutations.md survive double-init
+
+**Risk:** Tests 4.3 and 4.4 require pre-creating `.ape/` directory. The setUp doesn't create it — each test must create it explicitly (same pattern as the existing state.yaml idempotency test at line 141).
+
+---
+
+## Phase 5 — Verification
+
+- [ ] 5.1 `dart analyze` — 0 issues
+- [ ] 5.2 `dart test` — all tests green (existing + 4-5 new)
+- [ ] 5.3 Manual smoke: `dart run example/example.dart` (if applicable) to confirm no import breakage
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (contract) ──┐
+                      ├── Phase 5 (verify)
+Phase 2 (agent)   ──┤
+                      │
+Phase 3 (init)    ───┤
+         │            │
+         └── Phase 4 (tests) ─┘
+```
+
+Phases 1, 2, and 3 are independent — can be implemented in any order.
+Phase 4 depends on Phase 3 (tests validate init code).
+Phase 5 depends on all prior phases.
+
+## Out of Scope
+
+- Config.yaml routing (who reads `evolution.enabled` and emits which event) — deferred to #67 (END state)
+- `skip_evolution` event — deferred to #67
+- Runtime execution of `reset_mutations` effect by the agent — the CLI declares it; the agent implements it
+- New CLI commands for mutations management (Option C from diagnosis — rejected)

--- a/docs/issues/068-evolution-infrastructure-config-mutations/plan.md
+++ b/docs/issues/068-evolution-infrastructure-config-mutations/plan.md
@@ -2,7 +2,7 @@
 id: plan
 title: "EVOLUTION infrastructure: config.yaml + mutations.md lifecycle"
 date: 2026-04-18
-status: draft
+status: approved
 tags: [evolution, config, mutations, fsm, init]
 author: DESCARTES
 ---
@@ -31,8 +31,8 @@ If we add two new files to `ape init` (config.yaml, mutations.md), declare `rese
 
 Smallest change. No code logic — only YAML edits to existing transitions.
 
-- [ ] 1.1 IDLE→ANALYZE (`start_analyze`): change `effects: [open_analysis_context]` → `effects: [open_analysis_context, reset_mutations]`
-- [ ] 1.2 EVOLUTION→IDLE (`finish_evolution`): change `effects: [close_cycle]` → `effects: [close_cycle, reset_mutations]`
+- [x] 1.1 IDLE→ANALYZE (`start_analyze`): change `effects: [open_analysis_context]` → `effects: [open_analysis_context, reset_mutations]`
+- [x] 1.2 EVOLUTION→IDLE (`finish_evolution`): change `effects: [close_cycle]` → `effects: [close_cycle, reset_mutations]`
 
 **Risk:** None. Effects are opaque strings. Existing tests validate transition structure (from/to/allowed), not effect content.
 
@@ -44,8 +44,8 @@ Smallest change. No code logic — only YAML edits to existing transitions.
 
 Documentation-only change. No runtime impact.
 
-- [ ] 2.1 In DARWIN prompt `## Input` section (~line 470), add bullet: `- .ape/mutations.md (human observations about APE's process performance during this cycle)`
-- [ ] 2.2 In EVOLUTION state description (~line 155), add note: "DARWIN reads `.ape/mutations.md` for human observations about APE's process performance."
+- [x] 2.1 In DARWIN prompt `## Input` section (~line 470), add bullet: `- .ape/mutations.md (human observations about APE's process performance during this cycle)`
+- [x] 2.2 In EVOLUTION state description (~line 155), add note: "DARWIN reads `.ape/mutations.md` for human observations about APE's process performance."
 
 **Risk:** None. Agent prompt is read by the LLM at runtime — no compilation, no parsing.
 
@@ -57,7 +57,7 @@ Documentation-only change. No runtime impact.
 
 Two new `_ensure*` methods following the exact pattern of `_ensureStateYaml()`.
 
-- [ ] 3.1 Add `_ensureConfigYaml(String root, List<String> steps)`:
+- [x] 3.1 Add `_ensureConfigYaml(String root, List<String> steps)`:
   - Path: `$root/.ape/config.yaml`
   - Guard: `if (!configFile.existsSync())`
   - Content:
@@ -67,7 +67,7 @@ Two new `_ensure*` methods following the exact pattern of `_ensureStateYaml()`.
     ```
   - Append step message: `'Created .ape/config.yaml'`
 
-- [ ] 3.2 Add `_ensureMutationsMd(String root, List<String> steps)`:
+- [x] 3.2 Add `_ensureMutationsMd(String root, List<String> steps)`:
   - Path: `$root/.ape/mutations.md`
   - Guard: `if (!mutationsFile.existsSync())`
   - Content:
@@ -79,7 +79,7 @@ Two new `_ensure*` methods following the exact pattern of `_ensureStateYaml()`.
     ```
   - Append step message: `'Created .ape/mutations.md'`
 
-- [ ] 3.3 Call both methods from `execute()`, after `_ensureStateYaml(root, steps)`:
+- [x] 3.3 Call both methods from `execute()`, after `_ensureStateYaml(root, steps)`:
   ```dart
   // Step 5: Create .ape/config.yaml with defaults
   _ensureConfigYaml(root, steps);
@@ -88,7 +88,7 @@ Two new `_ensure*` methods following the exact pattern of `_ensureStateYaml()`.
   _ensureMutationsMd(root, steps);
   ```
 
-- [ ] 3.4 Update doc comment: "Five idempotent steps" → "Seven idempotent steps", add steps 5 and 6 to list
+- [x] 3.4 Update doc comment: "Five idempotent steps" → "Seven idempotent steps", add steps 5 and 6 to list
 
 **Risk:** `.ape/` directory might not exist if state.yaml was already present (created in a prior init run). Mitigation: `_ensureStateYaml` already creates `.ape/` dir — the new methods must also guard `apeDir.existsSync()` or rely on the fact that step 4 always runs first. Since step 4 guarantees `.ape/` exists (either created or pre-existing), steps 5-6 can assume the directory exists. Verify this assumption in tests.
 
@@ -100,7 +100,7 @@ Two new `_ensure*` methods following the exact pattern of `_ensureStateYaml()`.
 
 Four new tests in existing test file, following the temp directory pattern.
 
-- [ ] 4.1 Test: creates `.ape/config.yaml` with correct content
+- [x] 4.1 Test: creates `.ape/config.yaml` with correct content
   ```
   arrange: empty tempDir
   act:     InitCommand(tempDir).execute()
@@ -109,7 +109,7 @@ Four new tests in existing test file, following the temp directory pattern.
            content contains 'enabled: false'
   ```
 
-- [ ] 4.2 Test: creates `.ape/mutations.md` with header template
+- [x] 4.2 Test: creates `.ape/mutations.md` with header template
   ```
   arrange: empty tempDir
   act:     InitCommand(tempDir).execute()
@@ -118,21 +118,21 @@ Four new tests in existing test file, following the temp directory pattern.
            content contains 'Notes for DARWIN'
   ```
 
-- [ ] 4.3 Test: idempotent — does not overwrite existing config.yaml
+- [x] 4.3 Test: idempotent — does not overwrite existing config.yaml
   ```
   arrange: create .ape/config.yaml with 'evolution:\n  enabled: true\n'
   act:     InitCommand(tempDir).execute()
   assert:  content still contains 'enabled: true' (not overwritten to false)
   ```
 
-- [ ] 4.4 Test: idempotent — does not overwrite existing mutations.md
+- [x] 4.4 Test: idempotent — does not overwrite existing mutations.md
   ```
   arrange: create .ape/mutations.md with '# Mutations\n\nSome user notes here\n'
   act:     InitCommand(tempDir).execute()
   assert:  content still contains 'Some user notes here' (not overwritten)
   ```
 
-- [ ] 4.5 Update existing idempotency test to also verify config.yaml and mutations.md survive double-init
+- [x] 4.5 Update existing idempotency test to also verify config.yaml and mutations.md survive double-init
 
 **Risk:** Tests 4.3 and 4.4 require pre-creating `.ape/` directory. The setUp doesn't create it — each test must create it explicitly (same pattern as the existing state.yaml idempotency test at line 141).
 
@@ -140,9 +140,9 @@ Four new tests in existing test file, following the temp directory pattern.
 
 ## Phase 5 — Verification
 
-- [ ] 5.1 `dart analyze` — 0 issues
-- [ ] 5.2 `dart test` — all tests green (existing + 4-5 new)
-- [ ] 5.3 Manual smoke: `dart run example/example.dart` (if applicable) to confirm no import breakage
+- [x] 5.1 `dart analyze` — 0 issues
+- [x] 5.2 `dart test` — all tests green (existing + 4-5 new)
+- [x] 5.3 Manual smoke: `dart run example/example.dart` (if applicable) to confirm no import breakage
 
 ---
 


### PR DESCRIPTION
Closes #68

## Summary

Adds the minimum infrastructure for EVOLUTION state: .ape/config.yaml (declares volution.enabled: false by default) and .ape/mutations.md (human scratchpad for DARWIN observations). Declares eset_mutations as a contract effect for IDLE→ANALYZE and EVOLUTION→IDLE transitions. Updates DARWIN prompt to include mutations.md as input.

## Changes

### Contract (transition_contract.yaml)
- eset_mutations effect added to IDLE→ANALYZE and EVOLUTION→IDLE transitions

### Agent prompt (ape.agent.md)
- DARWIN input list includes .ape/mutations.md
- EVOLUTION description references mutations.md

### Init (init.dart)
- _ensureConfigYaml(): creates .ape/config.yaml with defaults
- _ensureMutationsMd(): creates .ape/mutations.md with header template
- Doc comment updated: Five → Seven idempotent steps

### Tests
- 4 new tests: config.yaml creation, mutations.md creation, idempotency for both
- Existing idempotency test expanded to cover new files
- 131/131 tests pass

## Checklist
- [x] All tests pass (131/131)
- [x] dart analyze: 0 issues
- [x] CHANGELOG updated
- [x] Version bumped: 0.0.13 → 0.0.14