### PR TITLE
docs(#73): rewrite README to reflect v0.0.14 state + add roadmap.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,92 +2,114 @@
 
 > Infinite monkeys produce noise. Finite APEs produce software.
 
-A formal framework for AI-assisted software development that models coding agents as cooperative finite state machines. APE imposes structure on the chaos of "vibe coding" through a methodology cycle — **Analyze, Plan, Execute + Learn** — where the value is in the process, not the model.
+A framework for AI-assisted software development that models coding agents as a cooperative finite state machine. APE replaces "vibe coding" with a deterministic methodology cycle — **Analyze → Plan → Execute → End → [Evolution] → Idle** — where the value is in the process, not the model.
+
+**Status:** `v0.0.14` · 131 tests · 12 GitHub releases · Windows + Linux · Single-target MVP (Copilot)
 
 ## What is APE?
 
-APE treats AI coding agents ("apes") as deterministic automata with prompts as transition functions. A cooperative event loop orchestrator — inspired by microcontroller scheduling — coordinates specialized agents (MARCOPOLO, SOCRATES, VITRUVIUS, SUNZI, GATSBY, ADA, DIJKSTRA, BORGES, DARWIN) without any agent being aware of the others. Intelligence emerges from orchestration, not individual capability.
+APE treats coding agents ("apes") as states of a finite state machine. Each state has one specialized agent in charge, a declarative transition contract, and pre/post-conditions enforced by the CLI. Intelligence emerges from orchestration and memory, not from any single agent's capability.
 
 **Core ideas:**
 
-- **Agents as FSMs** — each ape is a finite state machine: δ(state, context) → new_state + output
-- **Methodology over model** — a 7B local model following APE's structured runbook beats a frontier model freestyling
-- **Memory as Code** — project memory as version-controlled markdown with database-inspired indexing. No vector DB, no cloud dependency
-- **DARWIN** — an evolutionary meta-agent that modifies other agents' behavior across three learning levels (project → personal → community)
-- **Semantic risk matrix** — human approval only when engineering judgment matters. When APE asks, the question matters
-- **@contracts** — language-agnostic traceability from specs to tests
+- **Agents as FSM states** — each phase has one ape; transitions are declarative, total, and validated (`code/cli/assets/transition_contract.yaml`)
+- **Methodology over model** — a smaller model following APE's runbook beats a frontier model freestyling
+- **Memory as Code** — project memory as version-controlled markdown in `.ape/` and `docs/`. No vector DB, no cloud dependency
+- **DARWIN** — an evolutionary meta-agent that proposes mutations to APE itself after each cycle
+- **Semantic risk matrix** — human approval only when engineering judgment matters
 
-## Status
+## Quick start
 
-**Phase: Analyze** — specifications and formal design complete. Implementation has not started.
-
-### What exists
-
-```
-doc/
-├── finite-ape-machine.md    # Core methodology specification
-├── ape-cli-spec.md          # CLI tool specification (Dart)
-├── memory-as-code-spec.md   # Memory system specification
-├── orchestrator-spec.md     # Cooperative event loop orchestrator
-├── lore.md                  # The Apes — names, allegories, and roles
-├── adrs.md                  # Architecture Decision Records (6)
-└── ape-paper.md             # arXiv-style paper with 36 formal references
-```
-
-### What's next
-
-- [x] `ape init` — project scaffolding
-- [x] `ape version` — print CLI version
-- [x] `ape target get` — deploy APE agents and skills to all AI coding tools
-- [x] `ape target clean` — remove deployed APE files from all targets
-- [x] `ape upgrade` — download and install the latest APE release
-- [x] `ape uninstall` — remove APE CLI from the system
-- [ ] `ape memory` — Memory as Code CLI commands
-- [ ] `ape task` — GitHub Issues-backed task management
-- [ ] Orchestrator prompts for Copilot (first target)
-- [ ] BORGES validation engine
-- [ ] DARWIN learning loop
-
-## Install (Windows)
+### Install (Windows)
 
 ```powershell
 irm https://www.ccisne.dev/finite_ape_machine/install.ps1 | iex
 ```
 
-This downloads the latest release, extracts it to `%LOCALAPPDATA%\ape\`, adds it to PATH, and deploys APE agents/skills to all supported AI coding tools.
+### Install (Linux)
 
-To update to the latest version:
-
-```powershell
-ape upgrade
+```bash
+curl -fsSL https://www.ccisne.dev/finite_ape_machine/install.sh | bash
 ```
 
-## The APE Cycle
+The installer downloads the latest release, places `ape` on `PATH`, and verifies prerequisites.
 
-Every task follows four phases:
+### Initialize a repository
 
-**Analyze** → Understand requirements, classify risk, read project memory
-**Plan** → Generate a phased runbook with entry criteria and verification conditions
-**Execute** → Specialized apes collaborate via TDD (RED → GREEN), interleaved with review, documentation, and human gates
-**Learn** → DARWIN extracts lessons, updates memory, improves future runs
+```bash
+ape doctor               # verify ape, git, gh, gh auth
+ape target get           # deploy APE agent + skills to ~/.copilot
+cd your-repo
+ape init                 # create .ape/{state,config,mutations}
+ape                      # show TUI banner with current FSM state
+```
+
+## Available commands
+
+| Command | Purpose |
+|---|---|
+| `ape` | TUI banner with current FSM state and diagram |
+| `ape init` | Idempotent scaffolding of `.ape/` (state.yaml, config.yaml, mutations.md) |
+| `ape doctor` | Verify prerequisites: `ape`, `git`, `gh`, `gh auth` |
+| `ape version` | Print CLI version |
+| `ape upgrade` | Download and install latest release |
+| `ape uninstall` | Remove `ape` binary and deployed assets |
+| `ape target get` | Deploy APE agent and skills to active AI tool (Copilot) |
+| `ape target clean` | Remove deployed APE files from all known targets |
+| `ape state transition --event <e>` | Execute a deterministic FSM transition with prechecks/effects |
+
+## The APE cycle
+
+```
+IDLE ──start_analyze──▶ ANALYZE ──complete_analysis──▶ PLAN
+                          │                              │
+                          │                       approve_plan
+                          │                              ▼
+                          └────── start_analyze ──── EXECUTE
+                                                        │
+                                                  finish_execute
+                                                        ▼
+                          IDLE ◀── finish_end ──── END (PR gate)
+                            ▲                          │
+                            │                    finish_end
+                            │                          ▼
+                            └─── finish_evolution ── EVOLUTION
+                                  (when enabled)
+```
+
+| State | Agent | Function | Output |
+|---|---|---|---|
+| **ANALYZE** | SOCRATES | Mayéutica — clarify requirements via dialog | `diagnosis.md` |
+| **PLAN** | DESCARTES | Method — divide, order, verify, enumerate | `plan.md` |
+| **EXECUTE** | BASHŌ | Techne — minimal, beautiful implementation under tests | code + commits |
+| **END** | — | PR gate — `gh pr create` + `gh pr merge` | merged PR |
+| **EVOLUTION** | DARWIN | Natural selection — propose APE mutations | issues in this repo |
+
+EVOLUTION is opt-in (`evolution.enabled` in `.ape/config.yaml`) and one-shot: if interrupted, the cycle simply returns to IDLE.
+
+## Architecture
+
+- **CLI:** Dart, compiled to a single cross-platform binary, built on top of [`modular_cli_sdk`](https://github.com/ccisnedev/modular_cli_sdk)
+- **Modules:** `global` (init, doctor, version, upgrade, uninstall, tui), `target` (get, clean), `state` (transition)
+- **FSM:** declarative `transition_contract.yaml` parsed into `FsmContract` — every (state, event) pair is total (allowed or explicitly illegal)
+- **Targets:** Copilot only in v0.0.x per [ADR D20](docs/spec/target-specific-agents.md). Adapters for Claude/Codex/Crush/Gemini exist for cleanup but are deferred until MVP
+- **Memory:** `.ape/` (per-cycle runtime), `docs/issues/NNN-slug/` (per-cycle artifacts), `docs/spec/` (canonical specs)
+
+## Documentation
+
+- **[`docs/spec/`](docs/spec/index.md)** — canonical specifications (FSM, CLI, Memory as Code, orchestrator, target-specific agents)
+- **[`docs/research/ape_builds_ape/`](docs/research/ape_builds_ape/index.md)** — research papers and methodology (APE building APE — empirical bootstrap)
+- **[`docs/adr/`](docs/adr/)** — Architecture Decision Records
+- **[`docs/issues/`](docs/issues/)** — per-cycle work artifacts (analysis, plan, metrics)
+- **[`docs/lore.md`](docs/lore.md)** — the apes' nomenclature and historical vision
+- **[`roadmap.md`](roadmap.md)** — where APE is going next
 
 ## Philosophy
 
-APE is designed to be **antifragile** across AI market scenarios. Cloud models get expensive? APE works with local models. LLMs plateau? DARWIN is the only improvement mechanism left. Models get better? APE amplifies the gains. The framework benefits from disorder.
+APE is designed to be **antifragile** across AI market scenarios. If cloud models get expensive, APE runs on local models. If frontier models plateau, DARWIN is the only improvement mechanism left. If models keep improving, APE amplifies the gains. The methodology benefits from disorder.
 
-The collaboration model — **AAD/AAE/AAM** (Agent-Aided Design/Engineering/Manufacturing) — draws from CAD/CAE/CAM: humans design with AI assistance, co-engineer with AI execution, and delegate mechanical tasks to full automation. The risk matrix calibrates where on this spectrum each action falls.
-
-## Tech Stack
-
-- **CLI:** Dart (compiled, cross-platform, single binary)
-- **Memory:** Markdown + YAML frontmatter in `.ape/`
-- **Tasks:** GitHub Issues via `gh` CLI
-- **Orchestrator targets:** Copilot → Claude Code → OpenCode
+The collaboration model — **AAD/AAE/AAM** (Agent-Aided Design/Engineering/Manufacturing) — draws from CAD/CAE/CAM: humans design with AI assistance, co-engineer with AI execution, and delegate mechanical work to automation. The risk matrix calibrates where each action falls on that spectrum.
 
 ## License
 
 MIT
-
-## Acknowledgments
-
-Inspired by [gentle-ai](https://github.com/user/gentle-ai).

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,115 @@
+# Roadmap
+
+> Where APE is going next. For where APE is today, see [README.md](README.md).
+
+This roadmap is **descriptive, not prescriptive**: it reflects the open issues currently in the backlog and the long-running theses that motivate the project. Anything not backed by an issue is exploratory.
+
+## Vision
+
+APE aims to be a **methodology that survives any AI market scenario**. Three theses guide every decision:
+
+1. **Methodology > model.** A small local model following a structured runbook should outperform a frontier model freestyling. If true, APE generalizes.
+2. **Memory as code.** Project knowledge belongs in the repo, version-controlled, queryable by any agent — not in a cloud-hosted vector DB.
+3. **Antifragility.** Each cycle should leave APE measurably better. DARWIN turns operational friction into improvements to the framework itself.
+
+The end-state is an **APE that builds APE**: a self-improving framework where every cycle generates evidence (in `metrics.yaml`, in evolution issues, in mutations.md) that feeds the next cycle.
+
+## Where we are (v0.0.14)
+
+- 5-state FSM with declarative transition contract (IDLE / ANALYZE / PLAN / EXECUTE / EVOLUTION)
+- 9 working CLI commands across 3 modules (`global`, `target`, `state`)
+- Single-target deployment (Copilot) per [ADR D20](docs/spec/target-specific-agents.md)
+- 4 active agents: SOCRATES, DESCARTES, BASHŌ, DARWIN
+- 131 tests, cross-platform (Windows + Linux), 12 GitHub releases
+- Empirical bootstrap underway: APE is being built using APE (see [bootstrap-validation](docs/research/ape_builds_ape/bootstrap-validation.md))
+
+## Near-term (v0.0.x → v0.1.0)
+
+Open issues actively being worked or queued. Grouped by theme.
+
+### FSM completeness
+- **#62** — Add `END` state to transition contract (PR gate between EXECUTE and EVOLUTION)
+- **#63** — Backward transitions: `PLAN → ANALYZE`, `EXECUTE → ANALYZE`; mark `EVOLUTION + block` illegal
+
+### Cycle memory infrastructure
+- **#47** — `evolution_notes.md` lifecycle in `.ape/`
+- **#48** — `.ape/` as cycle memory accessible to subagents
+- **#49** — Single-task-per-cycle rule (one issue → one cycle, no scope drift)
+- **#57** — EVOLUTION fully internal (no human intervention required during DARWIN's pass)
+
+### Subagent delegation
+- **#46** — Delegate research to subagent during ANALYZE (reduces SOCRATES context window pressure)
+
+### Cross-cycle features
+- **#60** — Cross-repo dependency chains (when an APE cycle modifies an upstream dependency)
+- **#50** — Dual language config (es/en outputs depending on user preference)
+
+### Research data collection
+- **#72** — `metrics.yaml` per cycle (foundation for the empirical paper; reproducibility currently scored 2/10)
+
+## Mid-term (v0.1.x → v0.5.0)
+
+Larger features that require infrastructure from the near-term to land first. Not yet split into discrete issues.
+
+### `ape memory` CLI
+First-class commands for the Memory-as-Code spec:
+- `ape memory query` — index-aware lookup over `docs/`
+- `ape memory validate` — schema enforcement (this is where **BORGES** materializes as a skill, not a separate agent)
+- `ape memory write` — guided creation of new memory artifacts
+
+### `ape task` CLI
+Replace the manual `gh issue create / gh pr create / gh pr merge` dance with a single command per FSM transition. Currently the agent calls `gh` directly; `ape task` would wrap that with prechecks (issue exists, branch matches issue number, no scope drift per #49).
+
+### Multi-target reactivation
+The deferred half of [ADR D20](docs/spec/target-specific-agents.md). Adapters already exist for Claude Code, Crush, Codex, and Gemini — they just aren't wired into `ape target get`. Reactivation requires:
+1. Stable agent prompt API (so the same APE methodology runs identically across hosts)
+2. A test matrix that runs the same APE cycle against multiple targets
+3. The metrics system from #72 to compare targets quantitatively
+
+### Antifragility validation harness
+A test rig that runs N identical APE cycles against M targets (Copilot, Crush, local Gemma) and aggregates `metrics.yaml` to validate or refute the **methodology > model** thesis.
+
+## Long-term (v1.0+)
+
+Theses that take the project beyond a CLI tool.
+
+### Local-first APE
+A reference deployment running entirely on local models (Gemma, Qwen, etc.) with no cloud dependency. This is the hardest test of thesis #1: if APE makes a 7B local model competitive with a frontier cloud model on real cycles, the framework's value is proven.
+
+### Bootstrap-validation paper
+Publish the empirical paper on APE-builds-APE. Requires the full metrics dataset from #72 and at least 30 cycles of clean data. Plan: [docs/research/ape_builds_ape/bootstrap-validation.md](docs/research/ape_builds_ape/bootstrap-validation.md).
+
+### DARWIN community-level learning
+Currently DARWIN proposes mutations only to *this* repo's APE. The long-term vision is a community-level DARWIN that aggregates evolution issues across many APE-using projects to propose changes upstream to the framework itself.
+
+### Risk-matrix-driven UX
+The semantic risk matrix exists in spec but not yet in CLI behavior. End-state: `ape state transition` automatically gates on human approval only when the risk class warrants it, and silently proceeds otherwise.
+
+## Lore vs reality
+
+The original [docs/lore.md](docs/lore.md) sketched 9+ apes. After two months of building APE with APE, the roster collapsed to 4 active agents. This is honest accounting, not a roadmap commitment to revive deferred ones — most were absorbed by simpler agents that turned out to do the job better.
+
+| Lore agent | Status | What happened |
+|---|---|---|
+| **SOCRATES** | ✅ Active | ANALYZE — implemented as the mayéutica agent |
+| **DESCARTES** | ✅ Active | PLAN — replaces SUNZI's strategy + VITRUVIUS's WBS in one Cartesian Method |
+| **BASHŌ** | ✅ Active | EXECUTE — replaces ADA's TDD with techne (functional beauty under constraints) |
+| **DARWIN** | ✅ Active | EVOLUTION — implemented; produces concrete evidence (e.g. issue #54) |
+| **MARCOPOLO** | Absorbed | Document ingestion handled by SOCRATES + the `memory-read` skill |
+| **VITRUVIUS** | Absorbed | WBS / decomposition is part of DESCARTES's plan phase |
+| **SUNZI** | Replaced | DESCARTES's Method is more explicit and testable than strategic prose |
+| **GATSBY** | Absorbed | Test pseudocode lives in `plan.md` written by DESCARTES |
+| **ADA** | Replaced | BASHŌ's techne replaces explicit TDD as a separate phase |
+| **DIJKSTRA** | Future skill | Quality-gate becomes a `pre-pr-review` skill inside END, not a separate agent |
+| **BORGES** | Future skill | Schema validation becomes `ape memory validate`, not a standalone ape |
+| **HERMES** | Materialized | State transitions are now `ape state transition` (CLI command, not an agent) |
+
+The lesson: **the framework wants fewer, sharper agents, not more**. Each absorption was driven by a real cycle where two agents were doing what one could do better.
+
+## How this roadmap is updated
+
+- **Near-term** items are GitHub issues in the backlog. They appear and disappear as DARWIN proposes and the maintainer accepts/rejects.
+- **Mid-term** items become near-term once split into concrete issues with acceptance criteria.
+- **Long-term** items are theses, not commitments. They move forward only when evidence justifies the investment.
+
+If you want the absolute current state, run `gh issue list --state open` and `gh release list`.


### PR DESCRIPTION
Closes #73

## Summary

README.md was claiming "Phase: Analyze, implementation has not started" while v0.0.14 is released with 131 tests, 12 GitHub releases, and 9 working CLI commands. This PR rewrites README.md to reflect the actual state and extracts forward-looking content into a new roadmap.md.

## Changes

### README.md (rewrite)
- Status line: v0.0.14, 131 tests, 12 releases, Windows + Linux
- Quick start: install (Windows + Linux) → doctor → target get → init → tui
- Available commands table: 9 commands across global/target/state modules
- FSM diagram includes END state (PR gate) and EVOLUTION as opt-in
- Agent table: 4 active apes with namesake → function → output
- Architecture: Dart + modular_cli_sdk + declarative transition_contract.yaml
- Doc paths corrected: docs/spec/, docs/research/, docs/adr/, docs/issues/
- Removed obsolete "what's next" checklist (now in roadmap.md)

### roadmap.md (new)
- Vision: 3 theses (methodology > model, memory as code, antifragility)
- Where we are now (v0.0.14 capabilities)
- Near-term: open issues #46-50, #57, #60, #62-63, #72 grouped by theme
- Mid-term: ape memory CLI (BORGES becomes a skill), ape task CLI, multi-target reactivation, antifragility validation harness
- Long-term: local-first APE, bootstrap-validation paper, community-level DARWIN, risk-matrix UX
- Lore vs reality: honest table of which apes materialized, were absorbed, or became skills

## Stats
- 2 files changed, 195 insertions, 58 deletions
- Documentation only, no code changes

## Acceptance criteria
- [x] README.md reflects v0.0.14 state accurately
- [x] README.md lists all 9 currently-implemented commands
- [x] README.md FSM diagram includes END state
- [x] README.md only references active agents (SOCRATES, DESCARTES, BASHŌ, DARWIN)
- [x] README.md uses correct paths (docs/spec/, docs/research/)
- [x] roadmap.md exists with vision + near/mid/long-term sections
- [x] roadmap.md classifies open GitHub issues into roadmap phases
- [x] roadmap.md includes honest lore-vs-reality table