### PR TITLE
#77: docs: rewrite architecture.md + move roadmap to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,13 @@ EVOLUTION is opt-in (`evolution.enabled` in `.ape/config.yaml`) and one-shot: if
 
 ## Documentation
 
+- **[`docs/architecture.md`](docs/architecture.md)** — how the CLI is built (repo layout, modules, data flows, dependencies)
+- **[`docs/roadmap.md`](docs/roadmap.md)** — where APE is going next (near/mid/long-term, lore vs reality)
 - **[`docs/spec/`](docs/spec/index.md)** — canonical specifications (FSM, CLI, Memory as Code, orchestrator, target-specific agents)
 - **[`docs/research/ape_builds_ape/`](docs/research/ape_builds_ape/index.md)** — research papers and methodology (APE building APE — empirical bootstrap)
 - **[`docs/adr/`](docs/adr/)** — Architecture Decision Records
 - **[`docs/issues/`](docs/issues/)** — per-cycle work artifacts (analysis, plan, metrics)
 - **[`docs/lore.md`](docs/lore.md)** — the apes' nomenclature and historical vision
-- **[`roadmap.md`](roadmap.md)** — where APE is going next
 
 ## Philosophy
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,190 @@
+# Architecture
+
+> How APE orchestrates AI coding agents through a finite state machine.
+
+## The system in one diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Human (developer)                                                  │
+│    ↕ authorizes transitions, writes mutations.md, reviews PRs       │
+└──────────────────────────────────┬──────────────────────────────────┘
+                                   │
+┌──────────────────────────────────▼──────────────────────────────────┐
+│  ape CLI                                                            │
+│                                                                     │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │  FSM Engine (transition_contract.yaml)                        │  │
+│  │                                                               │  │
+│  │  (state, event) → allowed? → prechecks → effects → new state  │  │
+│  │                                                               │  │
+│  │  Total matrix: every (state × event) pair is explicit         │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+│                                                                     │
+│  ┌──────────────┐    ┌──────────────────────────────────────────┐   │
+│  │ .ape/        │    │ Target Deployer                          │   │
+│  │  state.yaml  │    │                                          │   │
+│  │  config.yaml │    │  ape target get → copies to ~/.copilot/  │   │
+│  │  mutations.md│    │    agents/ape.agent.md                   │   │
+│  └──────────────┘    │    skills/{issue-start,issue-end,...}    │   │
+│                      └──────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+                                   │
+                          deploys agent + skills
+                                   │
+┌──────────────────────────────────▼──────────────────────────────────┐
+│  AI Coding Tool (Copilot, future: Claude/Crush/Gemini/Codex)        │
+│                                                                     │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │  ape.agent.md (orchestrator)                                  │  │
+│  │                                                               │  │
+│  │  Reads .ape/state.yaml → knows current FSM state              │  │
+│  │  Activates the agent for that state:                          │  │
+│  │                                                               │  │
+│  │    ANALYZE  → SOCRATES  (mayéutica, produces diagnosis.md)    │  │
+│  │    PLAN     → DESCARTES (method, produces plan.md)            │  │
+│  │    EXECUTE  → BASHŌ     (techne, produces code + commits)     │  │
+│  │    END      → (PR gate: gh pr create + gh pr merge)           │  │
+│  │    EVOLUTION→ DARWIN    (mutations, produces issues)          │  │
+│  │                                                               │  │
+│  │  Invokes skills as needed:                                    │  │
+│  │    issue-start  → IDLE → ANALYZE protocol                     │  │
+│  │    issue-end    → EXECUTE → END → IDLE protocol               │  │
+│  │    memory-read  → structured doc retrieval                    │  │
+│  │    memory-write → structured doc creation                     │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+│                                                                     │
+│  The agent has NO knowledge of other states' agents.                │
+│  It only sees: current state + transition contract + memory.        │
+└─────────────────────────────────────────────────────────────────────┘
+                                   │
+                          reads/writes
+                                   │
+┌──────────────────────────────────▼──────────────────────────────────┐
+│  Repository (Memory as Code)                                        │
+│                                                                     │
+│  .ape/state.yaml        ← current FSM state (IDLE, ANALYZE, etc.)   │
+│  .ape/config.yaml       ← cycle config (evolution.enabled, etc.)    │
+│  .ape/mutations.md      ← human notes for DARWIN                    │
+│  docs/issues/NNN-slug/  ← per-cycle artifacts (plan.md, metrics)    │
+│  docs/spec/             ← canonical specifications                  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## FSM: the transition contract
+
+The core of APE is a **declarative, total** finite state machine. "Total" means every `(state, event)` pair has an explicit entry — no implicit behavior.
+
+```yaml
+# transition_contract.yaml (excerpt)
+- from: IDLE
+  event: start_analyze
+  to: ANALYZE
+  allowed: true
+  operations:
+    prechecks: []
+    effects: [open_analysis_context, reset_mutations]
+    artifacts: [analysis/index.md]
+    commit_policy: none
+    prompt_fragment_id: idle_to_analyze
+
+- from: IDLE
+  event: approve_plan
+  to: ILLEGAL
+  allowed: false
+  reason: "IDLE cannot approve plan directly"
+```
+
+Each allowed transition carries:
+
+| Field | Purpose |
+|---|---|
+| `prechecks` | Conditions that must be true before transition fires |
+| `effects` | Side effects to execute (reset_mutations, open_analysis_context) |
+| `artifacts` | Files that this transition should produce |
+| `commit_policy` | When to commit (none, after_effects, after_artifacts) |
+| `prompt_fragment_id` | Links to agent prompt section for this transition |
+
+The CLI enforces this via `ape state transition --event <e>`: reads `.ape/state.yaml`, looks up `(current_state, event)` in the contract, validates prechecks, applies effects, writes new state.
+
+## Agent architecture
+
+There is **one agent file** (`ape.agent.md`) that acts as orchestrator. It is NOT 4 separate agents — it is one prompt that **behaves differently depending on FSM state**:
+
+```
+ape.agent.md
+├── Reads .ape/state.yaml → determines active phase
+├── IDLE: waits for user to invoke issue-start skill
+├── ANALYZE: becomes SOCRATES (asks questions, writes diagnosis.md)
+├── PLAN: becomes DESCARTES (decomposes, writes plan.md with phases)
+├── EXECUTE: becomes BASHŌ (implements, tests, commits)
+├── END: executes PR creation protocol
+└── EVOLUTION: becomes DARWIN (reads mutations.md, proposes issues)
+```
+
+The agent **never decides** state transitions on its own. Transitions are authorized by:
+1. The human (explicitly)
+2. A skill protocol (issue-start, issue-end)
+3. The CLI contract (prechecks must pass)
+
+## Skills as protocols
+
+Skills are **step-by-step protocols** invoked by the agent at specific moments:
+
+| Skill | When | Does |
+|---|---|---|
+| `issue-start` | Human says "start working on issue #N" | Creates branch, reads issue, transitions IDLE → ANALYZE |
+| `issue-end` | All plan checkboxes complete | Pushes, creates PR, merges, transitions → END → IDLE |
+| `memory-read` | Agent needs project context | Index scan → filter → partial read → full read |
+| `memory-write` | Agent produces documentation | YAML frontmatter, one topic per doc, index maintenance |
+
+Skills are **shared across targets** (same SKILL.md for Copilot, Claude, etc.). The agent file is **target-specific** (prompt format differs per tool).
+
+## Deployment model
+
+```
+ape target get
+    │
+    ├── Reads bundled assets/ from alongside the ape binary
+    ├── Cleans ~/.copilot/{agents,skills}/  (idempotent reset)
+    ├── Copies ape.agent.md → ~/.copilot/agents/
+    └── Copies skills/ → ~/.copilot/skills/
+         ├── issue-start/SKILL.md
+         ├── issue-end/SKILL.md
+         ├── memory-read/SKILL.md
+         └── memory-write/SKILL.md
+```
+
+Only **Copilot** is active in v0.0.x ([ADR D20](spec/target-specific-agents.md)). Adapters for Claude, Codex, Crush, and Gemini exist but are deferred — they only participate in `ape target clean` (removes orphaned files from previous multi-target deploys).
+
+## Cycle lifecycle
+
+A complete APE cycle from issue to merge:
+
+```
+1. Human creates GitHub issue with requirements
+2. Human invokes issue-start skill
+3. CLI: IDLE → ANALYZE (start_analyze event)
+4. Agent (SOCRATES): asks clarifying questions, produces diagnosis.md
+5. Human authorizes: ANALYZE → PLAN (complete_analysis)
+6. Agent (DESCARTES): writes plan.md with phased checkboxes
+7. Human authorizes: PLAN → EXECUTE (approve_plan)
+8. Agent (BASHŌ): implements phase by phase, commits, marks checkboxes
+9. Human invokes issue-end skill when plan complete
+10. CLI: EXECUTE → END (finish_execute) → git push + gh pr create
+11. PR merged → END → EVOLUTION or END → IDLE (per config)
+12. If EVOLUTION: DARWIN reads mutations.md, proposes improvement issues
+13. CLI: EVOLUTION → IDLE (finish_evolution), resets mutations.md
+```
+
+## Key design decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| **One agent, many behaviors** | Single ape.agent.md, state-driven | Simpler deployment, no inter-agent coordination needed |
+| **Total FSM** | Every (state,event) explicit | No undefined behavior, contract is auditable |
+| **CLI enforces, agent proposes** | Transitions go through CLI | Agent can't corrupt state; human is gate |
+| **Skills are protocols** | Step-by-step markdown, not code | Portable across any LLM that reads markdown |
+| **Memory in repo** | .ape/ + docs/, no external DB | Version-controlled, survives any infrastructure change |
+| **Single target until MVP** | Copilot only (D20) | Prove methodology on one tool before fragmenting |
+| **EVOLUTION is opt-in** | config.yaml flag | Self-modification is powerful but must be conscious |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> Where APE is going next. For where APE is today, see [README.md](README.md).
+> Where APE is going next. For where APE is today, see [README.md](../README.md).
 
 This roadmap is **descriptive, not prescriptive**: it reflects the open issues currently in the backlog and the long-running theses that motivate the project. Anything not backed by an issue is exploratory.
 


### PR DESCRIPTION
Closes #77

## Summary

Three documentation changes:

### 1. `docs/architecture.md` — rewritten
Old version was a folder-tree listing. New version documents the actual FSM/agent/skill architecture: states, transition contract, agent roster, skill system, memory-as-code, and CLI layer.

### 2. `docs/roadmap.md` — moved from root
Moved `roadmap.md` from project root to `docs/roadmap.md` for consistency with all other documentation.

### 3. `README.md` — links updated
Documentation section links now point to `docs/architecture.md` and `docs/roadmap.md`.

## Stats
- 3 files changed, 193 insertions, 2 deletions
- Documentation only, no code changes

## Checklist
- [x] docs/architecture.md reflects FSM/agent architecture
- [x] docs/roadmap.md exists (moved from root)
- [x] Root roadmap.md deleted (git detects as rename)
- [x] README.md links updated