### PR TITLE
086: ape-vscode v0.0.2 — APE Init + command guards

### DIFF
--- a/code/site/icons.html
+++ b/code/site/icons.html
@@ -1,0 +1,544 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Icons · APE — brand + sidebar system</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700;800&display=swap" rel="stylesheet">
+
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --bg: #0a0e1a;
+      --bg-elevated: #141b2e;
+      --fg: #e8ecf7;
+      --fg-dim: #a8b0c4;
+      --muted: #6a7188;
+      --primary: #ef4444;
+      --accent: #00d4b4;
+      --border: #232b45;
+      --border-strong: #4a5678;
+      --mono: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
+      --sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    }
+
+    body {
+      font-family: var(--sans);
+      background: var(--bg);
+      color: var(--fg);
+      line-height: 1.6;
+      padding: 3rem 1.5rem;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+
+    header { text-align: center; margin-bottom: 3rem; }
+    header h1 { font-size: 1.75rem; font-weight: 700; margin-bottom: 0.5rem; letter-spacing: -0.02em; }
+    header p { color: var(--fg-dim); max-width: 66ch; margin: 0 auto; }
+
+    .nav {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+      flex-wrap: wrap;
+      margin-top: 1.5rem;
+      font-family: var(--mono);
+      font-size: 0.78rem;
+    }
+    .nav a {
+      color: var(--fg-dim);
+      text-decoration: none;
+      padding: 0.4rem 0.75rem;
+      border: 1px solid var(--border-strong);
+      border-radius: 4px;
+    }
+    .nav a:hover { color: var(--fg); border-color: var(--primary); }
+
+    .direction {
+      margin-top: 3rem;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 1.75rem;
+    }
+
+    .direction header {
+      text-align: left;
+      margin-bottom: 1.5rem;
+      display: flex;
+      align-items: baseline;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .tag {
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      color: var(--primary);
+      padding: 0.1rem 0.55rem;
+      border: 1px solid var(--primary);
+      border-radius: 3px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .direction h2 {
+      font-size: 1.3rem;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+    }
+
+    .direction .desc {
+      color: var(--fg-dim);
+      font-size: 0.92rem;
+      flex-basis: 100%;
+      margin-top: 0.25rem;
+      max-width: 78ch;
+    }
+
+    .row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.25rem;
+      margin-bottom: 1rem;
+    }
+
+    .panel {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.5rem;
+    }
+
+    .panel h3 {
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      margin-bottom: 0.85rem;
+    }
+
+    .panel-note {
+      font-size: 0.8rem;
+      color: var(--fg-dim);
+      margin-top: 0.75rem;
+      font-style: italic;
+    }
+
+    .brand-row {
+      display: flex;
+      gap: 1.25rem;
+      flex-wrap: wrap;
+      align-items: flex-start;
+    }
+
+    .brand-sample {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      align-items: center;
+    }
+
+    .brand-sample .label {
+      font-family: var(--mono);
+      font-size: 0.68rem;
+      color: var(--muted);
+    }
+
+    .sizes {
+      display: flex;
+      gap: 1rem;
+      align-items: flex-end;
+      flex-wrap: wrap;
+    }
+
+    .size {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .size .label {
+      font-family: var(--mono);
+      font-size: 0.65rem;
+      color: var(--muted);
+    }
+
+    /* Mock VSCode sidebar container */
+    .vscode-mock {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 50px;
+      height: 40px;
+      background: #181818;
+      border-radius: 4px;
+      color: #cccccc;
+    }
+    .vscode-mock.active {
+      background: #1f1f1f;
+      color: #ffffff;
+      position: relative;
+    }
+    .vscode-mock.active::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      background: #ef4444;
+    }
+
+    .light-swatch {
+      background: #e8ecf7;
+      color: #0a0e1a;
+      padding: 1rem;
+      border-radius: 8px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 1rem;
+    }
+
+    .row-wide {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1.5rem;
+      align-items: center;
+    }
+
+    @media (max-width: 700px) {
+      .row { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Icons · APE system</h1>
+    <p>
+      Three directions that keep the three letters <strong>APE</strong> legible across every context. Each direction has a <em>brand icon</em> (colored, detailed, for marketplace / favicon / OG / merch) and a <em>sidebar glyph</em> (monochrome line, <code>currentColor</code>, for VSCode activity bar and other small monochrome slots).
+    </p>
+    <nav class="nav">
+      <a href="#h">1 · Horizontal APE</a>
+      <a href="#s">2 · Stacked APE</a>
+      <a href="#t">3 · Triangle APE</a>
+    </nav>
+  </header>
+
+  <!-- ============================================ DIRECTION 1 ============================================ -->
+  <section class="direction" id="h">
+    <header>
+      <span class="tag">Direction 1</span>
+      <h2>Horizontal APE</h2>
+      <p class="desc">
+        Three letters on one line, JetBrains Mono bold, tight kerning. The most direct, most wordmark-like. Reads instantly as "APE" at any size. Brand version adds a subtle accent mark; sidebar version is pure letterforms.
+      </p>
+    </header>
+
+    <div class="row">
+      <!-- BRAND -->
+      <div class="panel">
+        <h3>Brand icon · colored · 128 and up</h3>
+        <div class="brand-row">
+          <div class="brand-sample">
+            <!-- 128x128 brand -->
+            <svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+              <rect width="128" height="128" rx="20" fill="#0a0e1a"/>
+              <rect x="0" y="0" width="128" height="128" rx="20" fill="url(#h-glow)"/>
+              <defs>
+                <radialGradient id="h-glow" cx="50%" cy="0%" r="70%">
+                  <stop offset="0%" stop-color="#ef4444" stop-opacity="0.18"/>
+                  <stop offset="70%" stop-color="#ef4444" stop-opacity="0"/>
+                </radialGradient>
+              </defs>
+              <text x="64" y="82" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="700" font-size="48" fill="#ef4444" letter-spacing="-1">APE</text>
+              <circle cx="64" cy="104" r="2.5" fill="#00d4b4"/>
+            </svg>
+            <span class="label">128 × 128</span>
+          </div>
+          <div class="brand-sample">
+            <svg width="64" height="64" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+              <rect width="128" height="128" rx="20" fill="#0a0e1a"/>
+              <text x="64" y="82" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="700" font-size="48" fill="#ef4444" letter-spacing="-1">APE</text>
+              <circle cx="64" cy="104" r="2.5" fill="#00d4b4"/>
+            </svg>
+            <span class="label">64 × 64</span>
+          </div>
+          <div class="brand-sample">
+            <svg width="32" height="32" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+              <rect width="128" height="128" rx="20" fill="#0a0e1a"/>
+              <text x="64" y="82" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="700" font-size="48" fill="#ef4444" letter-spacing="-1">APE</text>
+            </svg>
+            <span class="label">32 · favicon</span>
+          </div>
+        </div>
+        <p class="panel-note">Rounded-square brand tile. Red "APE" centered, small cyan dot as accent/anchor. Navy base matches site palette.</p>
+      </div>
+
+      <!-- SIDEBAR -->
+      <div class="panel">
+        <h3>Sidebar glyph · monochrome · 24 × 24</h3>
+        <div class="brand-row">
+          <div class="brand-sample">
+            <div class="vscode-mock active">
+              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <text x="12" y="16" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="700" font-size="10" fill="currentColor" letter-spacing="-0.5">APE</text>
+              </svg>
+            </div>
+            <span class="label">VSCode · active</span>
+          </div>
+          <div class="brand-sample">
+            <div class="vscode-mock">
+              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <text x="12" y="16" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="700" font-size="10" fill="currentColor" letter-spacing="-0.5">APE</text>
+              </svg>
+            </div>
+            <span class="label">VSCode · inactive</span>
+          </div>
+          <div class="brand-sample">
+            <svg width="48" height="48" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="color: #e8ecf7;">
+              <text x="12" y="16" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="700" font-size="10" fill="currentColor" letter-spacing="-0.5">APE</text>
+            </svg>
+            <span class="label">2× preview</span>
+          </div>
+          <div class="brand-sample">
+            <div class="light-swatch">
+              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="color: #0a0e1a;">
+                <text x="12" y="16" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="700" font-size="10" fill="currentColor" letter-spacing="-0.5">APE</text>
+              </svg>
+            </div>
+            <span class="label">on light</span>
+          </div>
+        </div>
+        <p class="panel-note">Single color via <code>currentColor</code> — VSCode tints it with the theme. Bold mono, tight kerning to fit 3 letters in 24 px.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================================ DIRECTION 2 ============================================ -->
+  <section class="direction" id="s">
+    <header>
+      <span class="tag">Direction 2</span>
+      <h2>Stacked APE</h2>
+      <p class="desc">
+        Letters stacked vertically — A over P over E. Vertical reading rarely used in dev-tool icons, which makes it memorable. At 24 px each letter gets ~7 px of height, readable in heavy mono weight. At larger sizes the stack has strong presence as a block shape.
+      </p>
+    </header>
+
+    <div class="row">
+      <!-- BRAND -->
+      <div class="panel">
+        <h3>Brand icon · colored · 128 and up</h3>
+        <div class="brand-row">
+          <div class="brand-sample">
+            <svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+              <rect width="128" height="128" rx="20" fill="#0a0e1a"/>
+              <defs>
+                <radialGradient id="s-glow" cx="50%" cy="0%" r="70%">
+                  <stop offset="0%" stop-color="#ef4444" stop-opacity="0.18"/>
+                  <stop offset="70%" stop-color="#ef4444" stop-opacity="0"/>
+                </radialGradient>
+              </defs>
+              <rect width="128" height="128" rx="20" fill="url(#s-glow)"/>
+              <text x="64" y="44" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="34" fill="#ef4444">A</text>
+              <text x="64" y="80" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="34" fill="#ef4444">P</text>
+              <text x="64" y="116" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="34" fill="#ef4444">E</text>
+              <!-- tiny connecting dots (cycle hint) -->
+              <circle cx="84" cy="55" r="1.2" fill="#00d4b4"/>
+              <circle cx="84" cy="91" r="1.2" fill="#00d4b4"/>
+            </svg>
+            <span class="label">128 × 128</span>
+          </div>
+          <div class="brand-sample">
+            <svg width="64" height="64" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+              <rect width="128" height="128" rx="20" fill="#0a0e1a"/>
+              <text x="64" y="44" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="34" fill="#ef4444">A</text>
+              <text x="64" y="80" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="34" fill="#ef4444">P</text>
+              <text x="64" y="116" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="34" fill="#ef4444">E</text>
+            </svg>
+            <span class="label">64 × 64</span>
+          </div>
+          <div class="brand-sample">
+            <svg width="32" height="32" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+              <rect width="128" height="128" rx="20" fill="#0a0e1a"/>
+              <text x="64" y="44" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="34" fill="#ef4444">A</text>
+              <text x="64" y="80" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="34" fill="#ef4444">P</text>
+              <text x="64" y="116" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="34" fill="#ef4444">E</text>
+            </svg>
+            <span class="label">32 · favicon</span>
+          </div>
+        </div>
+        <p class="panel-note">Three letters in heavy mono, stacked. Two tiny cyan dots to the right of A-P and P-E boundaries hint at transitions without spelling them out.</p>
+      </div>
+
+      <!-- SIDEBAR -->
+      <div class="panel">
+        <h3>Sidebar glyph · monochrome · 24 × 24</h3>
+        <div class="brand-row">
+          <div class="brand-sample">
+            <div class="vscode-mock active">
+              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <text x="12" y="8" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">A</text>
+                <text x="12" y="15" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">P</text>
+                <text x="12" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">E</text>
+              </svg>
+            </div>
+            <span class="label">VSCode · active</span>
+          </div>
+          <div class="brand-sample">
+            <div class="vscode-mock">
+              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <text x="12" y="8" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">A</text>
+                <text x="12" y="15" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">P</text>
+                <text x="12" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">E</text>
+              </svg>
+            </div>
+            <span class="label">VSCode · inactive</span>
+          </div>
+          <div class="brand-sample">
+            <svg width="48" height="48" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="color: #e8ecf7;">
+              <text x="12" y="8" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">A</text>
+              <text x="12" y="15" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">P</text>
+              <text x="12" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">E</text>
+            </svg>
+            <span class="label">2× preview</span>
+          </div>
+          <div class="brand-sample">
+            <div class="light-swatch">
+              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="color: #0a0e1a;">
+                <text x="12" y="8" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">A</text>
+                <text x="12" y="15" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">P</text>
+                <text x="12" y="22" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">E</text>
+              </svg>
+            </div>
+            <span class="label">on light</span>
+          </div>
+        </div>
+        <p class="panel-note">Stack reads vertically. Heaviest mono weight (800) makes each letter legible at the small size.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============================================ DIRECTION 3 ============================================ -->
+  <section class="direction" id="t">
+    <header>
+      <span class="tag">Direction 3</span>
+      <h2>Triangle APE</h2>
+      <p class="desc">
+        A at the top vertex, P at bottom-left, E at bottom-right — three letters forming a triangle. The geometric arrangement implies a three-state FSM cycle without drawing arrows. Most distinctive direction, connects typography to methodology. Most challenging at 24 px because space per letter is smallest.
+      </p>
+    </header>
+
+    <div class="row">
+      <!-- BRAND -->
+      <div class="panel">
+        <h3>Brand icon · colored · 128 and up</h3>
+        <div class="brand-row">
+          <div class="brand-sample">
+            <svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+              <rect width="128" height="128" rx="20" fill="#0a0e1a"/>
+              <defs>
+                <radialGradient id="t-glow" cx="50%" cy="20%" r="70%">
+                  <stop offset="0%" stop-color="#ef4444" stop-opacity="0.18"/>
+                  <stop offset="70%" stop-color="#ef4444" stop-opacity="0"/>
+                </radialGradient>
+              </defs>
+              <rect width="128" height="128" rx="20" fill="url(#t-glow)"/>
+              <!-- Cyan connecting arcs (cycle hint) -->
+              <path d="M 54 52 Q 40 70, 48 92" stroke="#00d4b4" stroke-width="1.2" fill="none" stroke-dasharray="2 3" opacity="0.6"/>
+              <path d="M 74 52 Q 88 70, 80 92" stroke="#00d4b4" stroke-width="1.2" fill="none" stroke-dasharray="2 3" opacity="0.6"/>
+              <path d="M 52 100 L 76 100" stroke="#00d4b4" stroke-width="1.2" fill="none" stroke-dasharray="2 3" opacity="0.6"/>
+              <!-- A top -->
+              <text x="64" y="58" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="30" fill="#ef4444">A</text>
+              <!-- P bottom-left -->
+              <text x="36" y="104" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="30" fill="#ef4444">P</text>
+              <!-- E bottom-right -->
+              <text x="92" y="104" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="30" fill="#ef4444">E</text>
+            </svg>
+            <span class="label">128 × 128</span>
+          </div>
+          <div class="brand-sample">
+            <svg width="64" height="64" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+              <rect width="128" height="128" rx="20" fill="#0a0e1a"/>
+              <path d="M 54 52 Q 40 70, 48 92" stroke="#00d4b4" stroke-width="1.2" fill="none" stroke-dasharray="2 3" opacity="0.6"/>
+              <path d="M 74 52 Q 88 70, 80 92" stroke="#00d4b4" stroke-width="1.2" fill="none" stroke-dasharray="2 3" opacity="0.6"/>
+              <path d="M 52 100 L 76 100" stroke="#00d4b4" stroke-width="1.2" fill="none" stroke-dasharray="2 3" opacity="0.6"/>
+              <text x="64" y="58" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="30" fill="#ef4444">A</text>
+              <text x="36" y="104" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="30" fill="#ef4444">P</text>
+              <text x="92" y="104" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="30" fill="#ef4444">E</text>
+            </svg>
+            <span class="label">64 × 64</span>
+          </div>
+          <div class="brand-sample">
+            <svg width="32" height="32" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+              <rect width="128" height="128" rx="20" fill="#0a0e1a"/>
+              <text x="64" y="58" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="30" fill="#ef4444">A</text>
+              <text x="36" y="104" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="30" fill="#ef4444">P</text>
+              <text x="92" y="104" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="30" fill="#ef4444">E</text>
+            </svg>
+            <span class="label">32 · favicon</span>
+          </div>
+        </div>
+        <p class="panel-note">Letters at triangle vertices. Dashed cyan arcs connect them clockwise — visible at large sizes as the cycle hint, invisible at favicon size (too small for the arcs).</p>
+      </div>
+
+      <!-- SIDEBAR -->
+      <div class="panel">
+        <h3>Sidebar glyph · monochrome · 24 × 24</h3>
+        <div class="brand-row">
+          <div class="brand-sample">
+            <div class="vscode-mock active">
+              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <text x="12" y="11" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">A</text>
+                <text x="6" y="21" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">P</text>
+                <text x="18" y="21" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">E</text>
+              </svg>
+            </div>
+            <span class="label">VSCode · active</span>
+          </div>
+          <div class="brand-sample">
+            <div class="vscode-mock">
+              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <text x="12" y="11" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">A</text>
+                <text x="6" y="21" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">P</text>
+                <text x="18" y="21" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">E</text>
+              </svg>
+            </div>
+            <span class="label">VSCode · inactive</span>
+          </div>
+          <div class="brand-sample">
+            <svg width="48" height="48" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="color: #e8ecf7;">
+              <text x="12" y="11" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">A</text>
+              <text x="6" y="21" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">P</text>
+              <text x="18" y="21" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">E</text>
+            </svg>
+            <span class="label">2× preview</span>
+          </div>
+          <div class="brand-sample">
+            <div class="light-swatch">
+              <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="color: #0a0e1a;">
+                <text x="12" y="11" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">A</text>
+                <text x="6" y="21" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">P</text>
+                <text x="18" y="21" text-anchor="middle" font-family="'JetBrains Mono', monospace" font-weight="800" font-size="7" fill="currentColor">E</text>
+              </svg>
+            </div>
+            <span class="label">on light</span>
+          </div>
+        </div>
+        <p class="panel-note">Three letters arranged in triangle. No arcs at 24 px — the spatial arrangement alone carries the FSM narrative. Unique silhouette in any VSCode sidebar lineup.</p>
+      </div>
+    </div>
+  </section>
+
+  <div style="margin-top: 3rem; padding: 1.25rem 1.5rem; border-left: 3px solid var(--primary); background: var(--bg-elevated); border-radius: 0 6px 6px 0; color: var(--fg-dim);">
+    <strong style="color: var(--fg);">When you decide.</strong> I take the chosen direction, export the brand SVG (for the web favicon data-URI or a real <code>favicon.png</code>) and the sidebar SVG (for the future VSCode extension). Both become canonical files in <code>img/</code>. The ape-letter in the current favicon gets retired.
+  </div>
+</body>
+</html>

--- a/code/vscode/CHANGELOG.md
+++ b/code/vscode/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.0.2] - 2026-04-19
+
+### Added
+- `APE: Init` command — detects, installs, and initializes APE CLI from VS Code
+- Guard clause on all commands — validates CLI + workspace before executing
+- Cross-platform install (Windows + Linux) with progress notification
+
+### Fixed
+- Commands no longer silently create `.ape/` without CLI validation
+
 ## [0.0.1] - 2026-04-19
 
 ### Added

--- a/code/vscode/README.md
+++ b/code/vscode/README.md
@@ -19,9 +19,11 @@ This extension brings APE's lifecycle into VS Code — no CLI execution needed. 
 
 | Feature | Description |
 |---------|-------------|
+|  **Init** | Detect, install, and initialize APE CLI — full bootstrap from VS Code |
 |  **Status Bar** | Live display of the current APE state with phase-specific icons |
 |  **Toggle Evolution** | Enable/disable the EVOLUTION phase via `.ape/config.yaml` |
 |  **Add Mutation Note** | Append observations to `.ape/mutations.md` from the Command Palette |
+|  **Guard Clause** | All commands validate CLI + workspace before executing |
 |  **Auto-activation** | Extension activates automatically when `.ape/` exists in the workspace |
 
 ---
@@ -29,9 +31,10 @@ This extension brings APE's lifecycle into VS Code — no CLI execution needed. 
 ##  Quick Start
 
 1. Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ccisnedev.ape-vscode)
-2. Open a workspace that contains a `.ape/` directory
-3. The status bar shows the current FSM state
-4. Use `Ctrl+Shift+P` → **APE: Toggle Evolution** or **APE: Add Mutation Note**
+2. `Ctrl+Shift+P` → **APE: Init**
+3. If the CLI is missing, the extension offers to install it (Windows + Linux)
+4. `ape init` runs in the integrated terminal, creating `.ape/`
+5. The status bar appears — you're ready to work
 
 ---
 
@@ -39,6 +42,7 @@ This extension brings APE's lifecycle into VS Code — no CLI execution needed. 
 
 | Command | Action |
 |---------|--------|
+| **APE: Init** | Detect CLI, install if missing, run `ape init` in workspace |
 | **APE: Toggle Evolution** | Flip `evolution.enabled` in `.ape/config.yaml` |
 | **APE: Add Mutation Note** | Prompt for text → append to `.ape/mutations.md` |
 
@@ -60,13 +64,13 @@ This extension brings APE's lifecycle into VS Code — no CLI execution needed. 
 ## Requirements
 
 - VS Code ≥ 1.85
-- A workspace with a `.ape/` directory (created by the [APE CLI](https://github.com/ccisne-dev/finite_ape_machine))
+- Windows or Linux (macOS not yet supported)
+- The [APE CLI](https://github.com/ccisne-dev/finite_ape_machine) — installed automatically via `APE: Init` if missing
 
 ---
 
 ##  Roadmap
 
-- CLI integration (`ape` command execution from VS Code)
 - Tree view for `.ape/` directory contents
 - state.yaml editing via UI
 - Multi-root workspace support

--- a/code/vscode/README.md
+++ b/code/vscode/README.md
@@ -7,7 +7,7 @@
 
 ---
 
-## ✨ Overview
+##  Overview
 
 APE (Autonomous Programming Engine) is a strict six-state FSM that structures AI-assisted development: **IDLE → ANALYZE → PLAN → EXECUTE → END → EVOLUTION**.
 
@@ -15,18 +15,18 @@ This extension brings APE's lifecycle into VS Code — no CLI execution needed. 
 
 ---
 
-## 🧩 Features
+##  Features
 
 | Feature | Description |
 |---------|-------------|
-| 📊 **Status Bar** | Live display of the current APE state with phase-specific icons |
-| 🔄 **Toggle Evolution** | Enable/disable the EVOLUTION phase via `.ape/config.yaml` |
-| 📝 **Add Mutation Note** | Append observations to `.ape/mutations.md` from the Command Palette |
-| ⚡ **Auto-activation** | Extension activates automatically when `.ape/` exists in the workspace |
+|  **Status Bar** | Live display of the current APE state with phase-specific icons |
+|  **Toggle Evolution** | Enable/disable the EVOLUTION phase via `.ape/config.yaml` |
+|  **Add Mutation Note** | Append observations to `.ape/mutations.md` from the Command Palette |
+|  **Auto-activation** | Extension activates automatically when `.ape/` exists in the workspace |
 
 ---
 
-## 🚀 Quick Start
+##  Quick Start
 
 1. Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ccisnedev.ape-vscode)
 2. Open a workspace that contains a `.ape/` directory
@@ -35,7 +35,7 @@ This extension brings APE's lifecycle into VS Code — no CLI execution needed. 
 
 ---
 
-## 💾 Commands
+##  Commands
 
 | Command | Action |
 |---------|--------|
@@ -44,7 +44,7 @@ This extension brings APE's lifecycle into VS Code — no CLI execution needed. 
 
 ---
 
-## 📊 Status Bar Icons
+##  Status Bar Icons
 
 | State | Icon |
 |-------|------|
@@ -64,7 +64,7 @@ This extension brings APE's lifecycle into VS Code — no CLI execution needed. 
 
 ---
 
-## 🔭 Roadmap
+##  Roadmap
 
 - CLI integration (`ape` command execution from VS Code)
 - Tree view for `.ape/` directory contents
@@ -73,13 +73,13 @@ This extension brings APE's lifecycle into VS Code — no CLI execution needed. 
 
 ---
 
-## 🧾 License
+##  License
 
 MIT © 2026 Cristian Cisneros
 
 ---
 
-## 🧩 Links
+##  Links
 
-- 🧠 APE CLI: [ccisne-dev/finite_ape_machine](https://github.com/ccisne-dev/finite_ape_machine)
-- 💬 Report issues: [GitHub Issues](https://github.com/ccisne-dev/finite_ape_machine/issues)
+-  APE CLI: [ccisne-dev/finite_ape_machine](https://github.com/ccisne-dev/finite_ape_machine)
+-  Report issues: [GitHub Issues](https://github.com/ccisne-dev/finite_ape_machine/issues)

--- a/code/vscode/package.json
+++ b/code/vscode/package.json
@@ -19,10 +19,12 @@
   },
   "main": "./out/extension.js",
   "activationEvents": [
-    "workspaceContains:.ape/"
+    "workspaceContains:.ape/",
+    "onCommand:ape.init"
   ],
   "contributes": {
     "commands": [
+      { "command": "ape.init", "title": "APE: Init" },
       { "command": "ape.toggleEvolution", "title": "APE: Toggle Evolution" },
       { "command": "ape.addMutation", "title": "APE: Add Mutation Note" }
     ]

--- a/code/vscode/package.json
+++ b/code/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "ape-vscode",
   "displayName": "APE",
   "publisher": "ccisnedev",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "APE — Autonomous Programming Engine for VS Code",
   "license": "MIT",
   "icon": "assets/icon.png",

--- a/code/vscode/src/command-guard.ts
+++ b/code/vscode/src/command-guard.ts
@@ -1,0 +1,49 @@
+import { isApeInstalled, isApeWorkspace } from './guard';
+
+export interface GuardOptions {
+  skipWorkspaceCheck?: boolean;
+}
+
+export interface GuardDeps {
+  isApeInstalled: () => boolean;
+  isApeWorkspace: (folder: string) => boolean;
+  showMessage: (msg: string, ...items: string[]) => Thenable<string | undefined>;
+  executeCommand: (cmd: string) => Thenable<unknown>;
+}
+
+export async function withGuard(
+  workspaceFolder: string,
+  options: GuardOptions,
+  fn: () => Promise<void>,
+  deps?: Partial<GuardDeps>,
+): Promise<void> {
+  const installed = deps?.isApeInstalled ?? (() => isApeInstalled());
+  const workspace = deps?.isApeWorkspace ?? ((f: string) => isApeWorkspace(f));
+
+  let showMessage = deps?.showMessage;
+  let executeCommand = deps?.executeCommand;
+  if (!showMessage || !executeCommand) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const vscode = require('vscode');
+    showMessage = showMessage ?? vscode.window.showInformationMessage.bind(vscode.window);
+    executeCommand = executeCommand ?? vscode.commands.executeCommand.bind(vscode.commands);
+  }
+
+  if (!installed()) {
+    const action = await showMessage!('APE CLI not found. Install it?', 'Install');
+    if (action === 'Install') {
+      await executeCommand!('ape.init');
+    }
+    return;
+  }
+
+  if (!options.skipWorkspaceCheck && !workspace(workspaceFolder)) {
+    const action = await showMessage!('No APE workspace detected. Run ape init?', 'Init');
+    if (action === 'Init') {
+      await executeCommand!('ape.init');
+    }
+    return;
+  }
+
+  await fn();
+}

--- a/code/vscode/src/commands.ts
+++ b/code/vscode/src/commands.ts
@@ -13,7 +13,6 @@ export async function toggleEvolution(apeFolderPath: string): Promise<void> {
   const config = parseConfig(content);
   config.evolutionEnabled = !config.evolutionEnabled;
   const newContent = serializeConfig(config);
-  fs.mkdirSync(path.dirname(configPath), { recursive: true });
   fs.writeFileSync(configPath, newContent, 'utf-8');
 
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -34,7 +33,6 @@ export async function addMutation(apeFolderPath: string): Promise<void> {
 
   const mutationsPath = path.join(apeFolderPath, 'mutations.md');
   const entry = formatMutation(text, true);
-  fs.mkdirSync(path.dirname(mutationsPath), { recursive: true });
   fs.appendFileSync(mutationsPath, entry, 'utf-8');
   vscode.window.showInformationMessage('APE: Mutation note added');
 }

--- a/code/vscode/src/extension.ts
+++ b/code/vscode/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { createStatusBar } from './status-bar';
 import { toggleEvolution, addMutation } from './commands';
+import { withGuard } from './command-guard';
 
 export function activate(context: vscode.ExtensionContext): void {
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
@@ -13,10 +14,10 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('ape.toggleEvolution', () =>
-      toggleEvolution(apeFolderPath),
+      withGuard(workspaceFolder, {}, () => toggleEvolution(apeFolderPath)),
     ),
     vscode.commands.registerCommand('ape.addMutation', () =>
-      addMutation(apeFolderPath),
+      withGuard(workspaceFolder, {}, () => addMutation(apeFolderPath)),
     ),
   );
 }

--- a/code/vscode/src/extension.ts
+++ b/code/vscode/src/extension.ts
@@ -4,12 +4,23 @@ import { createStatusBar } from './status-bar';
 import { toggleEvolution, addMutation } from './commands';
 import { withGuard } from './command-guard';
 import { apeInit } from './init';
+import { installApeCli } from './installer';
 
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('ape.init', () => {
       const folder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-      return apeInit(folder);
+      return apeInit(folder, undefined, async () => {
+        await installApeCli();
+        const { isApeInstalled, getApeBinaryPath, getPlatform } = require('./guard');
+        if (isApeInstalled()) {
+          const terminal = vscode.window.createTerminal('APE Init');
+          terminal.show();
+          terminal.sendText(`"${getApeBinaryPath(getPlatform())}" init`);
+        } else {
+          vscode.window.showErrorMessage('APE CLI installation failed. Please install manually.');
+        }
+      });
     }),
   );
 

--- a/code/vscode/src/extension.ts
+++ b/code/vscode/src/extension.ts
@@ -3,8 +3,16 @@ import * as path from 'path';
 import { createStatusBar } from './status-bar';
 import { toggleEvolution, addMutation } from './commands';
 import { withGuard } from './command-guard';
+import { apeInit } from './init';
 
 export function activate(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ape.init', () => {
+      const folder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      return apeInit(folder);
+    }),
+  );
+
   const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
   if (!workspaceFolder) { return; }
 

--- a/code/vscode/src/guard.ts
+++ b/code/vscode/src/guard.ts
@@ -1,0 +1,30 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function getPlatform(): string {
+  return process.platform;
+}
+
+export function getApeBinaryPath(platform: string): string {
+  if (platform === 'win32') {
+    return path.join(process.env.LOCALAPPDATA!, 'ape', 'bin', 'ape.exe');
+  }
+  if (platform === 'linux') {
+    return path.join(process.env.HOME!, '.ape', 'bin', 'ape');
+  }
+  throw new Error(`Unsupported platform: ${platform}`);
+}
+
+export function isApeInstalled(
+  platform?: string,
+  existsSync: (p: fs.PathLike) => boolean = fs.existsSync
+): boolean {
+  return existsSync(getApeBinaryPath(platform ?? getPlatform()));
+}
+
+export function isApeWorkspace(
+  workspaceFolder: string,
+  existsSync: (p: fs.PathLike) => boolean = fs.existsSync
+): boolean {
+  return existsSync(path.join(workspaceFolder, '.ape'));
+}

--- a/code/vscode/src/init.ts
+++ b/code/vscode/src/init.ts
@@ -1,0 +1,43 @@
+import { isApeInstalled, getApeBinaryPath, getPlatform } from './guard';
+
+export interface InitDeps {
+  isApeInstalled: () => boolean;
+  getApeBinaryPath: () => string;
+  showErrorMessage: (msg: string) => Thenable<string | undefined>;
+  showInformationMessage: (msg: string, ...items: string[]) => Thenable<string | undefined>;
+  createTerminal: (name: string) => { show: () => void; sendText: (text: string) => void };
+}
+
+export async function apeInit(
+  workspaceFolder: string | undefined,
+  deps?: Partial<InitDeps>,
+  onInstallNeeded?: () => Promise<void>,
+): Promise<void> {
+  const vscode = deps ? undefined : require('vscode');
+
+  const showErrorMessage = deps?.showErrorMessage
+    ?? vscode.window.showErrorMessage.bind(vscode.window);
+  const showInformationMessage = deps?.showInformationMessage
+    ?? vscode.window.showInformationMessage.bind(vscode.window);
+  const installed = deps?.isApeInstalled ?? (() => isApeInstalled());
+  const binaryPath = deps?.getApeBinaryPath ?? (() => getApeBinaryPath(getPlatform()));
+  const createTerminal = deps?.createTerminal ?? vscode.window.createTerminal.bind(vscode.window);
+
+  if (!workspaceFolder) {
+    showErrorMessage('APE: Open a workspace folder first.');
+    return;
+  }
+
+  if (!installed()) {
+    if (onInstallNeeded) {
+      await onInstallNeeded();
+    } else {
+      showInformationMessage('APE CLI not found. Install it manually or wait for a future update.');
+    }
+    return;
+  }
+
+  const terminal = createTerminal('APE Init');
+  terminal.show();
+  terminal.sendText(`"${binaryPath()}" init`);
+}

--- a/code/vscode/src/installer.ts
+++ b/code/vscode/src/installer.ts
@@ -1,0 +1,84 @@
+import { EventEmitter } from 'events';
+
+export function getInstallCommand(platform: string): { shell: string; args: string[] } {
+  if (platform === 'win32') {
+    return {
+      shell: 'powershell',
+      args: ['-NoProfile', '-Command', 'irm https://www.ccisne.dev/finite_ape_machine/install.ps1 | iex'],
+    };
+  }
+  if (platform === 'linux') {
+    return {
+      shell: 'bash',
+      args: ['-c', 'curl -fsSL https://www.ccisne.dev/finite_ape_machine/install.sh | bash'],
+    };
+  }
+  throw new Error(`Unsupported platform: ${platform}`);
+}
+
+interface ChildProcessLike {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  on(event: string, listener: (...args: any[]) => void): void;
+  kill(): void;
+}
+
+interface CancellationTokenLike {
+  onCancellationRequested(listener: () => void): void;
+}
+
+export interface InstallerDeps {
+  platform: string;
+  spawn(cmd: string, args: string[]): ChildProcessLike;
+  withProgress(
+    options: { location: number; title: string; cancellable: boolean },
+    task: (progress: { report(value: { message?: string }): void }, token: CancellationTokenLike) => Promise<void>,
+  ): Promise<void>;
+}
+
+export async function installApeCli(deps?: Partial<InstallerDeps>): Promise<void> {
+  const platform = deps?.platform ?? process.platform;
+  const spawn = deps?.spawn ?? ((cmd: string, args: string[]) => {
+    const cp = require('child_process');
+    return cp.spawn(cmd, args);
+  });
+  const withProgress = deps?.withProgress ?? (() => {
+    const vscode = require('vscode');
+    return vscode.window.withProgress.bind(vscode.window);
+  })();
+
+  const { shell, args } = getInstallCommand(platform);
+
+  await withProgress(
+    { location: 15, title: 'Installing APE CLI...', cancellable: true },
+    (progress: { report(value: { message?: string }): void }, token: CancellationTokenLike) => {
+      return new Promise<void>((resolve, reject) => {
+        const proc = spawn(shell, args);
+
+        token.onCancellationRequested(() => {
+          proc.kill();
+          reject(new Error('Installation cancelled'));
+        });
+
+        proc.stdout.on('data', (data: Buffer | string) => {
+          const lines = data.toString().split('\n');
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (trimmed.startsWith('>>>')) {
+              const message = trimmed.slice(3).trim();
+              progress.report({ message });
+            }
+          }
+        });
+
+        proc.on('close', (code: number) => {
+          if (code === 0) {
+            resolve();
+          } else {
+            reject(new Error(`Install failed (exit ${code})`));
+          }
+        });
+      });
+    },
+  );
+}

--- a/code/vscode/test/unit/command-guard.test.ts
+++ b/code/vscode/test/unit/command-guard.test.ts
@@ -1,0 +1,86 @@
+import * as assert from 'assert';
+import { withGuard, GuardDeps } from '../../src/command-guard';
+
+describe('withGuard', () => {
+  it('executes fn when CLI installed and .ape/ exists', async () => {
+    let called = false;
+    const deps: GuardDeps = {
+      isApeInstalled: () => true,
+      isApeWorkspace: () => true,
+      showMessage: () => Promise.resolve(undefined),
+      executeCommand: () => Promise.resolve(undefined),
+    };
+
+    await withGuard('/workspace', {}, async () => { called = true; }, deps);
+    assert.strictEqual(called, true);
+  });
+
+  it('shows CLI notification when not installed', async () => {
+    let called = false;
+    let message = '';
+    const deps: GuardDeps = {
+      isApeInstalled: () => false,
+      isApeWorkspace: () => true,
+      showMessage: (msg) => { message = msg; return Promise.resolve(undefined); },
+      executeCommand: () => Promise.resolve(undefined),
+    };
+
+    await withGuard('/workspace', {}, async () => { called = true; }, deps);
+    assert.strictEqual(called, false);
+    assert.match(message, /APE CLI not found/);
+  });
+
+  it('shows workspace notification when .ape/ missing', async () => {
+    let called = false;
+    let message = '';
+    const deps: GuardDeps = {
+      isApeInstalled: () => true,
+      isApeWorkspace: () => false,
+      showMessage: (msg) => { message = msg; return Promise.resolve(undefined); },
+      executeCommand: () => Promise.resolve(undefined),
+    };
+
+    await withGuard('/workspace', {}, async () => { called = true; }, deps);
+    assert.strictEqual(called, false);
+    assert.match(message, /No APE workspace/);
+  });
+
+  it('skips workspace check when skipWorkspaceCheck is true', async () => {
+    let called = false;
+    const deps: GuardDeps = {
+      isApeInstalled: () => true,
+      isApeWorkspace: () => false,
+      showMessage: () => Promise.resolve(undefined),
+      executeCommand: () => Promise.resolve(undefined),
+    };
+
+    await withGuard('/workspace', { skipWorkspaceCheck: true }, async () => { called = true; }, deps);
+    assert.strictEqual(called, true);
+  });
+
+  it('calls ape.init when user clicks Install', async () => {
+    let executedCommand = '';
+    const deps: GuardDeps = {
+      isApeInstalled: () => false,
+      isApeWorkspace: () => true,
+      showMessage: () => Promise.resolve('Install'),
+      executeCommand: (cmd) => { executedCommand = cmd; return Promise.resolve(undefined); },
+    };
+
+    await withGuard('/workspace', {}, async () => {}, deps);
+    assert.strictEqual(executedCommand, 'ape.init');
+  });
+
+  it('calls ape.init when user clicks Init for workspace', async () => {
+    let executedCommand = '';
+    const deps: GuardDeps = {
+      isApeInstalled: () => true,
+      isApeWorkspace: () => false,
+      showMessage: () => Promise.resolve('Init'),
+      executeCommand: (cmd) => { executedCommand = cmd; return Promise.resolve(undefined); },
+    };
+
+    await withGuard('/workspace', {}, async () => {}, deps);
+    assert.strictEqual(executedCommand, 'ape.init');
+  });
+});

--- a/code/vscode/test/unit/guard.test.ts
+++ b/code/vscode/test/unit/guard.test.ts
@@ -1,0 +1,48 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { getApeBinaryPath, isApeInstalled, isApeWorkspace, getPlatform } from '../../src/guard';
+
+describe('getApeBinaryPath', () => {
+  it('returns LOCALAPPDATA path on win32', () => {
+    const result = getApeBinaryPath('win32');
+    const expected = path.join(process.env.LOCALAPPDATA!, 'ape', 'bin', 'ape.exe');
+    assert.strictEqual(result, expected);
+  });
+
+  it('returns HOME path on linux', () => {
+    const result = getApeBinaryPath('linux');
+    const expected = path.join(process.env.HOME!, '.ape', 'bin', 'ape');
+    assert.strictEqual(result, expected);
+  });
+
+  it('throws on unsupported platform', () => {
+    assert.throws(() => getApeBinaryPath('darwin'), /Unsupported platform: darwin/);
+  });
+});
+
+describe('isApeInstalled', () => {
+  it('returns true when binary exists', () => {
+    assert.strictEqual(isApeInstalled('win32', () => true), true);
+  });
+
+  it('returns false when binary missing', () => {
+    assert.strictEqual(isApeInstalled('linux', () => false), false);
+  });
+});
+
+describe('isApeWorkspace', () => {
+  it('returns true when .ape/ exists', () => {
+    const stub = (p: any) => p === path.join('/workspace', '.ape');
+    assert.strictEqual(isApeWorkspace('/workspace', stub), true);
+  });
+
+  it('returns false when .ape/ missing', () => {
+    assert.strictEqual(isApeWorkspace('/workspace', () => false), false);
+  });
+});
+
+describe('getPlatform', () => {
+  it('returns process.platform', () => {
+    assert.strictEqual(getPlatform(), process.platform);
+  });
+});

--- a/code/vscode/test/unit/init.test.ts
+++ b/code/vscode/test/unit/init.test.ts
@@ -1,0 +1,68 @@
+import * as assert from 'assert';
+import { apeInit, InitDeps } from '../../src/init';
+
+describe('apeInit', () => {
+  it('shows error when no workspace folder', async () => {
+    let errorMsg = '';
+    const deps: InitDeps = {
+      isApeInstalled: () => true,
+      getApeBinaryPath: () => '/usr/bin/ape',
+      showErrorMessage: (msg) => { errorMsg = msg; return Promise.resolve(undefined); },
+      showInformationMessage: () => Promise.resolve(undefined),
+      createTerminal: () => ({ show: () => {}, sendText: () => {} }),
+    };
+
+    await apeInit(undefined, deps);
+    assert.strictEqual(errorMsg, 'APE: Open a workspace folder first.');
+  });
+
+  it('runs ape init in terminal when CLI exists', async () => {
+    let terminalName = '';
+    let sentText = '';
+    const deps: InitDeps = {
+      isApeInstalled: () => true,
+      getApeBinaryPath: () => '/home/user/.ape/bin/ape',
+      showErrorMessage: () => Promise.resolve(undefined),
+      showInformationMessage: () => Promise.resolve(undefined),
+      createTerminal: (name) => {
+        terminalName = name;
+        return {
+          show: () => {},
+          sendText: (text) => { sentText = text; },
+        };
+      },
+    };
+
+    await apeInit('/workspace', deps);
+    assert.strictEqual(terminalName, 'APE Init');
+    assert.strictEqual(sentText, '"/home/user/.ape/bin/ape" init');
+  });
+
+  it('delegates to install flow when CLI missing', async () => {
+    let installCalled = false;
+    const deps: InitDeps = {
+      isApeInstalled: () => false,
+      getApeBinaryPath: () => '/usr/bin/ape',
+      showErrorMessage: () => Promise.resolve(undefined),
+      showInformationMessage: () => Promise.resolve(undefined),
+      createTerminal: () => ({ show: () => {}, sendText: () => {} }),
+    };
+
+    await apeInit('/workspace', deps, async () => { installCalled = true; });
+    assert.strictEqual(installCalled, true);
+  });
+
+  it('shows info message when CLI missing and no install callback', async () => {
+    let infoMsg = '';
+    const deps: InitDeps = {
+      isApeInstalled: () => false,
+      getApeBinaryPath: () => '/usr/bin/ape',
+      showErrorMessage: () => Promise.resolve(undefined),
+      showInformationMessage: (msg) => { infoMsg = msg; return Promise.resolve(undefined); },
+      createTerminal: () => ({ show: () => {}, sendText: () => {} }),
+    };
+
+    await apeInit('/workspace', deps);
+    assert.strictEqual(infoMsg, 'APE CLI not found. Install it manually or wait for a future update.');
+  });
+});

--- a/code/vscode/test/unit/installer.test.ts
+++ b/code/vscode/test/unit/installer.test.ts
@@ -1,0 +1,175 @@
+import * as assert from 'assert';
+import { EventEmitter } from 'events';
+import { getInstallCommand, installApeCli, InstallerDeps } from '../../src/installer';
+
+function createMockProcess() {
+  const proc = {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    on: (event: string, listener: (...args: any[]) => void) => {
+      (proc as any)._events = (proc as any)._events || {};
+      (proc as any)._events[event] = listener;
+    },
+    kill: () => { (proc as any)._killed = true; },
+    _killed: false,
+    _events: {} as Record<string, (...args: any[]) => void>,
+    emit_close: (code: number) => { (proc as any)._events['close'](code); },
+  };
+  return proc;
+}
+
+function createMockWithProgress() {
+  return async <T>(
+    _options: { location: number; title: string; cancellable: boolean },
+    task: (progress: { report(value: { message?: string }): void }, token: { onCancellationRequested(listener: () => void): void }) => Promise<T>,
+  ): Promise<T> => {
+    const reports: { message?: string }[] = [];
+    const progress = { report: (value: { message?: string }) => { reports.push(value); } };
+    let cancelListener: (() => void) | undefined;
+    const token = { onCancellationRequested: (listener: () => void) => { cancelListener = listener; } };
+    const result = task(progress, token);
+    (createMockWithProgress as any)._reports = reports;
+    (createMockWithProgress as any)._cancelListener = cancelListener;
+    return result;
+  };
+}
+
+describe('getInstallCommand', () => {
+  it('returns powershell command on win32', () => {
+    const cmd = getInstallCommand('win32');
+    assert.strictEqual(cmd.shell, 'powershell');
+    assert.deepStrictEqual(cmd.args, [
+      '-NoProfile', '-Command',
+      'irm https://www.ccisne.dev/finite_ape_machine/install.ps1 | iex',
+    ]);
+  });
+
+  it('returns bash command on linux', () => {
+    const cmd = getInstallCommand('linux');
+    assert.strictEqual(cmd.shell, 'bash');
+    assert.deepStrictEqual(cmd.args, [
+      '-c', 'curl -fsSL https://www.ccisne.dev/finite_ape_machine/install.sh | bash',
+    ]);
+  });
+
+  it('throws on unsupported platform', () => {
+    assert.throws(() => getInstallCommand('darwin'), /Unsupported platform: darwin/);
+  });
+});
+
+describe('installApeCli', () => {
+  it('spawns powershell on win32', async () => {
+    const mockProc = createMockProcess();
+    let spawnedCmd = '';
+    let spawnedArgs: string[] = [];
+
+    const deps: InstallerDeps = {
+      platform: 'win32',
+      spawn: (cmd, args) => { spawnedCmd = cmd; spawnedArgs = args; return mockProc; },
+      withProgress: async (_opts, task) => {
+        const reports: { message?: string }[] = [];
+        const progress = { report: (v: { message?: string }) => { reports.push(v); } };
+        const token = { onCancellationRequested: () => {} };
+        const promise = task(progress, token);
+        mockProc.stdout.emit('data', '>>> Downloading...\n');
+        mockProc.emit_close(0);
+        await promise;
+        assert.strictEqual(reports.length, 1);
+        assert.strictEqual(reports[0].message, 'Downloading...');
+      },
+    };
+
+    await installApeCli(deps);
+    assert.strictEqual(spawnedCmd, 'powershell');
+    assert.deepStrictEqual(spawnedArgs, [
+      '-NoProfile', '-Command',
+      'irm https://www.ccisne.dev/finite_ape_machine/install.ps1 | iex',
+    ]);
+  });
+
+  it('spawns bash on linux', async () => {
+    const mockProc = createMockProcess();
+    let spawnedCmd = '';
+
+    const deps: InstallerDeps = {
+      platform: 'linux',
+      spawn: (cmd, args) => { spawnedCmd = cmd; return mockProc; },
+      withProgress: async (_opts, task) => {
+        const progress = { report: () => {} };
+        const token = { onCancellationRequested: () => {} };
+        const promise = task(progress, token);
+        mockProc.emit_close(0);
+        await promise;
+      },
+    };
+
+    await installApeCli(deps);
+    assert.strictEqual(spawnedCmd, 'bash');
+  });
+
+  it('rejects on non-zero exit code', async () => {
+    const mockProc = createMockProcess();
+
+    const deps: InstallerDeps = {
+      platform: 'win32',
+      spawn: () => mockProc,
+      withProgress: async (_opts, task) => {
+        const progress = { report: () => {} };
+        const token = { onCancellationRequested: () => {} };
+        const promise = task(progress, token);
+        mockProc.emit_close(1);
+        return promise;
+      },
+    };
+
+    await assert.rejects(() => installApeCli(deps), /Install failed \(exit 1\)/);
+  });
+
+  it('kills process on cancellation', async () => {
+    const mockProc = createMockProcess();
+
+    const deps: InstallerDeps = {
+      platform: 'win32',
+      spawn: () => mockProc,
+      withProgress: async (_opts, task) => {
+        const progress = { report: () => {} };
+        let cancelFn: (() => void) | undefined;
+        const token = { onCancellationRequested: (listener: () => void) => { cancelFn = listener; } };
+        const promise = task(progress, token);
+        cancelFn!();
+        try { await promise; } catch { /* expected */ }
+      },
+    };
+
+    try {
+      await installApeCli(deps);
+    } catch {
+      // expected rejection from cancellation
+    }
+    assert.strictEqual(mockProc._killed, true);
+  });
+
+  it('reports multiple progress milestones', async () => {
+    const mockProc = createMockProcess();
+    const reports: { message?: string }[] = [];
+
+    const deps: InstallerDeps = {
+      platform: 'linux',
+      spawn: () => mockProc,
+      withProgress: async (_opts, task) => {
+        const progress = { report: (v: { message?: string }) => { reports.push(v); } };
+        const token = { onCancellationRequested: () => {} };
+        const promise = task(progress, token);
+        mockProc.stdout.emit('data', '>>> Fetching...\n>>> Downloading...\n>>> Extracting...\n');
+        mockProc.emit_close(0);
+        await promise;
+      },
+    };
+
+    await installApeCli(deps);
+    assert.strictEqual(reports.length, 3);
+    assert.strictEqual(reports[0].message, 'Fetching...');
+    assert.strictEqual(reports[1].message, 'Downloading...');
+    assert.strictEqual(reports[2].message, 'Extracting...');
+  });
+});

--- a/docs/issues/086-ape-vscode-init-command/analyze/diagnosis.md
+++ b/docs/issues/086-ape-vscode-init-command/analyze/diagnosis.md
@@ -1,0 +1,93 @@
+---
+id: diagnosis
+title: "Diagnosis: APE Init command — onboarding path from VS Code extension"
+date: 2026-04-19
+status: completed
+tags: [vscode, onboarding, cli-detection, install, ux]
+author: socrates
+---
+
+# Diagnosis: APE Init Command
+
+## Problem Statement
+
+Users who install the APE VS Code extension from the Marketplace cannot use it without first installing the APE CLI separately. There is no onboarding path from within VS Code — the extension activates only when `.ape/` exists, creating a chicken-and-egg problem for new users.
+
+## User Persona
+
+New user browsing the VS Code Marketplace for AI-assisted programming tools. Finds APE, installs the extension, and expects a guided setup experience (like Flutter's extension offers).
+
+## UX Flow
+
+1. User installs extension from Marketplace
+2. Opens any workspace → `Ctrl+Shift+P` → "APE" → selects **APE: Init**
+3. Extension checks if `ape` binary exists at known path:
+   - Windows: `%LOCALAPPDATA%\ape\bin\ape.exe`
+   - Linux: `~/.ape/bin/ape`
+4. **If found:** runs `ape init` in the workspace folder via terminal
+5. **If NOT found:** shows notification with `[Install]` and `[Cancel]` actions
+6. User clicks "Install" → extension spawns install script with `window.withProgress`:
+   - Windows: `powershell -c "irm https://www.ccisne.dev/finite_ape_machine/install.ps1 | iex"`
+   - Linux: `bash -c "curl -fsSL https://www.ccisne.dev/finite_ape_machine/install.sh | bash"`
+7. Progress notification shows milestones parsed from script stdout (`>>>` markers):
+   - "Fetching latest release..."
+   - "Downloading..."
+   - "Extracting..."
+   - "Verifying installation..."
+   - "APE CLI installed successfully!"
+8. On success → runs `ape init` in workspace
+9. `.ape/` created → status bar appears, extension fully functional
+
+## Technical Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | Invoke existing install scripts, not reimplementation | Single source of truth for installation logic |
+| D2 | Extension uses absolute path internally (hardcoded) | PATH changes not visible until VS Code restart. Known deterministic paths avoid ambiguity |
+| D3 | No configurable `ape.cliPath` setting | Third-party distribution unlikely to be relocated. KISS principle. |
+| D4 | `onCommand:ape.init` added to activationEvents | Onboarding requires activation without `.ape/` existing |
+| D5 | `child_process.spawn` + `window.withProgress` for install | Milestones parsed from script stdout markers (`>>>`). User sees live progress. |
+| D6 | Optimistic error handling | Show error notification on failure, no retry loops |
+| D7 | `ape init` runs in terminal (not hidden) | User sees output of `ape init`, transparency over magic |
+| D8 | No backward compatibility requirement | v0.0.x phase, no installed base to worry about |
+| D9 | Discoverability via Marketplace docs | `Ctrl+Shift+P` → "APE" shows `APE: Init`. Document in README. |
+
+## Constraints
+
+- v0.0.2 scope — only adds `APE: Init` command
+- No CLI execution beyond `ape init` (boundary from v0.0.1)
+- Cross-platform: Windows x64 + Linux x64
+- Scripts hosted at `ccisne.dev/finite_ape_machine/install.{ps1,sh}`
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Corporate proxy blocks GitHub API | Show error message with manual install link |
+| Antivirus quarantines binary after extraction | Show error, suggest allowlisting |
+| Script markers change | Loose parsing — unknown lines ignored, progress still works |
+| User cancels mid-install | No cleanup needed — partial install is harmless, next attempt overwrites |
+
+## Scope Boundary
+
+**IN:**
+- `APE: Init` command registered in `package.json`
+- `onCommand:ape.init` activation event
+- CLI detection (file existence check at known path)
+- Install via scripts with progress notification
+- Run `ape init` after install/detection
+- Updated README with onboarding instructions
+
+**OUT (deferred):**
+- `ape.cliPath` configurable setting
+- Walkthrough / welcome tab
+- Auto-update CLI
+- macOS support (no install script yet)
+- Retry/recovery loops on failure
+
+## References
+
+- Flutter/Dart extension SDK detection: `Dart-Code/Dart-Code` repo, `src/extension/sdk/utils.ts`
+- APE install scripts: `code/site/install.ps1`, `code/site/install.sh`
+- Current extension: `code/vscode/src/extension.js`
+- Issue: https://github.com/ccisnedev/finite_ape_machine/issues/86

--- a/docs/issues/086-ape-vscode-init-command/analyze/diagnosis.md
+++ b/docs/issues/086-ape-vscode-init-command/analyze/diagnosis.md
@@ -1,17 +1,44 @@
 ---
 id: diagnosis
-title: "Diagnosis: APE Init command — onboarding path from VS Code extension"
+title: "Diagnosis: APE Init + command guards — onboarding and validation from VS Code extension"
 date: 2026-04-19
 status: completed
-tags: [vscode, onboarding, cli-detection, install, ux]
+tags: [vscode, onboarding, cli-detection, install, ux, bug-fix, guard-clause]
 author: socrates
 ---
 
-# Diagnosis: APE Init Command
+# Diagnosis: APE Init + Command Guards
 
 ## Problem Statement
 
 Users who install the APE VS Code extension from the Marketplace cannot use it without first installing the APE CLI separately. There is no onboarding path from within VS Code — the extension activates only when `.ape/` exists, creating a chicken-and-egg problem for new users.
+
+## Bug in v0.0.1
+
+The commands `APE: Add Mutation Note` and `APE: Toggle Evolution` are active even when `.ape/` does not exist. If invoked without a workspace, they silently create the `.ape/` directory and their corresponding file (`mutations.md`, `config.yaml`) directly — bypassing `ape init` entirely.
+
+This is incorrect behavior:
+- Files are created without CLI validation, producing an incomplete `.ape/` structure
+- The user gets no feedback that the CLI is missing
+- The extension masks the absence of a proper `ape init` run
+
+**All APE commands must validate CLI installation and `.ape/` existence before executing.** Files should never be created directly by the extension.
+
+## Guard Clause Pattern
+
+Every APE command (`ape.init`, `ape.toggleEvolution`, `ape.addMutation`) must pass through a shared guard before execution:
+
+```
+1. Command triggered
+2. Guard: does `ape` binary exist at known path?
+   ├─ NO  → notification: "APE CLI not found. [Install] [Cancel]"
+   │        (Install triggers the install flow from APE: Init)
+   └─ YES → does `.ape/` exist in workspace?
+            ├─ NO  → notification: "No APE workspace found. Run APE: Init first. [Run Init] [Cancel]"
+            └─ YES → execute the command normally
+```
+
+Exception: `ape.init` skips the `.ape/` check (its purpose is to create it).
 
 ## User Persona
 
@@ -51,10 +78,11 @@ New user browsing the VS Code Marketplace for AI-assisted programming tools. Fin
 | D7 | `ape init` runs in terminal (not hidden) | User sees output of `ape init`, transparency over magic |
 | D8 | No backward compatibility requirement | v0.0.x phase, no installed base to worry about |
 | D9 | Discoverability via Marketplace docs | `Ctrl+Shift+P` → "APE" shows `APE: Init`. Document in README. |
+| D10 | All APE commands validate CLI + `.ape/` before executing | v0.0.1 bug: commands silently create files without CLI. Guard clause centralizes validation, provides user-friendly notifications with actionable buttons, and prevents corrupt `.ape/` state. |
 
 ## Constraints
 
-- v0.0.2 scope — only adds `APE: Init` command
+- v0.0.2 scope — adds `APE: Init` command + guard clause on all commands
 - No CLI execution beyond `ape init` (boundary from v0.0.1)
 - Cross-platform: Windows x64 + Linux x64
 - Scripts hosted at `ccisne.dev/finite_ape_machine/install.{ps1,sh}`
@@ -76,6 +104,8 @@ New user browsing the VS Code Marketplace for AI-assisted programming tools. Fin
 - CLI detection (file existence check at known path)
 - Install via scripts with progress notification
 - Run `ape init` after install/detection
+- Guard clause on `ape.toggleEvolution` and `ape.addMutation` (validate CLI + `.ape/`)
+- Remove direct file creation from existing commands (bug fix)
 - Updated README with onboarding instructions
 
 **OUT (deferred):**

--- a/docs/issues/086-ape-vscode-init-command/analyze/index.md
+++ b/docs/issues/086-ape-vscode-init-command/analyze/index.md
@@ -1,0 +1,14 @@
+# Analyze Phase — Index
+
+**Issue:** #86 — ape-vscode: APE Init command — detect, install, and init APE CLI from VS Code
+**Branch:** 086-ape-vscode-init-command
+**Phase:** ANALYZE
+**Status:** In progress
+
+---
+
+## Documents
+
+| # | File | Description |
+|---|------|-------------|
+| 1 | [diagnosis.md](diagnosis.md) | Full diagnosis: problem, UX flow, technical decisions, risks, scope |

--- a/docs/issues/086-ape-vscode-init-command/plan.md
+++ b/docs/issues/086-ape-vscode-init-command/plan.md
@@ -1,0 +1,360 @@
+---
+id: plan
+title: "Plan: APE Init command + command guards for VS Code extension"
+date: 2026-04-19
+status: draft
+tags: [vscode, onboarding, guard-clause, init, install, tdd]
+author: descartes
+---
+
+# Plan: APE Init + Command Guards
+
+## Summary
+
+Five phases transform the extension from v0.0.1 (no onboarding, buggy file creation) to v0.0.2 (guided init, guard clauses, cross-platform install).
+
+---
+
+## Phase 1 — Guard clause: pure logic + unit tests
+
+**Goal:** Create the guard module with platform-aware path resolution and existence checks. Pure functions, no VS Code API dependency.
+
+**File:** `src/guard.ts`
+
+### Steps
+
+- [ ] 1.1 Create `src/guard.ts` exporting:
+  - `getApeBinaryPath(platform: string): string` — returns absolute path
+    - `win32` → `path.join(process.env.LOCALAPPDATA!, 'ape', 'bin', 'ape.exe')`
+    - `linux` → `path.join(process.env.HOME!, '.ape', 'bin', 'ape')`
+  - `isApeInstalled(platform?: string): boolean` — `fs.existsSync(getApeBinaryPath(...))`
+  - `isApeWorkspace(workspaceFolder: string): boolean` — `fs.existsSync(path.join(folder, '.ape'))`
+
+- [ ] 1.2 Write unit tests `test/unit/guard.test.ts` (RED → GREEN)
+
+```pseudo
+describe('getApeBinaryPath')
+  it('returns LOCALAPPDATA path on win32')
+    assert getApeBinaryPath('win32') == join(LOCALAPPDATA, 'ape/bin/ape.exe')
+  it('returns HOME path on linux')
+    assert getApeBinaryPath('linux') == join(HOME, '.ape/bin/ape')
+  it('throws on unsupported platform')
+    assert throws(() => getApeBinaryPath('darwin'))
+
+describe('isApeInstalled')
+  it('returns true when binary exists')
+    stub fs.existsSync → true
+    assert isApeInstalled('win32') == true
+  it('returns false when binary missing')
+    stub fs.existsSync → false
+    assert isApeInstalled('linux') == false
+
+describe('isApeWorkspace')
+  it('returns true when .ape/ exists')
+    stub fs.existsSync(join(folder, '.ape')) → true
+    assert isApeWorkspace('/workspace') == true
+  it('returns false when .ape/ missing')
+    stub fs.existsSync → false
+    assert isApeWorkspace('/workspace') == false
+```
+
+- [ ] 1.3 All tests pass (GREEN)
+- [ ] 1.4 REFACTOR: extract platform detection to `getPlatform(): string` wrapper for testability
+
+**Risk:** `LOCALAPPDATA` env var undefined in CI. Mitigation: test with explicit platform param, mock env.
+
+---
+
+## Phase 2 — Guard integration into existing commands (bug fix)
+
+**Goal:** Wrap `toggleEvolution` and `addMutation` with guard validation. Remove `fs.mkdirSync` bug. Commands now fail gracefully when CLI or `.ape/` are missing.
+
+### Steps
+
+- [ ] 2.1 Create `src/command-guard.ts` — VS Code-aware wrapper:
+
+```pseudo
+async function withGuard(apeFolderPath, options, fn):
+  if not isApeInstalled():
+    show notification "APE CLI not found" with [Install] [Cancel]
+    if Install → execute command 'ape.init'
+    return
+  if not options.skipWorkspaceCheck and not isApeWorkspace(folder):
+    show notification "No APE workspace" with [Run Init] [Cancel]
+    if Run Init → execute command 'ape.init'
+    return
+  await fn()
+```
+
+- [ ] 2.2 Write unit tests `test/unit/command-guard.test.ts` (RED → GREEN)
+
+```pseudo
+describe('withGuard')
+  it('executes fn when CLI installed and .ape/ exists')
+    stub isApeInstalled → true, isApeWorkspace → true
+    assert fn called once
+
+  it('shows CLI notification when not installed')
+    stub isApeInstalled → false
+    assert showInformationMessage called with "APE CLI not found"
+    assert fn NOT called
+
+  it('shows workspace notification when .ape/ missing')
+    stub isApeInstalled → true, isApeWorkspace → false
+    assert showInformationMessage called with "No APE workspace"
+    assert fn NOT called
+
+  it('skips workspace check when skipWorkspaceCheck is true')
+    stub isApeInstalled → true, isApeWorkspace → false
+    options = { skipWorkspaceCheck: true }
+    assert fn called once
+```
+
+- [ ] 2.3 All tests pass (GREEN)
+
+- [ ] 2.4 Modify `src/commands.ts`:
+  - Remove `fs.mkdirSync(path.dirname(...), { recursive: true })` from both functions
+  - Both functions now assume `.ape/` exists (guard ensures it)
+
+- [ ] 2.5 Modify `src/extension.ts`:
+  - Wrap `toggleEvolution` call inside `withGuard(apeFolderPath, {}, () => ...)`
+  - Wrap `addMutation` call inside `withGuard(apeFolderPath, {}, () => ...)`
+
+- [ ] 2.6 Update existing tests in `test/unit/toggle-evolution.test.ts` and `test/unit/add-mutation.test.ts`:
+  - Tests must set up `.ape/` directory before calling commands
+  - Verify `mkdirSync` is no longer called
+
+- [ ] 2.7 Run full test suite — all 29 existing + new guard tests pass
+
+**Risk:** Breaking existing tests. Mitigation: run tests after each sub-step, not just at the end.
+
+---
+
+## Phase 3 — APE: Init command — happy path (CLI exists)
+
+**Goal:** Register `ape.init` command. When CLI exists, run `ape init` in a VS Code terminal. Extension activates on command.
+
+### Steps
+
+- [ ] 3.1 Update `package.json`:
+  - Add `"onCommand:ape.init"` to `activationEvents`
+  - Add `{ "command": "ape.init", "title": "APE: Init" }` to `contributes.commands`
+
+- [ ] 3.2 Create `src/init.ts` with `apeInit(workspaceFolder: string)`:
+
+```pseudo
+async function apeInit(workspaceFolder):
+  if not workspaceFolder:
+    showErrorMessage("Open a folder first")
+    return
+
+  if not isApeInstalled():
+    → delegate to install flow (Phase 4)
+    return
+
+  terminal = createTerminal('APE Init')
+  terminal.show()
+  terminal.sendText(`"${binaryPath}" init`)
+```
+
+- [ ] 3.3 Register command in `src/extension.ts`:
+  - `vscode.commands.registerCommand('ape.init', () => apeInit(workspaceFolder))`
+  - Command must work even when `workspaceFolder` was undefined at activation (re-query `workspaceFolders`)
+
+- [ ] 3.4 Write unit tests `test/unit/init.test.ts` (RED → GREEN)
+
+```pseudo
+describe('apeInit')
+  it('shows error when no workspace folder')
+    stub workspaceFolders → undefined
+    assert showErrorMessage called
+
+  it('runs ape init in terminal when CLI exists')
+    stub isApeInstalled → true
+    assert createTerminal called with 'APE Init'
+    assert sendText called with path containing 'ape init'
+
+  it('delegates to install flow when CLI missing')
+    stub isApeInstalled → false
+    assert install flow triggered (Phase 4 stub)
+```
+
+- [ ] 3.5 All tests pass (GREEN)
+
+- [ ] 3.6 Manual smoke test: `Ctrl+Shift+P` → "APE: Init" activates extension
+
+**Risk:** Terminal command path with spaces. Mitigation: quote the binary path.
+
+---
+
+## Phase 4 — APE: Init — install flow (CLI missing)
+
+**Goal:** When CLI not found, offer installation via notification. Spawn install script with progress parsing. Post-install, verify and run `ape init`.
+
+### Steps
+
+- [ ] 4.1 Create `src/installer.ts`:
+
+```pseudo
+async function installApeCli():
+  script = platform == 'win32'
+    ? 'powershell -NoProfile -c "irm https://www.ccisne.dev/finite_ape_machine/install.ps1 | iex"'
+    : 'bash -c "curl -fsSL https://www.ccisne.dev/finite_ape_machine/install.sh | bash"'
+
+  await window.withProgress({ location: Notification, title: 'Installing APE CLI', cancellable: true }, (progress, token) =>
+    return new Promise((resolve, reject) =>
+      proc = spawn(shell, args)
+      token.onCancellationRequested → proc.kill()
+
+      proc.stdout.on('data', chunk =>
+        lines = chunk.toString().split('\n')
+        for line in lines:
+          if line.startsWith('>>>'):
+            progress.report({ message: line.slice(4).trim() })
+      )
+
+      proc.on('close', code =>
+        if code == 0: resolve()
+        else: reject(new Error(`Install failed (exit ${code})`))
+      )
+    )
+  )
+```
+
+- [ ] 4.2 Wire install flow into `src/init.ts`:
+  - When `isApeInstalled()` returns false:
+    - Show notification: "APE CLI not found. Install it?" with [Install] [Cancel]
+    - If Install → call `installApeCli()`
+    - After install → verify `isApeInstalled()` is now true
+    - If verification passes → run `ape init` in terminal
+    - If verification fails → show error "Installation failed"
+
+- [ ] 4.3 Write unit tests `test/unit/installer.test.ts` (RED → GREEN)
+
+```pseudo
+describe('installApeCli')
+  it('spawns powershell on win32')
+    stub platform → 'win32'
+    stub spawn → mock process
+    emit stdout '>>> Downloading...\n'
+    emit close(0)
+    assert progress.report called with { message: 'Downloading...' }
+    assert resolves
+
+  it('spawns bash on linux')
+    stub platform → 'linux'
+    stub spawn → mock process
+    emit close(0)
+    assert resolves
+
+  it('rejects on non-zero exit code')
+    stub spawn → mock process
+    emit close(1)
+    assert rejects with 'Install failed (exit 1)'
+
+  it('kills process on cancellation')
+    stub spawn → mock process
+    fire token.onCancellationRequested
+    assert proc.kill called
+
+  it('reports multiple progress milestones')
+    emit stdout '>>> Fetching...\n>>> Downloading...\n>>> Extracting...\n'
+    emit close(0)
+    assert progress.report called 3 times
+```
+
+- [ ] 4.4 Integration test `test/integration/init-flow.test.ts` (deferred — requires VS Code runtime)
+
+```pseudo
+describe('APE: Init integration')
+  it('shows install notification when CLI missing')
+  it('completes full flow: install → verify → ape init')
+```
+
+- [ ] 4.5 All unit tests pass (GREEN)
+- [ ] 4.6 REFACTOR: extract `getInstallCommand(platform)` for testability
+
+**Risk:** Corporate proxy blocks download. Mitigation: D6 — show error with manual install URL.
+**Risk:** Antivirus quarantines binary. Mitigation: show error suggesting allowlist.
+
+---
+
+## Phase 5 — README + CHANGELOG + version bump + publish
+
+**Goal:** Document onboarding, bump version, publish v0.0.2.
+
+### Steps
+
+- [ ] 5.1 Update `README.md`:
+  - Add "Getting Started" section with `APE: Init` instructions
+  - Add "Requirements" section noting Windows/Linux only
+  - Document the three commands with expected behavior
+
+- [ ] 5.2 Update `CHANGELOG.md`:
+
+```markdown
+## [0.0.2] - 2026-04-XX
+
+### Added
+- `APE: Init` command — detects, installs, and initializes APE CLI
+- Guard clause on all commands — validates CLI + workspace before executing
+- Cross-platform install (Windows + Linux) with progress notification
+
+### Fixed
+- Commands no longer silently create `.ape/` without CLI validation
+```
+
+- [ ] 5.3 Bump `package.json` version: `"0.0.1"` → `"0.0.2"`
+
+- [ ] 5.4 Run full test suite: `npm run test:unit`
+
+- [ ] 5.5 Package: `npx vsce package --no-dependencies`
+
+- [ ] 5.6 Publish: `npx vsce publish --no-dependencies`
+
+- [ ] 5.7 Commit + PR: `"086: ape-vscode v0.0.2 — APE Init + command guards"`
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (guard logic)
+   ↓
+Phase 2 (bug fix — uses guard)
+   ↓
+Phase 3 (init command — uses guard)
+   ↓
+Phase 4 (install flow — called from init)
+   ↓
+Phase 5 (docs + release)
+```
+
+## Files Created/Modified
+
+| File | Action | Phase |
+|------|--------|-------|
+| `src/guard.ts` | CREATE | 1 |
+| `test/unit/guard.test.ts` | CREATE | 1 |
+| `src/command-guard.ts` | CREATE | 2 |
+| `test/unit/command-guard.test.ts` | CREATE | 2 |
+| `src/commands.ts` | MODIFY — remove mkdirSync | 2 |
+| `src/extension.ts` | MODIFY — add guards + init registration | 2, 3 |
+| `test/unit/toggle-evolution.test.ts` | MODIFY | 2 |
+| `test/unit/add-mutation.test.ts` | MODIFY | 2 |
+| `src/init.ts` | CREATE | 3 |
+| `test/unit/init.test.ts` | CREATE | 3 |
+| `package.json` | MODIFY — activationEvents + command | 3, 5 |
+| `src/installer.ts` | CREATE | 4 |
+| `test/unit/installer.test.ts` | CREATE | 4 |
+| `test/integration/init-flow.test.ts` | CREATE (stub) | 4 |
+| `README.md` | MODIFY | 5 |
+| `CHANGELOG.md` | MODIFY | 5 |
+
+## Exit Criteria
+
+- All unit tests pass (existing 29 + new ~20)
+- `APE: Init` works on Windows (manual test)
+- Guard blocks `toggleEvolution`/`addMutation` when `.ape/` missing
+- No `fs.mkdirSync` creating `.ape/` in command code
+- Published v0.0.2 on Marketplace

--- a/docs/issues/086-ape-vscode-init-command/plan.md
+++ b/docs/issues/086-ape-vscode-init-command/plan.md
@@ -23,14 +23,14 @@ Five phases transform the extension from v0.0.1 (no onboarding, buggy file creat
 
 ### Steps
 
-- [ ] 1.1 Create `src/guard.ts` exporting:
+- [x] 1.1 Create `src/guard.ts` exporting:
   - `getApeBinaryPath(platform: string): string` — returns absolute path
     - `win32` → `path.join(process.env.LOCALAPPDATA!, 'ape', 'bin', 'ape.exe')`
     - `linux` → `path.join(process.env.HOME!, '.ape', 'bin', 'ape')`
   - `isApeInstalled(platform?: string): boolean` — `fs.existsSync(getApeBinaryPath(...))`
   - `isApeWorkspace(workspaceFolder: string): boolean` — `fs.existsSync(path.join(folder, '.ape'))`
 
-- [ ] 1.2 Write unit tests `test/unit/guard.test.ts` (RED → GREEN)
+- [x] 1.2 Write unit tests `test/unit/guard.test.ts` (RED → GREEN)
 
 ```pseudo
 describe('getApeBinaryPath')
@@ -58,8 +58,8 @@ describe('isApeWorkspace')
     assert isApeWorkspace('/workspace') == false
 ```
 
-- [ ] 1.3 All tests pass (GREEN)
-- [ ] 1.4 REFACTOR: extract platform detection to `getPlatform(): string` wrapper for testability
+- [x] 1.3 All tests pass (GREEN)
+- [x] 1.4 REFACTOR: extract platform detection to `getPlatform(): string` wrapper for testability
 
 **Risk:** `LOCALAPPDATA` env var undefined in CI. Mitigation: test with explicit platform param, mock env.
 
@@ -71,7 +71,7 @@ describe('isApeWorkspace')
 
 ### Steps
 
-- [ ] 2.1 Create `src/command-guard.ts` — VS Code-aware wrapper:
+- [x] 2.1 Create `src/command-guard.ts` — VS Code-aware wrapper:
 
 ```pseudo
 async function withGuard(apeFolderPath, options, fn):
@@ -86,7 +86,7 @@ async function withGuard(apeFolderPath, options, fn):
   await fn()
 ```
 
-- [ ] 2.2 Write unit tests `test/unit/command-guard.test.ts` (RED → GREEN)
+- [x] 2.2 Write unit tests `test/unit/command-guard.test.ts` (RED → GREEN)
 
 ```pseudo
 describe('withGuard')
@@ -110,21 +110,21 @@ describe('withGuard')
     assert fn called once
 ```
 
-- [ ] 2.3 All tests pass (GREEN)
+- [x] 2.3 All tests pass (GREEN)
 
-- [ ] 2.4 Modify `src/commands.ts`:
+- [x] 2.4 Modify `src/commands.ts`:
   - Remove `fs.mkdirSync(path.dirname(...), { recursive: true })` from both functions
   - Both functions now assume `.ape/` exists (guard ensures it)
 
-- [ ] 2.5 Modify `src/extension.ts`:
+- [x] 2.5 Modify `src/extension.ts`:
   - Wrap `toggleEvolution` call inside `withGuard(apeFolderPath, {}, () => ...)`
   - Wrap `addMutation` call inside `withGuard(apeFolderPath, {}, () => ...)`
 
-- [ ] 2.6 Update existing tests in `test/unit/toggle-evolution.test.ts` and `test/unit/add-mutation.test.ts`:
+- [x] 2.6 Update existing tests in `test/unit/toggle-evolution.test.ts` and `test/unit/add-mutation.test.ts`:
   - Tests must set up `.ape/` directory before calling commands
   - Verify `mkdirSync` is no longer called
 
-- [ ] 2.7 Run full test suite — all 29 existing + new guard tests pass
+- [x] 2.7 Run full test suite — all 29 existing + new guard tests pass
 
 **Risk:** Breaking existing tests. Mitigation: run tests after each sub-step, not just at the end.
 
@@ -136,11 +136,11 @@ describe('withGuard')
 
 ### Steps
 
-- [ ] 3.1 Update `package.json`:
+- [x] 3.1 Update `package.json`:
   - Add `"onCommand:ape.init"` to `activationEvents`
   - Add `{ "command": "ape.init", "title": "APE: Init" }` to `contributes.commands`
 
-- [ ] 3.2 Create `src/init.ts` with `apeInit(workspaceFolder: string)`:
+- [x] 3.2 Create `src/init.ts` with `apeInit(workspaceFolder: string)`:
 
 ```pseudo
 async function apeInit(workspaceFolder):
@@ -157,11 +157,11 @@ async function apeInit(workspaceFolder):
   terminal.sendText(`"${binaryPath}" init`)
 ```
 
-- [ ] 3.3 Register command in `src/extension.ts`:
+- [x] 3.3 Register command in `src/extension.ts`:
   - `vscode.commands.registerCommand('ape.init', () => apeInit(workspaceFolder))`
   - Command must work even when `workspaceFolder` was undefined at activation (re-query `workspaceFolders`)
 
-- [ ] 3.4 Write unit tests `test/unit/init.test.ts` (RED → GREEN)
+- [x] 3.4 Write unit tests `test/unit/init.test.ts` (RED → GREEN)
 
 ```pseudo
 describe('apeInit')
@@ -179,9 +179,9 @@ describe('apeInit')
     assert install flow triggered (Phase 4 stub)
 ```
 
-- [ ] 3.5 All tests pass (GREEN)
+- [x] 3.5 All tests pass (GREEN)
 
-- [ ] 3.6 Manual smoke test: `Ctrl+Shift+P` → "APE: Init" activates extension
+- [x] 3.6 Manual smoke test: `Ctrl+Shift+P` → "APE: Init" activates extension
 
 **Risk:** Terminal command path with spaces. Mitigation: quote the binary path.
 
@@ -193,7 +193,7 @@ describe('apeInit')
 
 ### Steps
 
-- [ ] 4.1 Create `src/installer.ts`:
+- [x] 4.1 Create `src/installer.ts`:
 
 ```pseudo
 async function installApeCli():
@@ -221,7 +221,7 @@ async function installApeCli():
   )
 ```
 
-- [ ] 4.2 Wire install flow into `src/init.ts`:
+- [x] 4.2 Wire install flow into `src/init.ts`:
   - When `isApeInstalled()` returns false:
     - Show notification: "APE CLI not found. Install it?" with [Install] [Cancel]
     - If Install → call `installApeCli()`
@@ -229,7 +229,7 @@ async function installApeCli():
     - If verification passes → run `ape init` in terminal
     - If verification fails → show error "Installation failed"
 
-- [ ] 4.3 Write unit tests `test/unit/installer.test.ts` (RED → GREEN)
+- [x] 4.3 Write unit tests `test/unit/installer.test.ts` (RED → GREEN)
 
 ```pseudo
 describe('installApeCli')
@@ -263,7 +263,7 @@ describe('installApeCli')
     assert progress.report called 3 times
 ```
 
-- [ ] 4.4 Integration test `test/integration/init-flow.test.ts` (deferred — requires VS Code runtime)
+- [x] 4.4 Integration test `test/integration/init-flow.test.ts` (deferred — requires VS Code runtime)
 
 ```pseudo
 describe('APE: Init integration')
@@ -271,8 +271,8 @@ describe('APE: Init integration')
   it('completes full flow: install → verify → ape init')
 ```
 
-- [ ] 4.5 All unit tests pass (GREEN)
-- [ ] 4.6 REFACTOR: extract `getInstallCommand(platform)` for testability
+- [x] 4.5 All unit tests pass (GREEN)
+- [x] 4.6 REFACTOR: extract `getInstallCommand(platform)` for testability
 
 **Risk:** Corporate proxy blocks download. Mitigation: D6 — show error with manual install URL.
 **Risk:** Antivirus quarantines binary. Mitigation: show error suggesting allowlist.
@@ -285,12 +285,12 @@ describe('APE: Init integration')
 
 ### Steps
 
-- [ ] 5.1 Update `README.md`:
+- [x] 5.1 Update `README.md`:
   - Add "Getting Started" section with `APE: Init` instructions
   - Add "Requirements" section noting Windows/Linux only
   - Document the three commands with expected behavior
 
-- [ ] 5.2 Update `CHANGELOG.md`:
+- [x] 5.2 Update `CHANGELOG.md`:
 
 ```markdown
 ## [0.0.2] - 2026-04-XX
@@ -304,15 +304,15 @@ describe('APE: Init integration')
 - Commands no longer silently create `.ape/` without CLI validation
 ```
 
-- [ ] 5.3 Bump `package.json` version: `"0.0.1"` → `"0.0.2"`
+- [x] 5.3 Bump `package.json` version: `"0.0.1"` → `"0.0.2"`
 
-- [ ] 5.4 Run full test suite: `npm run test:unit`
+- [x] 5.4 Run full test suite: `npm run test:unit`
 
-- [ ] 5.5 Package: `npx vsce package --no-dependencies`
+- [x] 5.5 Package: `npx vsce package --no-dependencies`
 
-- [ ] 5.6 Publish: `npx vsce publish --no-dependencies`
+- [x] 5.6 Publish: `npx vsce publish --no-dependencies`
 
-- [ ] 5.7 Commit + PR: `"086: ape-vscode v0.0.2 — APE Init + command guards"`
+- [x] 5.7 Commit + PR: `"086: ape-vscode v0.0.2 — APE Init + command guards"`
 
 ---
 


### PR DESCRIPTION
Closes #86

## Summary

VS Code extension v0.0.2 adds onboarding via \APE: Init\ command and fixes v0.0.1 bug where commands silently created \.ape/\ files without CLI validation.

### Added
- \APE: Init\ command — detects CLI, installs if missing (Windows + Linux), runs \^Gpe init\
- Guard clause on all commands — validates CLI + workspace before executing
- Cross-platform install with \window.withProgress\ + \>>>\ marker parsing
- \onCommand:ape.init\ activation event (breaks chicken-and-egg problem)

### Fixed
- Commands no longer silently create \.ape/\ without CLI validation (\s.mkdirSync\ removed)

### Stats
- 55 unit tests passing (was 29)
- 6 new source files: \guard.ts\, \command-guard.ts\, \init.ts\, \installer.ts\ + tests
- Published to Marketplace as \ccisnedev.ape-vscode v0.0.2\

## Checklist
- [x] All tests pass (55 passing)
- [x] CHANGELOG updated
- [x] Version bumped (0.0.1 → 0.0.2)
- [x] Published to VS Code Marketplace