### PR TITLE
docs(#75): add Related work section crediting gentle-ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,7 @@ The collaboration model — **AAD/AAE/AAM** (Agent-Aided Design/Engineering/Manu
 ## License
 
 MIT
+
+## Related work
+
+The idea of a CLI that **installs prompts and skills** into whatever AI coding agent you use — instead of keeping custom agents and skills scattered across each tool's config — comes from [gentle-ai](https://github.com/Gentleman-Programming/gentle-ai) (Gentleman Programming). APE takes that packaging idea in a different direction: a single-target deterministic FSM contract enforced by the CLI, with the methodology itself as the durable artifact.


### PR DESCRIPTION
Closes #75

## Summary

Adds a "Related work" section at the end of README.md crediting gentle-ai (Gentleman Programming) for the technical pattern that inspired `ape target get`: a CLI that installs prompts and skills into AI coding agents.

## Why

Honest, specific attribution. The previous "Inspired by gentle-ai" line was removed during the README rewrite (#74) because it was vague and acknowledgment-style. This replacement is precise: it names the exact idea taken (CLI as installer for prompts/skills) and positions APE's distinct angle (FSM contract vs ecosystem configurator), so a reader who knows gentle-ai understands the relationship at a glance and a reader who doesn't discovers a relevant project.

## Changes

- `README.md`: append `## Related work` section after `## License` (4 lines added)

## Acceptance criteria

- [x] README.md has a "## Related work" section at the end
- [x] Section links to https://github.com/Gentleman-Programming/gentle-ai
- [x] Section names Gentleman Programming as author
- [x] Section specifies the inspiration: "CLI that installs prompts and skills"
- [x] Section differentiates APE: "FSM contract" vs "ecosystem configurator"