### PR TITLE
115: fix cross-platform vscode test failures

### DIFF
--- a/code/vscode/src/guard.ts
+++ b/code/vscode/src/guard.ts
@@ -7,10 +7,10 @@ export function getPlatform(): string {
 
 export function getInquiryBinaryPath(platform: string): string {
   if (platform === 'win32') {
-    return path.join(process.env.LOCALAPPDATA!, 'inquiry', 'bin', 'inquiry.exe');
+    return path.join(process.env.LOCALAPPDATA ?? '', 'inquiry', 'bin', 'inquiry.exe');
   }
   if (platform === 'linux') {
-    return path.join(process.env.HOME!, '.inquiry', 'bin', 'inquiry');
+    return path.join(process.env.HOME ?? '', '.inquiry', 'bin', 'inquiry');
   }
   throw new Error(`Unsupported platform: ${platform}`);
 }

--- a/code/vscode/test/unit/installer.test.ts
+++ b/code/vscode/test/unit/installer.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import { EventEmitter } from 'events';
+import * as path from 'path';
 import { getInstallScriptUrl, getRunCommand, installInquiryCli, InstallerDeps } from '../../src/installer';
 
 function createMockProcess() {
@@ -88,10 +89,10 @@ describe('installInquiryCli', () => {
 
     await installInquiryCli(deps);
     assert.strictEqual(downloadedUrl, 'https://www.si14bm.com/inquiry/install.ps1');
-    assert.strictEqual(downloadedDest, 'C:\\temp\\inquiry-install.ps1');
+    assert.strictEqual(downloadedDest, path.join('C:\\temp', 'inquiry-install.ps1'));
     assert.strictEqual(spawnedCmd, 'powershell');
     assert.deepStrictEqual(spawnedArgs, [
-      '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', 'C:\\temp\\inquiry-install.ps1',
+      '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', path.join('C:\\temp', 'inquiry-install.ps1'),
     ]);
   });
 


### PR DESCRIPTION
Closes #115

- guard.ts: use ?? '' instead of ! for LOCALAPPDATA/HOME env vars (undefined on Linux CI)
- installer.test.ts: use path.join() in assertions instead of hardcoded Windows separators

60 VS Code tests pass locally.