### PR TITLE
v0.0.15: ape doctor target verification

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.0.15]
+### Added
+- **Target verification in `ape doctor`** (#96): Verify agent and skill deployment per target
+  - Check `.ape/` directory existence with `ape init` remediation suggestion
+  - Check agent file existence in `~/.copilot/agents/`
+  - Dynamic skill discovery from asset tree (no hardcoded list)
+  - Asymmetric verbosity: clean output when OK, detailed errors with remediation
+  - Exit code 1 when target checks fail
+  - `FileSystemOps` abstraction for testable filesystem access
+  - 8 new tests covering Scenarios A-D (all pass, nothing deployed, no init, partial)
+  - Cross-platform validated: Windows + Linux (WSL)
+
 ## [0.0.14]
 ### Added
 - **EVOLUTION infrastructure** (#68): `.ape/config.yaml` + `.ape/mutations.md` lifecycle

--- a/code/cli/lib/modules/global/commands/doctor.dart
+++ b/code/cli/lib/modules/global/commands/doctor.dart
@@ -1,14 +1,18 @@
-/// Doctor command — verifies prerequisites.
+/// Doctor command — verifies prerequisites and target deployment.
 ///
-/// Checks: ape version, git, gh, gh auth.
+/// Checks: ape version, git, gh, gh auth, .ape/ init, target deployment.
 library;
 
 import 'dart:io';
 
 import 'package:cli_router/cli_router.dart';
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
+import 'package:path/path.dart' as p;
 
+import '../../../assets.dart';
 import '../../../src/version.dart' as version_lib;
+import '../../../targets/copilot_adapter.dart';
+import '../../../targets/target_adapter.dart';
 
 /// Function type for running external processes.
 ///
@@ -26,18 +30,48 @@ class DoctorCheck {
   final bool passed;
   final String? version;
   final String? error;
+  final String? remediation;
 
   DoctorCheck({
     required this.name,
     required this.passed,
     this.version,
     this.error,
+    this.remediation,
   });
 
   Map<String, dynamic> toJson() => {
     'name': name,
     'passed': passed,
     if (version != null) 'version': version,
+    if (error != null) 'error': error,
+    if (remediation != null) 'remediation': remediation,
+  };
+}
+
+/// Result of checking a target's deployment status.
+class TargetCheck {
+  final String targetName;
+  final bool agentExists;
+  final List<String> missingSkills;
+  final int totalSkills;
+  final String? error;
+
+  TargetCheck({
+    required this.targetName,
+    required this.agentExists,
+    required this.missingSkills,
+    required this.totalSkills,
+    this.error,
+  });
+
+  bool get passed => agentExists && missingSkills.isEmpty && error == null;
+
+  Map<String, dynamic> toJson() => {
+    'targetName': targetName,
+    'agentExists': agentExists,
+    'missingSkills': missingSkills,
+    'totalSkills': totalSkills,
     if (error != null) 'error': error,
   };
 }
@@ -57,13 +91,19 @@ class DoctorInput extends Input {
 /// Output for the doctor command.
 class DoctorOutput extends Output {
   final List<DoctorCheck> checks;
+  final List<TargetCheck> targetChecks;
   final bool passed;
 
-  DoctorOutput({required this.checks, required this.passed});
+  DoctorOutput({
+    required this.checks,
+    this.targetChecks = const [],
+    required this.passed,
+  });
 
   @override
   Map<String, dynamic> toJson() => {
     'checks': checks.map((c) => c.toJson()).toList(),
+    'targetChecks': targetChecks.map((c) => c.toJson()).toList(),
     'passed': passed,
   };
 
@@ -82,19 +122,77 @@ class DoctorOutput extends Output {
       } else {
         buffer.writeln('  $icon ${check.name}');
       }
+      if (!check.passed && check.remediation != null) {
+        buffer.writeln("    → ${check.remediation}");
+      }
     }
+
+    if (targetChecks.isNotEmpty) {
+      buffer.writeln('Checking targets...');
+      for (final tc in targetChecks) {
+        if (tc.error != null) {
+          buffer.writeln('  ✗ ${tc.targetName}: ${tc.error}');
+        } else if (tc.passed) {
+          final deployed = tc.totalSkills - tc.missingSkills.length;
+          buffer.writeln(
+            '  ✓ ${tc.targetName}: agent + $deployed skills deployed',
+          );
+        } else {
+          if (!tc.agentExists) {
+            buffer.writeln('  ✗ ${tc.targetName}: agent not deployed');
+          } else {
+            buffer.writeln('  ✓ ${tc.targetName}: agent deployed');
+          }
+          if (tc.missingSkills.isNotEmpty) {
+            buffer.writeln(
+              '  ✗ ${tc.targetName}: missing skills: '
+              '${tc.missingSkills.join(', ')}',
+            );
+          }
+          buffer.writeln("    → Run 'ape target get' to deploy");
+        }
+      }
+    }
+
     buffer.writeln();
     buffer.write(passed ? 'All checks passed.' : 'Some checks failed.');
     return buffer.toString();
   }
 }
 
-/// Command that verifies all prerequisites are installed.
+/// Abstraction for filesystem operations (testable).
+abstract class FileSystemOps {
+  bool fileExists(String path);
+  bool directoryExists(String path);
+  String homeDirectory();
+}
+
+/// Production implementation using dart:io.
+class RealFileSystemOps implements FileSystemOps {
+  @override
+  bool fileExists(String path) => File(path).existsSync();
+
+  @override
+  bool directoryExists(String path) => Directory(path).existsSync();
+
+  @override
+  String homeDirectory() {
+    final home =
+        Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'];
+    if (home != null && home.isNotEmpty) return home;
+    return Directory.current.path;
+  }
+}
+
+/// Command that verifies all prerequisites and target deployment.
 class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
   @override
   final DoctorInput input;
 
   final ProcessRunner _runProcess;
+  final FileSystemOps _fileSystem;
+  final Assets? _assets;
+  final List<TargetAdapter> _activeAdapters;
 
   /// Current APE version (injected for testability).
   final String apeVersion;
@@ -103,7 +201,13 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
     this.input, {
     ProcessRunner? runProcess,
     String? apeVersionOverride,
+    FileSystemOps? fileSystemOps,
+    Assets? assets,
+    List<TargetAdapter>? activeAdapters,
   }) : _runProcess = runProcess ?? Process.run,
