### PR TITLE
088: fix Marketplace virus scan — download-then-execute installer

### DIFF
--- a/code/vscode/.vscodeignore
+++ b/code/vscode/.vscodeignore
@@ -8,3 +8,4 @@ tsconfig.json
 **/*.ts
 **/*.map
 .gitignore
+docs/**

--- a/code/vscode/CHANGELOG.md
+++ b/code/vscode/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.0.3] - 2026-04-19
+
+### Fixed
+- Installer uses download-then-execute pattern instead of pipe-to-exec (fixes Marketplace virus scan failure)
+- Exclude `docs/` from `.vsix` package
+
+### Changed
+- `getInstallCommand` replaced by `getInstallScriptUrl` + `getRunCommand` (two-step: download to temp, then execute file)
+- Installer now downloads script to `%TEMP%`/`/tmp` via Node.js `https.get`, then runs with `powershell -File` / `bash`
+
 ## [0.0.2] - 2026-04-19
 
 ### Added

--- a/code/vscode/package.json
+++ b/code/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "ape-vscode",
   "displayName": "APE",
   "publisher": "ccisnedev",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "APE — Autonomous Programming Engine for VS Code",
   "license": "MIT",
   "icon": "assets/icon.png",

--- a/code/vscode/src/installer.ts
+++ b/code/vscode/src/installer.ts
@@ -1,16 +1,30 @@
 import { EventEmitter } from 'events';
+import * as path from 'path';
+import * as os from 'os';
 
-export function getInstallCommand(platform: string): { shell: string; args: string[] } {
+const INSTALL_BASE_URL = 'https://www.ccisne.dev/finite_ape_machine';
+
+export function getInstallScriptUrl(platform: string): { url: string; filename: string } {
+  if (platform === 'win32') {
+    return { url: `${INSTALL_BASE_URL}/install.ps1`, filename: 'ape-install.ps1' };
+  }
+  if (platform === 'linux') {
+    return { url: `${INSTALL_BASE_URL}/install.sh`, filename: 'ape-install.sh' };
+  }
+  throw new Error(`Unsupported platform: ${platform}`);
+}
+
+export function getRunCommand(platform: string, scriptPath: string): { shell: string; args: string[] } {
   if (platform === 'win32') {
     return {
       shell: 'powershell',
-      args: ['-NoProfile', '-Command', 'irm https://www.ccisne.dev/finite_ape_machine/install.ps1 | iex'],
+      args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', scriptPath],
     };
   }
   if (platform === 'linux') {
     return {
       shell: 'bash',
-      args: ['-c', 'curl -fsSL https://www.ccisne.dev/finite_ape_machine/install.sh | bash'],
+      args: [scriptPath],
     };
   }
   throw new Error(`Unsupported platform: ${platform}`);
@@ -30,10 +44,34 @@ interface CancellationTokenLike {
 export interface InstallerDeps {
   platform: string;
   spawn(cmd: string, args: string[]): ChildProcessLike;
+  downloadFile(url: string, destPath: string): Promise<void>;
   withProgress(
     options: { location: number; title: string; cancellable: boolean },
     task: (progress: { report(value: { message?: string }): void }, token: CancellationTokenLike) => Promise<void>,
   ): Promise<void>;
+  tmpdir(): string;
+}
+
+function defaultDownloadFile(url: string, destPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const https = require('https');
+    const fs = require('fs');
+    const file = fs.createWriteStream(destPath);
+    https.get(url, (res: any) => {
+      if (res.statusCode !== 200) {
+        file.close();
+        fs.unlinkSync(destPath);
+        reject(new Error(`Download failed: HTTP ${res.statusCode}`));
+        return;
+      }
+      res.pipe(file);
+      file.on('finish', () => { file.close(resolve); });
+    }).on('error', (err: Error) => {
+      file.close();
+      try { fs.unlinkSync(destPath); } catch { /* ignore */ }
+      reject(err);
+    });
+  });
 }
 
 export async function installApeCli(deps?: Partial<InstallerDeps>): Promise<void> {
@@ -42,16 +80,25 @@ export async function installApeCli(deps?: Partial<InstallerDeps>): Promise<void
     const cp = require('child_process');
     return cp.spawn(cmd, args);
   });