+       _fileSystem = fileSystemOps ?? RealFileSystemOps(),
+       _assets = assets,
+       _activeAdapters = activeAdapters ?? [CopilotAdapter()],
        apeVersion = apeVersionOverride ?? version_lib.apeVersion;
 
   @override
@@ -112,7 +216,7 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
   @override
   Future<DoctorOutput> execute() async {
     final checks = <DoctorCheck>[];
-    var allPassed = true;
+    var prereqPassed = true;
 
     // Check 1: APE version (always passes, internal)
     checks.add(DoctorCheck(name: 'ape', passed: true, version: apeVersion));
@@ -126,7 +230,7 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
     );
     checks.add(gitCheck);
     if (!gitCheck.passed) {
-      allPassed = false;
+      prereqPassed = false;
       return DoctorOutput(checks: checks, passed: false);
     }
 
@@ -139,7 +243,7 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
     );
     checks.add(ghCheck);
     if (!ghCheck.passed) {
-      allPassed = false;
+      prereqPassed = false;
       return DoctorOutput(checks: checks, passed: false);
     }
 
@@ -148,14 +252,80 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
       name: 'gh auth',
       executable: 'gh',
       arguments: ['auth', 'status'],
-      versionExtractor: (_) => null, // No version for auth
+      versionExtractor: (_) => null,
     );
     checks.add(authCheck);
     if (!authCheck.passed) {
-      allPassed = false;
+      prereqPassed = false;
     }
 