+  const downloadFile = deps?.downloadFile ?? defaultDownloadFile;
+  const tmpdir = deps?.tmpdir ?? (() => os.tmpdir());
   const withProgress = deps?.withProgress ?? (() => {
     const vscode = require('vscode');
     return vscode.window.withProgress.bind(vscode.window);
   })();
 
-  const { shell, args } = getInstallCommand(platform);
+  const { url, filename } = getInstallScriptUrl(platform);
+  const scriptPath = path.join(tmpdir(), filename);
 
   await withProgress(
     { location: 15, title: 'Installing APE CLI...', cancellable: true },
-    (progress: { report(value: { message?: string }): void }, token: CancellationTokenLike) => {
+    async (progress: { report(value: { message?: string }): void }, token: CancellationTokenLike) => {
+      progress.report({ message: 'Downloading installer...' });
+      await downloadFile(url, scriptPath);
+
+      progress.report({ message: 'Running installer...' });
+      const { shell, args } = getRunCommand(platform, scriptPath);
+
       return new Promise<void>((resolve, reject) => {
         const proc = spawn(shell, args);
 

--- a/code/vscode/test/unit/installer.test.ts
+++ b/code/vscode/test/unit/installer.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { EventEmitter } from 'events';
-import { getInstallCommand, installApeCli, InstallerDeps } from '../../src/installer';
+import { getInstallScriptUrl, getRunCommand, installApeCli, InstallerDeps } from '../../src/installer';
 
 function createMockProcess() {
   const proc = {
@@ -18,92 +18,105 @@ function createMockProcess() {
   return proc;
 }
 
-function createMockWithProgress() {
-  return async <T>(
-    _options: { location: number; title: string; cancellable: boolean },
-    task: (progress: { report(value: { message?: string }): void }, token: { onCancellationRequested(listener: () => void): void }) => Promise<T>,
-  ): Promise<T> => {
-    const reports: { message?: string }[] = [];
-    const progress = { report: (value: { message?: string }) => { reports.push(value); } };
-    let cancelListener: (() => void) | undefined;
-    const token = { onCancellationRequested: (listener: () => void) => { cancelListener = listener; } };
-    const result = task(progress, token);
-    (createMockWithProgress as any)._reports = reports;
-    (createMockWithProgress as any)._cancelListener = cancelListener;
-    return result;
-  };
-}
-
-describe('getInstallCommand', () => {
-  it('returns powershell command on win32', () => {
-    const cmd = getInstallCommand('win32');
-    assert.strictEqual(cmd.shell, 'powershell');
-    assert.deepStrictEqual(cmd.args, [
-      '-NoProfile', '-Command',
-      'irm https://www.ccisne.dev/finite_ape_machine/install.ps1 | iex',
-    ]);
+describe('getInstallScriptUrl', () => {
+  it('returns ps1 URL on win32', () => {
+    const result = getInstallScriptUrl('win32');
+    assert.strictEqual(result.url, 'https://www.ccisne.dev/finite_ape_machine/install.ps1');
+    assert.strictEqual(result.filename, 'ape-install.ps1');
   });
 
-  it('returns bash command on linux', () => {
-    const cmd = getInstallCommand('linux');
-    assert.strictEqual(cmd.shell, 'bash');
-    assert.deepStrictEqual(cmd.args, [
-      '-c', 'curl -fsSL https://www.ccisne.dev/finite_ape_machine/install.sh | bash',
-    ]);
+  it('returns sh URL on linux', () => {
+    const result = getInstallScriptUrl('linux');
+    assert.strictEqual(result.url, 'https://www.ccisne.dev/finite_ape_machine/install.sh');
+    assert.strictEqual(result.filename, 'ape-install.sh');
   });
 
   it('throws on unsupported platform', () => {
-    assert.throws(() => getInstallCommand('darwin'), /Unsupported platform: darwin/);
+    assert.throws(() => getInstallScriptUrl('darwin'), /Unsupported platform: darwin/);
+  });
+});
+
+describe('getRunCommand', () => {
+  it('returns powershell -File on win32', () => {
+    const cmd = getRunCommand('win32', 'C:\\temp\\ape-install.ps1');
+    assert.strictEqual(cmd.shell, 'powershell');
+    assert.deepStrictEqual(cmd.args, [
+      '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', 'C:\\temp\\ape-install.ps1',
+    ]);
+  });
+
+  it('returns bash on linux', () => {
+    const cmd = getRunCommand('linux', '/tmp/ape-install.sh');
+    assert.strictEqual(cmd.shell, 'bash');
+    assert.deepStrictEqual(cmd.args, ['/tmp/ape-install.sh']);
+  });
+
+  it('throws on unsupported platform', () => {
+    assert.throws(() => getRunCommand('darwin', '/tmp/x'), /Unsupported platform: darwin/);
   });
 });
 
 describe('installApeCli', () => {
-  it('spawns powershell on win32', async () => {
+  const tick = () => new Promise(r => setTimeout(r, 0));
+
+  it('downloads then spawns powershell -File on win32', async () => {
     const mockProc = createMockProcess();
     let spawnedCmd = '';
     let spawnedArgs: string[] = [];
+    let downloadedUrl = '';
+    let downloadedDest = '';
 
     const deps: InstallerDeps = {
       platform: 'win32',
+      tmpdir: () => 'C:\\temp',
+      downloadFile: async (url, dest) => { downloadedUrl = url; downloadedDest = dest; },
       spawn: (cmd, args) => { spawnedCmd = cmd; spawnedArgs = args; return mockProc; },
       withProgress: async (_opts, task) => {
         const reports: { message?: string }[] = [];
         const progress = { report: (v: { message?: string }) => { reports.push(v); } };
         const token = { onCancellationRequested: () => {} };
         const promise = task(progress, token);
-        mockProc.stdout.emit('data', '>>> Downloading...\n');
+        await tick();
+        mockProc.stdout.emit('data', '>>> Installing...\n');
         mockProc.emit_close(0);
         await promise;
-        assert.strictEqual(reports.length, 1);
-        assert.strictEqual(reports[0].message, 'Downloading...');
+        assert.ok(reports.some(r => r.message === 'Downloading installer...'));
+        assert.ok(reports.some(r => r.message === 'Running installer...'));
+        assert.ok(reports.some(r => r.message === 'Installing...'));
       },
     };
 
     await installApeCli(deps);
+    assert.strictEqual(downloadedUrl, 'https://www.ccisne.dev/finite_ape_machine/install.ps1');
+    assert.strictEqual(downloadedDest, 'C:\\temp\\ape-install.ps1');
     assert.strictEqual(spawnedCmd, 'powershell');
     assert.deepStrictEqual(spawnedArgs, [
-      '-NoProfile', '-Command',
-      'irm https://www.ccisne.dev/finite_ape_machine/install.ps1 | iex',
+      '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', 'C:\\temp\\ape-install.ps1',
     ]);
   });
 
-  it('spawns bash on linux', async () => {
+  it('downloads then spawns bash on linux', async () => {
     const mockProc = createMockProcess();
     let spawnedCmd = '';
+    let downloadedUrl = '';
 
     const deps: InstallerDeps = {
       platform: 'linux',
-      spawn: (cmd, args) => { spawnedCmd = cmd; return mockProc; },
+      tmpdir: () => '/tmp',
+      downloadFile: async (url) => { downloadedUrl = url; },
+      spawn: (cmd) => { spawnedCmd = cmd; return mockProc; },
       withProgress: async (_opts, task) => {
         const progress = { report: () => {} };
         const token = { onCancellationRequested: () => {} };
         const promise = task(progress, token);
+        await tick();
         mockProc.emit_close(0);
         await promise;
       },
     };
 
     await installApeCli(deps);
+    assert.strictEqual(downloadedUrl, 'https://www.ccisne.dev/finite_ape_machine/install.sh');
     assert.strictEqual(spawnedCmd, 'bash');
   });
 
@@ -112,11 +125,14 @@ describe('installApeCli', () => {
 
     const deps: InstallerDeps = {
       platform: 'win32',
+      tmpdir: () => 'C:\\temp',
+      downloadFile: async () => {},
       spawn: () => mockProc,
       withProgress: async (_opts, task) => {
         const progress = { report: () => {} };
         const token = { onCancellationRequested: () => {} };
         const promise = task(progress, token);
+        await tick();
         mockProc.emit_close(1);
         return promise;
       },
@@ -125,17 +141,36 @@ describe('installApeCli', () => {
     await assert.rejects(() => installApeCli(deps), /Install failed \(exit 1\)/);
   });
 
+  it('rejects on download failure', async () => {
+    const deps: InstallerDeps = {
+      platform: 'win32',
+      tmpdir: () => 'C:\\temp',
+      downloadFile: async () => { throw new Error('Network error'); },
+      spawn: () => { throw new Error('should not spawn'); },
+      withProgress: async (_opts, task) => {
+        const progress = { report: () => {} };
+        const token = { onCancellationRequested: () => {} };
+        return task(progress, token);
+      },
+    };
+
+    await assert.rejects(() => installApeCli(deps), /Network error/);
+  });
+
   it('kills process on cancellation', async () => {
     const mockProc = createMockProcess();
 
     const deps: InstallerDeps = {
       platform: 'win32',
+      tmpdir: () => 'C:\\temp',
+      downloadFile: async () => {},
       spawn: () => mockProc,
       withProgress: async (_opts, task) => {
         const progress = { report: () => {} };
         let cancelFn: (() => void) | undefined;
         const token = { onCancellationRequested: (listener: () => void) => { cancelFn = listener; } };
         const promise = task(progress, token);
+        await tick();
         cancelFn!();
         try { await promise; } catch { /* expected */ }
       },
@@ -149,17 +184,20 @@ describe('installApeCli', () => {
     assert.strictEqual(mockProc._killed, true);
   });
 
-  it('reports multiple progress milestones', async () => {
+  it('reports multiple progress milestones from stdout', async () => {
     const mockProc = createMockProcess();
     const reports: { message?: string }[] = [];
 
     const deps: InstallerDeps = {
       platform: 'linux',
+      tmpdir: () => '/tmp',
+      downloadFile: async () => {},
       spawn: () => mockProc,
       withProgress: async (_opts, task) => {
         const progress = { report: (v: { message?: string }) => { reports.push(v); } };
         const token = { onCancellationRequested: () => {} };
         const promise = task(progress, token);
+        await tick();
         mockProc.stdout.emit('data', '>>> Fetching...\n>>> Downloading...\n>>> Extracting...\n');
         mockProc.emit_close(0);
         await promise;
@@ -167,9 +205,9 @@ describe('installApeCli', () => {
     };
 
     await installApeCli(deps);
-    assert.strictEqual(reports.length, 3);
-    assert.strictEqual(reports[0].message, 'Fetching...');
-    assert.strictEqual(reports[1].message, 'Downloading...');
-    assert.strictEqual(reports[2].message, 'Extracting...');
+    // 2 built-in reports (Downloading installer..., Running installer...) + 3 from stdout
+    assert.ok(reports.some(r => r.message === 'Fetching...'));
+    assert.ok(reports.some(r => r.message === 'Downloading...'));
+    assert.ok(reports.some(r => r.message === 'Extracting...'));
   });
 });


### PR DESCRIPTION
Closes #88

## Summary

v0.0.2 failed the Marketplace virus scan because installer.ts contained pipe-to-exec patterns (\irm URL | iex\, \curl | bash\).

### Fix
- Download install script to temp file via Node.js \https.get\
- Execute the local file with \powershell -File\ / \ash\
- Matches Dart-Code/Flutter extension pattern (safeToolSpawn)

### Also
- Exclude \docs/**\ from .vsix package
- 59 tests passing (was 55)

## Checklist
- [x] All tests pass (59 passing)
- [x] CHANGELOG updated
- [x] Version bumped (0.0.2 → 0.0.3)