-    return DoctorOutput(checks: checks, passed: allPassed);
+    // Check 5: .ape/ directory (init)
+    final initExists = _fileSystem.directoryExists('.ape');
+    if (!initExists) {
+      checks.add(
+        DoctorCheck(
+          name: 'ape init',
+          passed: false,
+          error: 'not initialized',
+          remediation: "Run 'ape init' to initialize",
+        ),
+      );
+      prereqPassed = false;
+    }
+
+    // Target checks
+    final targetChecks = <TargetCheck>[];
+    for (final adapter in _activeAdapters) {
+      targetChecks.add(_verifyTarget(adapter));
+    }
+
+    final targetsPassed = targetChecks.every((tc) => tc.passed);
+
+    return DoctorOutput(
+      checks: checks,
+      targetChecks: targetChecks,
+      passed: prereqPassed && targetsPassed,
+    );
+  }
+
+  /// Discovers expected skills from the asset tree.
+  List<String> _getExpectedSkills() {
+    if (_assets == null) return [];
+    try {
+      return _assets.listDirectory('skills');
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// Verifies a single target adapter's deployment.
+  TargetCheck _verifyTarget(TargetAdapter adapter) {
+    final homeDir = _fileSystem.homeDirectory();
+    final expectedSkills = _getExpectedSkills();
+
+    // Check agent
+    final agentPath = p.join(adapter.agentDirectory(homeDir), 'ape.agent.md');
+    final agentExists = _fileSystem.fileExists(agentPath);
+
+    // Check skills
+    final missingSkills = <String>[];
+    for (final skill in expectedSkills) {
+      final skillPath = p.join(
+        adapter.skillsDirectory(homeDir),
+        skill,
+        'SKILL.md',
+      );
+      if (!_fileSystem.fileExists(skillPath)) {
+        missingSkills.add(skill);
+      }
+    }
+
+    return TargetCheck(
+      targetName: adapter.name,
+      agentExists: agentExists,
+      missingSkills: missingSkills,
+      totalSkills: expectedSkills.length,
+    );
   }
 
   /// Runs a command and returns a [DoctorCheck] with the result.

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String apeVersion = '0.0.14';
+const String apeVersion = '0.0.15';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ape_cli
 description: >
   CLI for the finite ape machine — workspace initialization and orchestration.
-version: 0.0.14
+version: 0.0.15
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/doctor_test.dart
+++ b/code/cli/test/doctor_test.dart
@@ -1,7 +1,29 @@
 import 'dart:io';
 
+import 'package:ape_cli/assets.dart';
 import 'package:ape_cli/modules/global/commands/doctor.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
+
+/// Mock filesystem for testing doctor target checks.
+class MockFileSystemOps implements FileSystemOps {
+  final Map<String, bool> _files = {};
+  final Map<String, bool> _dirs = {};
+  String _home = '/home/testuser';
+
+  void setFileExists(String path, bool exists) => _files[path] = exists;
+  void setDirectoryExists(String path, bool exists) => _dirs[path] = exists;
+  void setHome(String home) => _home = home;
+
+  @override
+  bool fileExists(String path) => _files[path] ?? false;
+
+  @override
+  bool directoryExists(String path) => _dirs[path] ?? false;
+
+  @override
+  String homeDirectory() => _home;
+}
 
 void main() {
   group('DoctorCommand', () {
@@ -55,13 +77,60 @@ void main() {
       };
     }
 
-    test('all checks pass → exit 0', () async {
-      final cmd = DoctorCommand(
-        DoctorInput(),
-        runProcess: fakeRunner(),
-        apeVersionOverride: '0.0.9',
-      );
+    /// Creates a mock FS where .ape/ exists and all targets are deployed.
+    MockFileSystemOps allPassFs(String home, List<String> skills) {
+      final fs = MockFileSystemOps()..setHome(home);
+      fs.setDirectoryExists('.ape', true);
+      fs.setFileExists(p.join(home, '.copilot', 'agents', 'ape.agent.md'), true);
+      for (final skill in skills) {
+        fs.setFileExists(
+          p.join(home, '.copilot', 'skills', skill, 'SKILL.md'),
+          true,
+        );
+      }
+      return fs;
+    }
 
+    /// Creates a temp Assets directory with the given skill names.
+    late Directory tempDir;
+    late Assets testAssets;
+    final testSkills = ['issue-start', 'issue-end', 'memory-read', 'memory-write'];
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('doctor_test_');
+      final skillsDir = Directory(p.join(tempDir.path, 'assets', 'skills'));
+      for (final skill in testSkills) {
+        final skillDir = Directory(p.join(skillsDir.path, skill));
+        skillDir.createSync(recursive: true);
+        File(p.join(skillDir.path, 'SKILL.md')).writeAsStringSync('---\nname: $skill\n---');
+      }
+      final agentsDir = Directory(p.join(tempDir.path, 'assets', 'agents'));
+      agentsDir.createSync(recursive: true);
+      File(p.join(agentsDir.path, 'ape.agent.md')).writeAsStringSync('# Agent');
+      testAssets = Assets(root: tempDir.path);
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    DoctorCommand makeCmd({
+      ProcessRunner? runProcess,
+      String version = '0.0.9',
+      MockFileSystemOps? fs,
+      Assets? assets,
+    }) {
+      return DoctorCommand(
+        DoctorInput(),
+        runProcess: runProcess ?? fakeRunner(),
+        apeVersionOverride: version,
+        fileSystemOps: fs ?? allPassFs('/home/testuser', testSkills),
+        assets: assets ?? testAssets,
+      );
+    }
+
+    test('all checks pass → exit 0', () async {
+      final cmd = makeCmd();
       final output = await cmd.execute();
 
       expect(output.passed, isTrue);
@@ -71,12 +140,7 @@ void main() {
     });
 
     test('git missing → exit 1, stopped at git', () async {
-      final cmd = DoctorCommand(
-        DoctorInput(),
-        runProcess: fakeRunner(gitFails: true),
-        apeVersionOverride: '0.0.9',
-      );
-
+      final cmd = makeCmd(runProcess: fakeRunner(gitFails: true));
       final output = await cmd.execute();
 
       expect(output.passed, isFalse);
@@ -88,12 +152,7 @@ void main() {
     });
 
     test('gh missing → exit 1', () async {
-      final cmd = DoctorCommand(
-        DoctorInput(),
-        runProcess: fakeRunner(ghFails: true),
-        apeVersionOverride: '0.0.9',
-      );
-
+      final cmd = makeCmd(runProcess: fakeRunner(ghFails: true));
       final output = await cmd.execute();
 
       expect(output.passed, isFalse);
@@ -104,12 +163,7 @@ void main() {
     });
 
     test('gh auth fails → exit 1', () async {
-      final cmd = DoctorCommand(
-        DoctorInput(),
-        runProcess: fakeRunner(ghAuthFails: true),
-        apeVersionOverride: '0.0.9',
-      );
-
+      final cmd = makeCmd(runProcess: fakeRunner(ghAuthFails: true));
       final output = await cmd.execute();
 
       expect(output.passed, isFalse);
@@ -120,18 +174,15 @@ void main() {
     });
 
     test('toJson() returns correct structure', () async {
-      final cmd = DoctorCommand(
-        DoctorInput(),
-        runProcess: fakeRunner(),
-        apeVersionOverride: '0.0.9',
-      );
-
+      final cmd = makeCmd();
       final output = await cmd.execute();
       final json = output.toJson();
 
       expect(json, containsPair('passed', true));
       expect(json['checks'], isList);
       expect((json['checks'] as List).length, 4);
+      expect(json['targetChecks'], isList);
+      expect((json['targetChecks'] as List).length, 1);
 
       final firstCheck = (json['checks'] as List).first as Map<String, dynamic>;
       expect(firstCheck, containsPair('name', 'ape'));
@@ -156,12 +207,7 @@ void main() {
     });
 
     test('toText() returns formatted checkmarks when all pass', () async {
-      final cmd = DoctorCommand(
-        DoctorInput(),
-        runProcess: fakeRunner(),
-        apeVersionOverride: '0.0.10',
-      );
-
+      final cmd = makeCmd(version: '0.0.10');
       final output = await cmd.execute();
       final text = output.toText()!;
 
@@ -173,18 +219,170 @@ void main() {
     });
 
     test('toText() shows failure indicators when check fails', () async {
-      final cmd = DoctorCommand(
-        DoctorInput(),
-        runProcess: fakeRunner(gitFails: true),
-        apeVersionOverride: '0.0.10',
-      );
-
+      final cmd = makeCmd(runProcess: fakeRunner(gitFails: true));
       final output = await cmd.execute();
       final text = output.toText()!;
 
       expect(text, contains('✓ ape'));
       expect(text, contains('✗ git'));
       expect(text, contains('Some checks failed.'));
+    });
+
+    group('Target verification', () {
+      test('Scenario A: all targets deployed → exit 0', () async {
+        final cmd = makeCmd();
+        final output = await cmd.execute();
+
+        expect(output.passed, isTrue);
+        expect(output.exitCode, 0);
+        expect(output.targetChecks.length, 1);
+        expect(output.targetChecks.first.passed, isTrue);
+        expect(output.targetChecks.first.agentExists, isTrue);
+        expect(output.targetChecks.first.missingSkills, isEmpty);
+
+        final text = output.toText()!;
+        expect(text, contains('Checking targets...'));
+        expect(text, contains('✓ copilot: agent + 4 skills deployed'));
+        expect(text, contains('All checks passed.'));
+      });
+
+      test('Scenario B: nothing deployed → exit 1', () async {
+        final fs = MockFileSystemOps()..setHome('/home/testuser');
+        fs.setDirectoryExists('.ape', true);
+        // Agent and skills do NOT exist
+
+        final cmd = makeCmd(fs: fs);
+        final output = await cmd.execute();
+
+        expect(output.passed, isFalse);
+        expect(output.exitCode, 1);
+        expect(output.targetChecks.first.agentExists, isFalse);
+        expect(output.targetChecks.first.missingSkills,
+            unorderedEquals(testSkills));
+
+        final text = output.toText()!;
+        expect(text, contains('✗ copilot: agent not deployed'));
+        expect(text, contains('✗ copilot: missing skills:'));
+        expect(text, contains("Run 'ape target get' to deploy"));
+        expect(text, contains('Some checks failed.'));
+      });
+
+      test('Scenario C: no .ape/ directory → exit 1', () async {
+        final fs = MockFileSystemOps()..setHome('/home/testuser');
+        // .ape does NOT exist, targets do NOT exist
+
+        final cmd = makeCmd(fs: fs);
+        final output = await cmd.execute();
+
+        expect(output.passed, isFalse);
+        expect(output.exitCode, 1);
+
+        // Init check failed
+        final initCheck = output.checks.firstWhere(
+          (c) => c.name == 'ape init',
+        );
+        expect(initCheck.passed, isFalse);
+
+        final text = output.toText()!;
+        expect(text, contains('✗ ape init'));
+        expect(text, contains("Run 'ape init' to initialize"));
+        expect(text, contains('✗ copilot: agent not deployed'));
+        expect(text, contains("Run 'ape target get' to deploy"));
+      });
+
+      test('Scenario D: partial deployment → exit 1', () async {
+        final fs = MockFileSystemOps()..setHome('/home/testuser');
+        fs.setDirectoryExists('.ape', true);
+        fs.setFileExists(
+          p.join('/home/testuser', '.copilot', 'agents', 'ape.agent.md'),
+          true,
+        );
+        // Deploy only 3 of 4 skills
+        for (final skill in ['issue-start', 'issue-end', 'memory-write']) {
+          fs.setFileExists(
+            p.join('/home/testuser', '.copilot', 'skills', skill, 'SKILL.md'),
+            true,
+          );
+        }
+        // memory-read is MISSING
+
+        final cmd = makeCmd(fs: fs);
+        final output = await cmd.execute();
+
+        expect(output.passed, isFalse);
+        expect(output.exitCode, 1);
+        expect(output.targetChecks.first.agentExists, isTrue);
+        expect(output.targetChecks.first.missingSkills, ['memory-read']);
+
+        final text = output.toText()!;
+        expect(text, contains('✓ copilot: agent deployed'));
+        expect(text, contains('✗ copilot: missing skills: memory-read'));
+        expect(text, contains("Run 'ape target get' to deploy"));
+      });
+
+      test('TargetCheck.toJson() includes all fields', () {
+        final check = TargetCheck(
+          targetName: 'copilot',
+          agentExists: true,
+          missingSkills: ['memory-read'],
+          totalSkills: 4,
+        );
+
+        final json = check.toJson();
+        expect(json['targetName'], 'copilot');
+        expect(json['agentExists'], true);
+        expect(json['missingSkills'], ['memory-read']);
+        expect(json['totalSkills'], 4);
+        expect(json.containsKey('error'), isFalse);
+      });
+
+      test('TargetCheck.passed is true when agent exists and no missing skills', () {
+        final passing = TargetCheck(
+          targetName: 'copilot',
+          agentExists: true,
+          missingSkills: [],
+          totalSkills: 4,
+        );
+        expect(passing.passed, isTrue);
+
+        final failing = TargetCheck(
+          targetName: 'copilot',
+          agentExists: false,
+          missingSkills: ['x'],
+          totalSkills: 1,
+        );
+        expect(failing.passed, isFalse);
+      });
+
+      test('DoctorCheck.toJson() includes remediation when present', () {
+        final check = DoctorCheck(
+          name: 'ape init',
+          passed: false,
+          error: 'not initialized',
+          remediation: "Run 'ape init' to initialize",
+        );
+
+        final json = check.toJson();
+        expect(json['remediation'], "Run 'ape init' to initialize");
+      });
+
+      test('no assets available → targets still checked, 0 skills expected', () async {
+        final fs = allPassFs('/home/testuser', []);
+        // Assets with empty skills dir
+        final emptyTempDir = Directory.systemTemp.createTempSync('empty_assets_');
+        Directory(p.join(emptyTempDir.path, 'assets', 'skills')).createSync(recursive: true);
+        final emptyAssets = Assets(root: emptyTempDir.path);
+
+        final cmd = makeCmd(fs: fs, assets: emptyAssets);
+        final output = await cmd.execute();
+
+        // Agent exists, 0 skills expected → passes
+        expect(output.targetChecks.first.totalSkills, 0);
+        expect(output.targetChecks.first.agentExists, isTrue);
+        expect(output.targetChecks.first.passed, isTrue);
+
+        emptyTempDir.deleteSync(recursive: true);
+      });
     });
   });
 }

--- a/docs/issues/096-doctor-target-visibility/analyze/diagnosis.md
+++ b/docs/issues/096-doctor-target-visibility/analyze/diagnosis.md
@@ -1,0 +1,214 @@
+---
+id: diagnosis
+title: Technical diagnosis - ape doctor target verification feature
+date: 2026-04-20
+status: ready-for-plan
+tags: [doctor-command, targets, agents, skills, diagnosis]
+author: SOCRATES
+---
+
+# Technical Diagnosis: ape doctor Target Verification Feature
+
+## Problem Statement
+
+**The Gap:** After a user runs `ape init`, the local APE infrastructure is initialized (`.ape/state.yaml`, `.ape/config.yaml`, `.ape/mutations.md`), but **agents and skills are NOT deployed**. Deployment is the separate responsibility of `ape target get`.
+
+**Missing Feedback:** There is no diagnostic mechanism to verify whether deployment has occurred. Users may believe their setup is complete when the agent remains invisible to Copilot.
+
+**Goal:** Extend `ape doctor` to verify agent and skill visibility in target deployment directories, bridging the gap between `ape init` and `ape target get`.
+
+---
+
+## Current State
+
+### 1. What `ape doctor` Checks Today
+
+Located in `code/cli/lib/modules/global/commands/doctor.dart`:
+
+| Check | Executable | Purpose |
+|-------|-----------|---------|
+| ape | (internal) | Reports current APE version |
+| git | `git --version` | Verifies Git is installed |
+| gh | `gh --version` | Verifies GitHub CLI is installed |
+| gh auth | `gh auth status` | Verifies GitHub authentication |
+
+**Early Exit:** If any prerequisite fails, doctor stops immediately and returns exit code 1.
+
+**Output Format:**
+```
+Checking prerequisites...
+  ✓ ape 0.0.14
+  ✓ git 2.45.1
+  ✓ gh 2.51.0
+  ✓ gh auth
+
+All checks passed.
+```
+
+### 2. What `ape init` Does and Does NOT Do
+
+Located in `code/cli/lib/modules/global/commands/init.dart`:
+
+**Init creates (7 idempotent steps):**
+1. Detects or creates `docs/` directory
+2. Creates `{docs}/issues/` if missing
+3. Adds `.ape/` to `.gitignore`
+4. Creates `.ape/state.yaml` with IDLE state
+5. Creates `.ape/config.yaml` with defaults
+6. Creates `.ape/mutations.md` with header template
+7. **Does NOT deploy** — delegated to `ape target get`
+
+### 3. What `ape target get` Deploys and Where
+
+Located in `code/cli/lib/targets/deployer.dart`:
+
+**Skills Deployment:**
+- Source: `code/cli/assets/skills/<skillName>/SKILL.md`
+- Target: `~/.copilot/skills/<skillName>/SKILL.md`
+- Dynamic discovery via `Assets.listDirectory('skills')`
+
+**Agents Deployment:**
+- Source: `code/cli/assets/agents/ape.agent.md`
+- Target: `~/.copilot/agents/ape.agent.md`
+
+**CopilotAdapter Paths** (`code/cli/lib/targets/copilot_adapter.dart`):
+- Base: `~/.copilot/`
+- Skills: `~/.copilot/skills/`
+- Agents: `~/.copilot/agents/`
+
+---
+
+## Decisions
+
+| # | Decision | Rationale |
+|----|----------|-----------|
+| **D1** | Existence-only check, no version matching | v0.0.x stage; simplicity reduces risk |
+| **D2** | Only active targets (Copilot) | MVP scope; only CopilotAdapter currently deployed |
+| **D3** | File existence in deployment dirs | Core question: "Can Copilot see the agent and skills?" |
+| **D4** | Passive verification + suggest remedy | flutter doctor pattern: diagnose, never auto-fix |
+| **D5** | Missing ~/.copilot/ = failed check | Directory absence is a deployment problem |
+| **D6** | Asymmetric verbosity: clean OK, detailed error | Passing = brief; Failure = detailed + remediation |
+| **D7** | Dynamic skill discovery from asset tree | No hardcoded list; new skills auto-verified |
+| **D8** | Only report missing items, not full tree | Focused error reporting |
+| **D9** | Missing target = fatal (exit 1) | Purpose of ape is to serve targets |
+| **D10** | No .ape/ → suggest `ape init`; then check targets separately | Two independent diagnostics, both reported |
+
+---
+
+## Expected Behavior
+
+### Scenario A: All Checks Pass
+
+```
+Checking prerequisites...
+  ✓ ape 0.0.14
+  ✓ git 2.45.1
+  ✓ gh 2.51.0
+  ✓ gh auth
+Checking targets...
+  ✓ copilot: agent + 4 skills deployed
+
+All checks passed.
+```
+
+**Exit Code:** 0
+
+### Scenario B: Target Not Deployed
+
+```
+Checking prerequisites...
+  ✓ ape 0.0.14
+  ✓ git 2.45.1
+  ✓ gh 2.51.0
+  ✓ gh auth
+Checking targets...
+  ✗ copilot: agent not deployed
+  ✗ copilot: missing skills: issue-start, issue-end, memory-read, memory-write
+    → Run 'ape target get' to deploy
+
+Some checks failed.
+```
+
+**Exit Code:** 1
+
+### Scenario C: No .ape/ Directory (Init Not Run)
+
+```
+Checking prerequisites...
+  ✓ ape 0.0.14
+  ✓ git 2.45.1
+  ✓ gh 2.51.0
+  ✓ gh auth
+  ✗ ape not initialized
+    → Run 'ape init' to initialize
+Checking targets...
+  ✗ copilot: agent not deployed
+  ✗ copilot: missing skills: issue-start, issue-end, memory-read, memory-write
+    → Run 'ape target get' to deploy
+
+Some checks failed.
+```
+
+**Exit Code:** 1
+
+### Scenario D: Partial Deployment (Agent OK, Some Skills Missing)
+
+```
+Checking prerequisites...
+  ✓ ape 0.0.14
+  ✓ git 2.45.1
+  ✓ gh 2.51.0
+  ✓ gh auth
+Checking targets...
+  ✓ copilot: agent deployed
+  ✗ copilot: missing skills: memory-read
+    → Run 'ape target get' to deploy
+
+Some checks failed.
+```
+
+**Exit Code:** 1
+
+---
+
+## Constraints
+
+- Doctor **must not modify files** (read-only diagnostic)
+- Doctor **must not create directories** (no implicit init)
+- Doctor **must not deploy** (that is `ape target get`'s responsibility)
+- Skill list is **dynamic** (discovered from assets, not hardcoded)
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Asset discovery differs between compiled binary and dev mode | Medium | Assets class abstracts discovery; root path injectable for testing |
+| Path resolution across OS (~/. on Windows vs Linux vs macOS) | Medium | Use Platform.environment HOME/USERPROFILE; verify in cross-platform tests |
+| Race condition during concurrent deployment | Low | Acceptable for v0.0.x diagnostic tool |
+
+## Scope
+
+### IN Scope
+- Prerequisite checks (ape, git, gh, gh auth) — already implemented
+- `.ape/` directory existence check
+- Agent file existence in deployment directory
+- Skills file existence in deployment directories
+- Dynamic skill discovery from asset tree
+- Remediation suggestions
+- Exit code 1 on any failure
+
+### OUT of Scope
+- Version matching
+- Content/frontmatter validation
+- Auto-fix or auto-deployment
+- Non-Copilot targets (Claude, Codex, Gemini, Crush)
+
+## References
+
+- Issue: #96 — ape doctor: verify agent and skill visibility per target
+- Scope Decisions: `docs/issues/096-doctor-target-visibility/analyze/scope-decisions.md`
+- Current Doctor: `code/cli/lib/modules/global/commands/doctor.dart`
+- Target Adapter: `code/cli/lib/targets/copilot_adapter.dart`
+- Deployer: `code/cli/lib/targets/deployer.dart`
+- Asset Discovery: `code/cli/lib/assets.dart`
+- Tests: `code/cli/test/doctor_test.dart`

--- a/docs/issues/096-doctor-target-visibility/analyze/index.md
+++ b/docs/issues/096-doctor-target-visibility/analyze/index.md
@@ -1,0 +1,15 @@
+# Analyze Phase — Index
+
+**Issue:** #96 — ape doctor: verify agent and skill visibility per target
+**Branch:** 096-doctor-target-visibility
+**Phase:** ANALYZE
+**Status:** Complete
+
+---
+
+## Documents
+
+| # | File | Description |
+|---|------|-------------|
+| 1 | [scope-decisions.md](scope-decisions.md) | Scope decisions: existence-only, active targets, skill visibility |
+| 2 | [diagnosis.md](diagnosis.md) | Technical diagnosis: problem, 10 decisions, expected behavior, constraints, risks, scope |

--- a/docs/issues/096-doctor-target-visibility/analyze/scope-decisions.md
+++ b/docs/issues/096-doctor-target-visibility/analyze/scope-decisions.md
@@ -1,0 +1,53 @@
+---
+id: scope-decisions
+title: Scope decisions for ape doctor checks on target visibility
+date: 2026-04-20
+status: active
+tags: [doctor-command, targets, agents-skills, scope]
+author: SOCRATES
+---
+
+# Scope Decisions — ape doctor target verification
+
+## Context
+
+After `ape init`, the APE infrastructure is initialized locally (`.ape/state.yaml`, `.ape/config.yaml`, `.ape/mutations.md`), but agents and skills are **not deployed**. Deployment happens via `ape target get`, which copies:
+- Skills to `~/.copilot/skills/`
+- Agents to `~/.copilot/agents/`
+
+**The gap:** There is no feedback mechanism to detect when a user has run `ape init` but NOT yet run `ape target get`. The agent is invisible in Copilot until deployment occurs.
+
+## Current ape doctor Implementation
+
+Today `ape doctor` verifies:
+1. APE version (always passes)
+2. `git --version` installed
+3. `gh --version` installed
+4. `gh auth status` (logged in)
+
+**Missing:** No verification of agent/skill deployment to targets.
+
+## Scope Decisions Made
+
+### Decision 1: Version matching scope
+**Decision:** Check for file **existence only**, not version matching. No frontmatter validation at this stage.
+
+**Rationale:** Early development (v0.0.x). Single-target MVP means simplicity is priority.
+
+### Decision 2: Target scope
+**Decision:** Only check for `CopilotAdapter` deployment. Do not verify other targets (Claude, Codex, Gemini, Crush).
+
+**Rationale:** Currently only Copilot is deployed. Future targets added post-MVP.
+
+### Decision 3: Skill visibility definition
+**Decision:** Verify file existence in deployment directories:
+- `~/.copilot/agents/ape.agent.md` exists
+- `~/.copilot/skills/<skillName>/SKILL.md` exists for each expected skill
+
+**Rationale:** Answers the question: "Can Copilot see the agent and skills?"
+
+## Open Questions
+
+1. ¿El doctor debe descubrir skills dinámicamente del asset tree, o validar una lista fija?
+2. ¿En despliegue parcial: reportar solo lo faltante o árbol completo con ✓/✗?
+3. ¿Target sin desplegar debe ser fatal (exit 1) o solo advertencia (exit 0)?

--- a/docs/issues/096-doctor-target-visibility/plan.md
+++ b/docs/issues/096-doctor-target-visibility/plan.md
@@ -1,0 +1,277 @@
+---
+id: plan
+title: "DESCARTES Plan: Implement ape doctor target verification (Issue #096)"
+date: 2026-04-20
+status: ready-for-execution
+phases: 10
+author: DESCARTES
+references:
+  - diagnosis: docs/issues/096-doctor-target-visibility/analyze/diagnosis.md
+  - decisions: D1-D10 in diagnosis.md
+  - scenarios: A-D in diagnosis.md
+  - source: code/cli/lib/modules/global/commands/doctor.dart
+---
+
+# Experimental Plan: ape doctor Target Verification Feature
+
+## Hypothesis
+
+> If we extend DoctorOutput to capture target deployment checks, inject testable filesystem access, implement file-existence verification for agents/skills, discover skills dynamically from Assets, format asymmetric output, and integrate into DoctorCommand.execute(), then doctor will verify target visibility and accurately diagnose when deployment has NOT occurred.
+
+---
+
+## Dependency Graph
+
+```
+Phase 1: Data Model
+    │
+    ├── Phase 2: FS Abstraction
+    ├── Phase 3: Init Check
+    └── Phase 4: Skill Discovery
+            │
+        Phase 5: Target Verification Logic
+            │
+        Phase 6: Output Formatting
+            │
+        Phase 7: Command Integration
+            │
+        Phase 8: Tests (RED → GREEN)
+            │
+        Phase 9: Cross-Platform Validation
+            │
+        Phase 10: Retrospective
+```
+
+---
+
+## Phase 1: Data Model Extension
+
+**Purpose:** Extend `DoctorOutput` to capture target deployment results alongside prerequisite checks.
+
+- [ ] Step 1.1: Create `TargetCheck` value class in `doctor.dart`
+  - Fields: `targetName: String`, `agentExists: bool`, `missingSkills: List<String>`, `error: String?`
+  - Add `toJson()` method
+- [ ] Step 1.2: Extend `DoctorOutput`
+  - Add field: `targetChecks: List<TargetCheck>`
+  - Update `toJson()` to include targetChecks
+  - Update `passed` logic: `passed = prereqPassed && targetChecksPassed`
+- [ ] Step 1.3: Verify JSON serialization
+
+**Test pseudocode:**
+```dart
+test('TargetCheck.toJson() includes missingSkills') {
+  final check = TargetCheck(targetName: 'copilot', agentExists: true, missingSkills: ['memory-read']);
+  expect(check.toJson()['missingSkills'], ['memory-read']);
+}
+```
+
+**Risk:** None — pure data model.
+
+---
+
+## Phase 2: Filesystem Abstraction for Testability
+
+**Purpose:** Injectable interface for file operations so target verification can be unit-tested.
+
+- [ ] Step 2.1: Create `FileSystemOps` abstract interface
+  - Methods: `fileExists(path)`, `directoryExists(path)`, `homeDirectory()`
+  - Location: `code/cli/lib/targets/file_system_ops.dart`
+- [ ] Step 2.2: Create `RealFileSystemOps` implementation
+  - `homeDirectory()`: `Platform.environment['HOME']` (Unix) or `USERPROFILE` (Windows)
+  - Use `dart:io` for existence checks
+- [ ] Step 2.3: Create `MockFileSystemOps` for tests
+  - Configurable file/dir existence via setters
+- [ ] Step 2.4: Update `DoctorCommand` to accept `FileSystemOps`
+  - Constructor parameter with default `RealFileSystemOps()`
+
+**Test pseudocode:**
+```dart
+test('RealFileSystemOps.homeDirectory() returns valid path') {
+  expect(RealFileSystemOps().homeDirectory(), isNotEmpty);
+}
+```
+
+**Risk:** Medium — cross-platform path resolution. Mitigation: use `package:path`.
+
+---
+
+## Phase 3: Init Directory Check
+
+**Purpose:** Verify `.ape/` directory exists (implies `ape init` has run).
+
+- [ ] Step 3.1: Add `_checkInitialization()` method to `DoctorCommand`
+  - Check `directoryExists('.ape')` in cwd
+  - Return `({bool exists, String? remediation})`
+- [ ] Step 3.2: If missing, add failed check with remediation `→ Run 'ape init'`
+
+**Test pseudocode:**
+```dart
+test('Doctor detects missing .ape/ and suggests ape init (Scenario C)') {
+  mock.setDirectoryExists('.ape', false);
+  final output = await cmd.execute();
+  expect(output.toText(), contains('ape not initialized'));
+  expect(output.toText(), contains("Run 'ape init'"));
+}
+```
+
+**Risk:** Low.
+
+---
+
+## Phase 4: Dynamic Skill Discovery
+
+**Purpose:** Discover expected skills from asset tree (D7: no hardcoded list).
+
+- [ ] Step 4.1: Inject `Assets` into `DoctorCommand`
+  - Constructor parameter with default from resolved executable
+- [ ] Step 4.2: Create `_getExpectedSkills()` method
+  - Calls `assets.listDirectory('skills')`
+  - Handles exception gracefully (returns empty list)
+- [ ] Step 4.3: Add test setup with temporary asset structure
+
+**Test pseudocode:**
+```dart
+test('DoctorCommand discovers skills dynamically from Assets') {
+  final skills = cmd._getExpectedSkills();
+  expect(skills, contains('issue-start'));
+}
+```
+
+**Risk:** Medium — asset root path detection at runtime.
+
+---
+
+## Phase 5: Target Verification Logic
+
+**Purpose:** Core logic — check if agent and skills exist in deployment directories.
+
+- [ ] Step 5.1: Create `_verifyTargetDeployment(adapter, fs, expectedSkills)` method
+- [ ] Step 5.2: Implement verification logic
+  - Check agent: `fs.fileExists(agentPath)`
+  - For each skill: `fs.fileExists(skillPath)`
+  - Collect missing skills
+  - Return `TargetCheck`
+- [ ] Step 5.3: Use `package:path` for cross-platform path joins
+- [ ] Step 5.4: Error handling (try-catch for permission denied, etc.)
+
+**Test pseudocode:**
+```dart
+test('Scenario D: agent OK, skill missing') {
+  mock.setFileExists('agents/ape.agent.md', true);
+  mock.setFileExists('skills/memory-read/SKILL.md', false);
+  final check = await cmd._verifyTargetDeployment(adapter, mock, ['memory-read']);
+  expect(check.agentExists, true);
+  expect(check.missingSkills, ['memory-read']);
+}
+```
+
+**Risk:** Medium — cross-platform paths.
+
+---
+
+## Phase 6: Output Formatting (Asymmetric Verbosity)
+
+**Purpose:** Format target results per D6 — clean when OK, detailed when error.
+
+- [ ] Step 6.1: Implement `TargetCheck.toText(totalSkills)`
+  - Success: `✓ copilot: agent + N skills deployed`
+  - Failure: `✗ copilot: agent not deployed` / `✗ copilot: missing skills: x, y`
+  - Remediation: `  → Run 'ape target get' to deploy`
+- [ ] Step 6.2: Update `DoctorOutput.toText()` to include `Checking targets...` section
+- [ ] Step 6.3: Add init remediation line: `✗ ape not initialized → Run 'ape init'`
+
+**Test pseudocode:**
+```dart
+test('Scenario A output is clean') {
+  expect(output.toText(), contains('✓ copilot: agent + 4 skills deployed'));
+  expect(output.toText(), contains('All checks passed.'));
+}
+test('Scenario B output shows remediation') {
+  expect(output.toText(), contains("Run 'ape target get' to deploy"));
+}
+```
+
+**Risk:** Low.
+
+---
+
+## Phase 7: Command Integration
+
+**Purpose:** Wire target checks into `DoctorCommand.execute()`.
+
+- [ ] Step 7.1: Add init check to prerequisites section
+- [ ] Step 7.2: Add target verification loop after prerequisites
+  - Iterate active adapters (only CopilotAdapter per D2)
+  - Discover skills, verify deployment, collect results
+- [ ] Step 7.3: Construct `DoctorOutput` with targetChecks
+- [ ] Step 7.4: Handle scenario where .ape/ missing but targets still checked (D10)
+
+**Test pseudocode:**
+```dart
+test('Scenario A: full success → exit 0') {
+  // All prereqs + all targets pass
+  expect(output.passed, true);
+  expect(output.exitCode, 0);
+}
+test('Scenario C: no init + no deploy → exit 1') {
+  expect(output.passed, false);
+  expect(output.toText(), contains('ape not initialized'));
+  expect(output.toText(), contains('agent not deployed'));
+}
+```
+
+**Risk:** Medium — init check naming (use 'ape init' to avoid conflict with 'ape' version check).
+
+---
+
+## Phase 8: Complete Test Suite (RED → GREEN)
+
+**Purpose:** Comprehensive tests covering all 4 scenarios + edge cases.
+
+- [ ] Step 8.1: Write test stubs for Scenarios A-D (RED)
+- [ ] Step 8.2: Run tests, observe failures
+- [ ] Step 8.3: Implement test bodies (GREEN)
+- [ ] Step 8.4: Add edge case tests
+  - Permission denied on .copilot/
+  - Asset root invalid
+  - Empty skills directory
+- [ ] Step 8.5: Test output formatting matches expected
+- [ ] Step 8.6: Test JSON output includes targetChecks
+
+---
+
+## Phase 9: Cross-Platform Validation
+
+**Purpose:** Verify on Windows, Linux, macOS.
+
+- [ ] Step 9.1: Run tests on Windows
+- [ ] Step 9.2: Run tests on Linux
+- [ ] Step 9.3: Manual test on developer machine
+- [ ] Step 9.4: Document platform gotchas
+
+**Risk:** Medium — CI filesystem permissions.
+
+---
+
+## Phase 10: Retrospective & Documentation
+
+- [ ] Step 10.1: Review against hypothesis
+- [ ] Step 10.2: Document lessons learned
+- [ ] Step 10.3: Prepare changelog entry
+- [ ] Step 10.4: Produce retrospective.md
+
+---
+
+## Risk Matrix
+
+| Phase | Risk | Severity | Mitigation |
+|-------|------|----------|-----------|
+| 2 | Windows path handling | Medium | Use `package:path` |
+| 4 | Asset root discovery | Medium | Inject Assets; fallback |
+| 5 | Race condition during deploy | Low | Acceptable for v0.0.x |
+| 7 | Init check naming conflict | Medium | Use 'ape init' |
+
+## TDD Applicability
+
+- **RED→GREEN:** Phase 5 (core logic), Phase 8 (test suite)
+- **No TDD:** Phase 1 (data model), Phase 2 (infrastructure), Phase 6 (UI)


### PR DESCRIPTION
Closes #96

## Summary

Extends \^Gpe doctor\ to verify agent and skill deployment per target adapter, bridging the gap between \^Gpe init\ and \^Gpe target get\.

## Changes

- **TargetCheck data model**: New class capturing agent existence, missing skills, total skills per target
- **FileSystemOps abstraction**: Injectable interface for testable filesystem access (RealFileSystemOps + MockFileSystemOps)
- **Init check**: Verifies \.ape/\ directory exists, suggests \^Gpe init\ if missing
- **Dynamic skill discovery**: Discovers expected skills from asset tree (no hardcoded list)
- **Target verification**: Checks agent + skill file existence in \~/.copilot/\
- **Asymmetric verbosity**: Clean output when OK (\✓ copilot: agent + 4 skills deployed\), detailed errors with remediation arrows
- **Exit code 1** when any target check fails

## Test Coverage

17 tests (8 new), all passing on Windows + Linux (WSL):
- Scenario A: All pass → exit 0
- Scenario B: Nothing deployed → exit 1
- Scenario C: No .ape/ directory → exit 1
- Scenario D: Partial deployment → exit 1

## Checklist
- [x] All tests pass
- [x] CHANGELOG updated
- [x] Version bumped to 0.0.15
- [x] Cross-platform validated (Windows + Linux)