### PR TITLE
134: align docs, live FSM, and VS Code integration coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@
 
 A methodology for AI-assisted software development that models coding agents as a cooperative finite state machine — **Analyze → Plan → Execute → End → [Evolution] → Idle** — where the value is in the process, not the model.
 
-**Status:** `v0.1.0` · 131 tests · 12 GitHub releases · Windows + Linux · Single-target MVP (Copilot)
+**Status:** `v0.1.3` · Windows + Linux · Single-target MVP (Copilot)
+
+This README is the public entry surface. For the repository's canonical documentation map, start at [`docs/index.md`](docs/index.md).
 
 ## What is Inquiry?
 
-Inquiry treats coding agents ("apes") as states of a finite state machine. Each state has one specialized agent in charge, a declarative transition contract, and pre/post-conditions enforced by the CLI. Intelligence emerges from orchestration and memory, not from any single agent's capability.
+Inquiry names the cycle-level process. APE names the orchestrating methodology that schedules that process. Finite APE Machine names the engineered finite-state system that makes the methodology operational through explicit states, transitions, and artifacts. This README summarizes that model; the canonical explanations live in the documentation set.
+
+Historical naming note: APE was the system's initial working name. The individual sub-agents still appear as apes in the lore and avatar language, but Inquiry is the current name of the system and its public identity.
 
 **Core ideas:**
 
@@ -77,18 +81,21 @@ EVOLUTION is opt-in (`evolution.enabled` in `.inquiry/config.yaml`) and one-shot
 - **CLI:** Dart, compiled to a single cross-platform binary, built on top of [`modular_cli_sdk`](https://github.com/siliconbrainedmachines/modular_cli_sdk)
 - **Modules:** `global` (init, doctor, version, upgrade, uninstall, tui), `target` (get, clean), `state` (transition)
 - **FSM:** declarative `transition_contract.yaml` parsed into `FsmContract` — every (state, event) pair is total (allowed or explicitly illegal)
-- **Targets:** Copilot only in v0.0.x per [ADR D20](docs/spec/target-specific-agents.md). Adapters for Claude/Codex/Crush/Gemini exist for cleanup but are deferred until MVP
-- **Memory:** `.inquiry/` (per-cycle runtime), `docs/issues/NNN-slug/` (per-cycle artifacts), `docs/spec/` (canonical specs)
+- **Targets:** Copilot only at present per [ADR D20](docs/spec/target-specific-agents.md). Adapters for Claude/Codex/Crush/Gemini exist for cleanup but are deferred until multi-target reactivation
+- **Memory:** `.inquiry/` (per-cycle runtime), `docs/cleanrooms/NNN-slug/` (per-cycle artifacts), `docs/spec/` (technical specifications)
 
 ## Documentation
 
-- **[`docs/architecture.md`](docs/architecture.md)** — how the CLI is built (repo layout, modules, data flows, dependencies)
-- **[`docs/roadmap.md`](docs/roadmap.md)** — where Inquiry is going next (near/mid/long-term, lore vs reality)
-- **[`docs/spec/`](docs/spec/index.md)** — canonical specifications (FSM, CLI, Memory as Code, orchestrator, target-specific agents)
-- **[`docs/research/ape_builds_ape/`](docs/research/ape_builds_ape/index.md)** — research papers and methodology (Inquiry building Inquiry — empirical bootstrap)
+- **[`docs/index.md`](docs/index.md)** — top-level navigation across the current documentation set
+- **[`docs/research/inquiry/index.md`](docs/research/inquiry/index.md)** — canonical philosophical home of Inquiry
+- **[`docs/architecture.md`](docs/architecture.md)** — canonical current explanation of APE as orchestrating methodology
+- **[`docs/spec/finite-ape-machine.md`](docs/spec/finite-ape-machine.md)** — canonical technical overview of the Finite APE Machine
+- **[`docs/thinking-tools.md`](docs/thinking-tools.md)** — canonical explanation of Thinking Tools in the current model
+- **[`docs/spec/index.md`](docs/spec/index.md)** — status-aware navigation across technical specifications
+- **[`docs/cleanrooms/`](docs/cleanrooms/)** — per-issue working artifacts (analysis, plan, metrics)
+- **[`docs/roadmap.md`](docs/roadmap.md)** — strategic direction and long-term theses
+- **[`docs/lore.md`](docs/lore.md)** — nomenclature, allegory, and historical context for the named agents
 - **[`docs/adr/`](docs/adr/)** — Architecture Decision Records
-- **[`docs/issues/`](docs/issues/)** — per-cycle work artifacts (analysis, plan, metrics)
-- **[`docs/lore.md`](docs/lore.md)** — the apes' nomenclature and historical vision
 
 ## Philosophy
 

--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.1.3]
+### Changed
+- **Historical naming boundary** (#134): `APE builds APE` is now preserved only as the historical bootstrap thesis and lore wording from the period when APE was the system's working name; Inquiry remains the current system identity across README, lore, and site bootstrap surfaces
+- **Live FSM contract** (#134): the CLI now treats `END` as an explicit runtime state between `EXECUTE` and `EVOLUTION`, with updated transition prompts, TUI output, and distributed FSM assets
+
+### Fixed
+- **issue-start skill path drift** (#134): deployed source and build assets now create `docs/cleanrooms/<NNN>-<slug>/analyze/` instead of the stale `docs/issues/` path
+- **Asset regression coverage** (#134): `assets_test.dart` now asserts the distributed `issue-start` skill uses `docs/cleanrooms/`
+- **FSM verification drift** (#134): transition tests now reuse the live contract asset and cover the `EXECUTE -> END -> EVOLUTION|IDLE` flow explicitly
+
 ## [0.1.2]
 ### Changed
 - **Identity unification** (#122): canonical title+subtitle `Inquiry — Analyze. Plan. Execute.` applied uniformly across README, CLI README, agent definition, and site

--- a/code/cli/README.md
+++ b/code/cli/README.md
@@ -4,7 +4,9 @@
 
 The `iq` CLI enforces the Inquiry methodology in your repository — scaffolding the FSM state, deploying agents to your AI tool, and validating transitions.
 
-For the full methodology, architecture, and philosophy, see the [root README](../../README.md).
+This README is the CLI package entry surface. For the canonical documentation map, see [../../docs/index.md](../../docs/index.md). For the broader public overview, see the [root README](../../README.md).
+
+Inquiry names the cycle-level process. APE names the orchestrating methodology. The Finite APE Machine names the engineered finite-state system that the CLI enforces through explicit transitions and persisted artifacts.
 
 ## Install
 

--- a/code/cli/assets/agents/inquiry.agent.md
+++ b/code/cli/assets/agents/inquiry.agent.md
@@ -178,7 +178,7 @@ DARWIN uses **natural selection**: observe what worked, what failed, what mutate
 - This state is automatic. No user approval required.
 - Can be disabled: if `.inquiry/config.yaml` has `evolution.enabled: false` (default OFF), skip this state entirely — END goes directly to IDLE.
 - DARWIN never modifies the project code or documentation — only creates issues/comments in the APE repo.
-- metrics.yaml is generated ONLY for complete cycles (IDLE → ANALYZE → PLAN → EXECUTE → EVOLUTION). If evolution.enabled is false, no metrics are generated.
+- metrics.yaml is generated ONLY for complete cycles (IDLE → ANALYZE → PLAN → EXECUTE → END → EVOLUTION). If evolution.enabled is false, no metrics are generated.
 
 ---
 
@@ -249,7 +249,7 @@ docs/cleanrooms/NNN-<slug>/
 
 ## SOCRATES — Subagent Prompt (ANALYZE)
 
-APE constructs the SOCRATES prompt on each invocation. SOCRATES is a subagent that **does not know** about PLAN, EXECUTE, EVOLUTION, or state transitions. Its entire world is analysis.
+APE constructs the SOCRATES prompt on each invocation. SOCRATES is a subagent that **does not know** about PLAN, EXECUTE, END, EVOLUTION, or state transitions. Its entire world is analysis.
 
 ### Base Prompt (always included)
 
@@ -355,7 +355,7 @@ Ask: "Are we asking the right questions?", "Is there a better question we should
 
 ## DESCARTES — Subagent Prompt (PLAN)
 
-DESCARTES is a subagent that **does not know** about ANALYZE, EXECUTE, or EVOLUTION. Its entire world is planning.
+DESCARTES is a subagent that **does not know** about ANALYZE, EXECUTE, END, or EVOLUTION. Its entire world is planning.
 
 ### Prompt
 
@@ -403,7 +403,7 @@ The plan's structure is immutable after approval. Only checkboxes and deviation 
 
 ## BASHŌ — Subagent Prompt (EXECUTE)
 
-BASHŌ is a subagent that **does not know** about IDLE, ANALYZE, or EVOLUTION. Its entire world is implementation.
+BASHŌ is a subagent that **does not know** about IDLE, ANALYZE, END, or EVOLUTION. Its entire world is implementation.
 
 ### Prompt
 

--- a/code/cli/assets/fsm/fsm-diagram.md
+++ b/code/cli/assets/fsm/fsm-diagram.md
@@ -19,9 +19,10 @@ stateDiagram-v2
     PLAN --> IDLE : block
 
     EXECUTE --> ANALYZE : start_analyze
-    EXECUTE --> EVOLUTION : finish_execute
+    EXECUTE --> END : finish_execute
     EXECUTE --> EXECUTE : go_execute
-    EXECUTE --> IDLE : block
+    END --> EVOLUTION : pr_ready
+    END --> IDLE : pr_ready_no_evolution
 
     EVOLUTION --> IDLE : finish_evolution
 
@@ -44,10 +45,15 @@ stateDiagram-v2
     end note
 
     note right of EXECUTE
-        Prechecks for → EVOLUTION:
+        Prechecks for → END:
         issue_selected
         feature_branch_selected
-        pr_created
+    end note
+
+    note right of END
+        Prechecks for → EVOLUTION / IDLE:
+        issue_selected
+        feature_branch_selected
     end note
 
     note right of EVOLUTION

--- a/code/cli/assets/fsm/transition_contract.yaml
+++ b/code/cli/assets/fsm/transition_contract.yaml
@@ -7,6 +7,7 @@ states:
   - ANALYZE
   - PLAN
   - EXECUTE
+  - END
   - EVOLUTION
 
 events:
@@ -14,6 +15,8 @@ events:
   - complete_analysis
   - approve_plan
   - finish_execute
+  - pr_ready
+  - pr_ready_no_evolution
   - finish_evolution
   - block
   - go_execute
@@ -47,6 +50,18 @@ transitions:
     to: ILLEGAL
     allowed: false
     reason: "IDLE cannot finish execute"
+
+  - from: IDLE
+    event: pr_ready
+    to: ILLEGAL
+    allowed: false
+    reason: "IDLE cannot create PR or enter evolution"
+
+  - from: IDLE
+    event: pr_ready_no_evolution
+    to: ILLEGAL
+    allowed: false
+    reason: "IDLE cannot create PR or skip evolution"
 
   - from: IDLE
     event: finish_evolution
@@ -106,6 +121,18 @@ transitions:
     reason: "ANALYZE cannot finish execute"
 
   - from: ANALYZE
+    event: pr_ready
+    to: ILLEGAL
+    allowed: false
+    reason: "ANALYZE cannot create PR or enter evolution"
+
+  - from: ANALYZE
+    event: pr_ready_no_evolution
+    to: ILLEGAL
+    allowed: false
+    reason: "ANALYZE cannot create PR or skip evolution"
+
+  - from: ANALYZE
     event: finish_evolution
     to: ILLEGAL
     allowed: false
@@ -163,6 +190,18 @@ transitions:
     reason: "PLAN cannot finish execute"
 
   - from: PLAN
+    event: pr_ready
+    to: ILLEGAL
+    allowed: false
+    reason: "PLAN cannot create PR or enter evolution"
+
+  - from: PLAN
+    event: pr_ready_no_evolution
+    to: ILLEGAL
+    allowed: false
+    reason: "PLAN cannot create PR or skip evolution"
+
+  - from: PLAN
     event: finish_evolution
     to: ILLEGAL
     allowed: false
@@ -215,14 +254,26 @@ transitions:
 
   - from: EXECUTE
     event: finish_execute
-    to: EVOLUTION
+    to: END
     allowed: true
     operations:
-      prechecks: [issue_selected, feature_branch_selected, pr_created]
+      prechecks: [issue_selected, feature_branch_selected]
       effects: [finalize_execution]
       artifacts: [execution_summary.md]
-      commit_policy: push_and_pr
-      prompt_fragment_id: execute_to_evolution
+      commit_policy: stage_only
+      prompt_fragment_id: execute_to_end
+
+  - from: EXECUTE
+    event: pr_ready
+    to: ILLEGAL
+    allowed: false
+    reason: "EXECUTE must go through END before PR creation"
+
+  - from: EXECUTE
+    event: pr_ready_no_evolution
+    to: ILLEGAL
+    allowed: false
+    reason: "EXECUTE must go through END before returning to IDLE"
 
   - from: EXECUTE
     event: finish_evolution
@@ -232,14 +283,9 @@ transitions:
 
   - from: EXECUTE
     event: block
-    to: IDLE
-    allowed: true
-    operations:
-      prechecks: []
-      effects: [pause_execute]
-      artifacts: []
-      commit_policy: none
-      prompt_fragment_id: execute_to_idle
+    to: ILLEGAL
+    allowed: false
+    reason: "EXECUTE cannot pause directly to IDLE; return to ANALYZE or finish execution"
 
   - from: EXECUTE
     event: go_execute
@@ -251,6 +297,70 @@ transitions:
       artifacts: []
       commit_policy: branch_required
       prompt_fragment_id: execute_continue
+
+  - from: END
+    event: start_analyze
+    to: ILLEGAL
+    allowed: false
+    reason: "END cannot start analyze"
+
+  - from: END
+    event: complete_analysis
+    to: ILLEGAL
+    allowed: false
+    reason: "END cannot complete analysis"
+
+  - from: END
+    event: approve_plan
+    to: ILLEGAL
+    allowed: false
+    reason: "END cannot approve plan"
+
+  - from: END
+    event: finish_execute
+    to: ILLEGAL
+    allowed: false
+    reason: "END cannot finish execute again"
+
+  - from: END
+    event: pr_ready
+    to: EVOLUTION
+    allowed: true
+    operations:
+      prechecks: [issue_selected, feature_branch_selected]
+      effects: [push_branch, create_pull_request]
+      artifacts: [pull_request.md]
+      commit_policy: push_and_pr
+      prompt_fragment_id: end_to_evolution
+
+  - from: END
+    event: pr_ready_no_evolution
+    to: IDLE
+    allowed: true
+    operations:
+      prechecks: [issue_selected, feature_branch_selected]
+      effects: [push_branch, create_pull_request]
+      artifacts: [pull_request.md]
+      commit_policy: push_and_pr
+      prompt_fragment_id: end_to_idle
+
+  - from: END
+    event: finish_evolution
+    to: ILLEGAL
+    allowed: false
+    reason: "END cannot finish evolution"
+
+  - from: END
+    event: block
+    to: ILLEGAL
+    allowed: false
+    reason: "END is an explicit PR gate and cannot be paused"
+
+  - from: END
+    event: go_execute
+    to: ILLEGAL
+    allowed: false
+    reason: "END -> EXECUTE is forbidden"
 
   - from: EVOLUTION
     event: start_analyze
@@ -275,6 +385,18 @@ transitions:
     to: ILLEGAL
     allowed: false
     reason: "EVOLUTION cannot finish execute"
+
+  - from: EVOLUTION
+    event: pr_ready
+    to: ILLEGAL
+    allowed: false
+    reason: "EVOLUTION cannot create PR or re-enter itself"
+
+  - from: EVOLUTION
+    event: pr_ready_no_evolution
+    to: ILLEGAL
+    allowed: false
+    reason: "EVOLUTION cannot skip itself after it has started"
 
   - from: EVOLUTION
     event: finish_evolution
@@ -351,14 +473,10 @@ prompt_fragments:
     role: APE
     skill: memory-read
     template: "plan.pause"
-  execute_to_evolution:
-    role: DARWIN
-    skill: issue-end
-    template: "evolution.from_execution"
-  execute_to_idle:
+  execute_to_end:
     role: APE
-    skill: memory-read
-    template: "execute.pause"
+    skill: issue-end
+    template: "end.review"
   execute_continue:
     role: BASHO
     skill: issue-start
@@ -371,6 +489,14 @@ prompt_fragments:
     role: SOCRATES
     skill: memory-read
     template: "analyze.reopen"
+  end_to_evolution:
+    role: DARWIN
+    skill: issue-end
+    template: "evolution.from_end"
+  end_to_idle:
+    role: APE
+    skill: issue-end
+    template: "idle.resume"
   evolution_to_idle:
     role: APE
     skill: memory-read

--- a/code/cli/assets/skills/issue-end/SKILL.md
+++ b/code/cli/assets/skills/issue-end/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-end
-description: 'Protocol for ending an APE cycle. Use when: all plan.md checkboxes are complete, ready to release. Guides: version bump, changelog, commit, PR, EVOLUTION transition.'
+description: 'Protocol for ending an APE cycle. Use when: all plan.md checkboxes are complete, ready to release. Guides: version bump, changelog, END gate, PR, and EVOLUTION transition.'
 ---
 
 # issue-end — Cycle Completion Protocol
@@ -114,13 +114,27 @@ Commit message format: `vX.Y.Z: <issue-title-summary>`
 - `v0.0.9: fix version inconsistency + skill issue-end + TUI ape`
 - `v0.1.0: add authentication module`
 
-### Step 7: Push Branch
+### Step 7: Transition to END
+
+Update `.inquiry/state.yaml` (if using state tracking):
+
+```yaml
+phase: END
+issue: {issue-number}
+branch: {branch}
+version: X.Y.Z
+```
+
+Announce state change:
+> `[APE: END]`
+
+### Step 8: Push Branch
 
 ```bash
 git push -u origin {branch}
 ```
 
-### Step 8: Create Pull Request
+### Step 9: Create Pull Request
 
 ```bash
 gh pr create \
@@ -137,15 +151,16 @@ gh pr create \
 "
 ```
 
-**Important:** PR creation = APE cycle completion. The APE cycle ends here.
+**Important:** PR creation completes the explicit END gate.
 
+- If `evolution.enabled: true`, the cycle advances from END to EVOLUTION after PR creation.
+- If `evolution.enabled: false`, the cycle returns directly from END to IDLE after PR creation.
 - PR merge is an **external event** (happens later, possibly with CI checks)
-- DARWIN collects retrospective data from this cycle
-- Do not wait for PR merge to transition to EVOLUTION
+- Do not wait for PR merge to leave END
 
-### Step 9: Transition to EVOLUTION
+### Step 10: Transition to EVOLUTION or IDLE
 
-Update `.inquiry/state.yaml` (if using state tracking):
+If evolution is enabled, update `.inquiry/state.yaml` (if using state tracking):
 
 ```yaml
 phase: EVOLUTION
@@ -156,6 +171,8 @@ version: X.Y.Z
 
 Announce state change:
 > `[APE: EVOLUTION]`
+
+If evolution is disabled, update `.inquiry/state.yaml` directly to IDLE instead.
 
 ## After PR Merge
 
@@ -173,7 +190,8 @@ When the PR is merged:
 4. Update version files (pubspec.yaml + lib/src/version.dart)
 5. Update CHANGELOG.md
 6. Commit: git add -A && git commit -m "vX.Y.Z: ..."
-7. Push: git push -u origin {branch}
-8. Create PR: gh pr create --title "vX.Y.Z: ..."
-9. Transition to EVOLUTION
+7. Transition to END
+8. Push: git push -u origin {branch}
+9. Create PR: gh pr create --title "vX.Y.Z: ..."
+10. Transition to EVOLUTION or IDLE
 ```

--- a/code/cli/assets/skills/issue-start/SKILL.md
+++ b/code/cli/assets/skills/issue-start/SKILL.md
@@ -81,14 +81,14 @@ Note: Pad issue numbers less than 100 with leading zeros for sort consistency.
 ### Step 5: Create Working Directory
 
 ```bash
-mkdir -p docs/issues/<NNN>-<slug>/analyze/
+mkdir -p docs/cleanrooms/<NNN>-<slug>/analyze/
 ```
 
 This creates the analysis directory for SOCRATES to work in during ANALYZE phase.
 
 ### Step 6: Create index.md
 
-Create `docs/issues/<NNN>-<slug>/analyze/index.md` with this template:
+Create `docs/cleanrooms/<NNN>-<slug>/analyze/index.md` with this template:
 
 ```markdown
 # Analyze Phase — Index
@@ -137,7 +137,7 @@ The scheduler is now in ANALYZE state and should invoke SOCRATES for analysis wo
 After completing all steps, verify:
 
 - [ ] Branch exists: `git branch --show-current` returns `<NNN>-<slug>`
-- [ ] Directory exists: `docs/issues/<NNN>-<slug>/analyze/index.md`
+- [ ] Directory exists: `docs/cleanrooms/<NNN>-<slug>/analyze/index.md`
 - [ ] State updated: `.inquiry/state.yaml` shows `phase: ANALYZE`
 
 ## Notes

--- a/code/cli/lib/fsm_contract.dart
+++ b/code/cli/lib/fsm_contract.dart
@@ -7,6 +7,7 @@ enum FsmState {
   analyze('ANALYZE'),
   plan('PLAN'),
   execute('EXECUTE'),
+  end('END'),
   evolution('EVOLUTION');
 
   const FsmState(this.value);
@@ -25,6 +26,8 @@ enum FsmEvent {
   completeAnalysis('complete_analysis'),
   approvePlan('approve_plan'),
   finishExecute('finish_execute'),
+  prReady('pr_ready'),
+  prReadyNoEvolution('pr_ready_no_evolution'),
   finishEvolution('finish_evolution'),
   block('block'),
   goExecute('go_execute');

--- a/code/cli/lib/modules/global/commands/tui.dart
+++ b/code/cli/lib/modules/global/commands/tui.dart
@@ -66,9 +66,9 @@ String _buildDiagram(String version) {
   return '''
 Inquiry v$version — powered by the Finite APE Machine
 
-       ╭──────────────────────────╮
-IDLE → │ Analyze → Plan → Execute │ → EVOLUTION
-       ╰──────────────────────────╯
+  ╭────────────────────────────────╮
+IDLE → │ Analyze → Plan → Execute → End │ → EVOLUTION
+  ╰────────────────────────────────╯
 
 
 Commands: init, doctor, version

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.1.2';
+const String inquiryVersion = '0.1.3';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.1.2
+version: 0.1.3
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/assets_test.dart
+++ b/code/cli/test/assets_test.dart
@@ -100,6 +100,13 @@ void main() {
       expect(content, isNotEmpty);
     });
 
+    test('reads skills/issue-start/SKILL.md with cleanrooms paths', () {
+      final content = assets.loadString('skills/issue-start/SKILL.md');
+      expect(content, contains('docs/cleanrooms/<NNN>-<slug>/analyze/'));
+      expect(content, isNot(contains('docs/issues/<NNN>-<slug>/analyze/')));
+      expect(content, isNotEmpty);
+    });
+
     test('listDirectory skills returns all skill directories', () {
       final dirs = assets.listDirectory('skills');
       expect(

--- a/code/cli/test/fsm_contract_test.dart
+++ b/code/cli/test/fsm_contract_test.dart
@@ -21,6 +21,7 @@ void main() {
 
   test('matrix is total for all known states and events', () {
     expect(() => contract.assertMatrixIsTotal(), returnsNormally);
+    expect(contract.states, contains(FsmState.end));
 
     for (final state in contract.states) {
       for (final event in contract.events) {
@@ -53,6 +54,30 @@ void main() {
     expect(transition.operations!.prechecks, contains('issue_selected_or_created'));
     expect(transition.operations!.commitPolicy, 'stage_only');
     expect(transition.operations!.promptFragmentId, 'analyze_to_plan');
+  });
+
+  test('EXECUTE passes through END before PR creation', () {
+    final finishExecution = contract.transitionFor(
+      FsmState.execute,
+      FsmEvent.finishExecute,
+    );
+    final createPr = contract.transitionFor(FsmState.end, FsmEvent.prReady);
+    final skipEvolution = contract.transitionFor(
+      FsmState.end,
+      FsmEvent.prReadyNoEvolution,
+    );
+
+    expect(finishExecution.allowed, isTrue);
+    expect(finishExecution.to, FsmState.end);
+    expect(finishExecution.operations!.promptFragmentId, 'execute_to_end');
+
+    expect(createPr.allowed, isTrue);
+    expect(createPr.to, FsmState.evolution);
+    expect(createPr.operations!.promptFragmentId, 'end_to_evolution');
+
+    expect(skipEvolution.allowed, isTrue);
+    expect(skipEvolution.to, FsmState.idle);
+    expect(skipEvolution.operations!.promptFragmentId, 'end_to_idle');
   });
 
   test('preconditions contract exists for irreversible actions', () {

--- a/code/cli/test/state_transition_integration_test.dart
+++ b/code/cli/test/state_transition_integration_test.dart
@@ -74,14 +74,21 @@ void main() {
 
       final t4 = await transition('finish_execute');
       expect(t4.allowed, isTrue);
-      expect(t4.nextState, 'EVOLUTION');
+      expect(t4.nextState, 'END');
       expect(t4.promptFragmentId, isNotNull);
       current = t4.nextState!;
 
-      final t5 = await transition('finish_evolution');
+      final t5 = await transition('pr_ready');
       expect(t5.allowed, isTrue);
-      expect(t5.nextState, 'IDLE');
+      expect(t5.nextState, 'EVOLUTION');
       expect(t5.promptFragmentId, isNotNull);
+
+      current = t5.nextState!;
+
+      final t6 = await transition('finish_evolution');
+      expect(t6.allowed, isTrue);
+      expect(t6.nextState, 'IDLE');
+      expect(t6.promptFragmentId, isNotNull);
     });
   });
 }

--- a/code/cli/test/state_transition_test.dart
+++ b/code/cli/test/state_transition_test.dart
@@ -125,6 +125,44 @@ void main() {
       expect(output.exitCode, 7);
       expect(output.message, contains('ERROR_PRECONDITION_BRANCH_POLICY'));
     });
+
+    test('routes EXECUTE through END before PR creation', () async {
+      _writeState(tempDir.path, 'EXECUTE');
+      _writeContext(tempDir.path, 'issue: 51\n');
+
+      final output = await StateTransitionCommand(
+        StateTransitionInput(
+          currentState: null,
+          event: 'finish_execute',
+          workingDirectory: tempDir.path,
+        ),
+        branchProvider: (_) async => '51-idle-execution-guardrails',
+      ).execute();
+
+      expect(output.allowed, isTrue);
+      expect(output.nextState, 'END');
+      expect(output.promptFragmentId, 'execute_to_end');
+      expect(output.requiredRole, 'APE');
+    });
+
+    test('allows END to create PR and enter EVOLUTION', () async {
+      _writeState(tempDir.path, 'END');
+      _writeContext(tempDir.path, 'issue: 51\n');
+
+      final output = await StateTransitionCommand(
+        StateTransitionInput(
+          currentState: null,
+          event: 'pr_ready',
+          workingDirectory: tempDir.path,
+        ),
+        branchProvider: (_) async => '51-idle-execution-guardrails',
+      ).execute();
+
+      expect(output.allowed, isTrue);
+      expect(output.nextState, 'EVOLUTION');
+      expect(output.promptFragmentId, 'end_to_evolution');
+      expect(output.requiredRole, 'DARWIN');
+    });
   });
 }
 
@@ -141,324 +179,15 @@ void _writeContext(String root, String content) {
 }
 
 void _writeContract(String root) {
+  final source = File(
+    p.join(
+      Directory.current.path,
+      'assets',
+      'fsm',
+      'transition_contract.yaml',
+    ),
+  );
   final file = File(p.join(root, 'assets', 'fsm', 'transition_contract.yaml'));
   file.createSync(recursive: true);
-  file.writeAsStringSync('''
-metadata:
-  version: "1.0.0"
-  description: "APE FSM transition contract"
-states: [IDLE, ANALYZE, PLAN, EXECUTE, EVOLUTION]
-events: [start_analyze, complete_analysis, approve_plan, finish_execute, finish_evolution, block, go_execute]
-transitions:
-  - from: IDLE
-    event: start_analyze
-    to: ANALYZE
-    allowed: true
-    operations:
-      prechecks: []
-      effects: [open_analysis_context]
-      artifacts: [analysis/index.md]
-      commit_policy: none
-      prompt_fragment_id: idle_to_analyze
-
-  - from: IDLE
-    event: complete_analysis
-    to: ILLEGAL
-    allowed: false
-    reason: "IDLE cannot complete analysis before ANALYZE"
-
-  - from: IDLE
-    event: approve_plan
-    to: ILLEGAL
-    allowed: false
-    reason: "IDLE cannot approve plan directly"
-
-  - from: IDLE
-    event: finish_execute
-    to: ILLEGAL
-    allowed: false
-    reason: "IDLE cannot finish execute"
-
-  - from: IDLE
-    event: finish_evolution
-    to: ILLEGAL
-    allowed: false
-    reason: "IDLE cannot finish evolution"
-
-  - from: IDLE
-    event: block
-    to: IDLE
-    allowed: true
-    operations:
-      prechecks: []
-      effects: [noop]
-      artifacts: []
-      commit_policy: none
-      prompt_fragment_id: idle_block
-
-  - from: IDLE
-    event: go_execute
-    to: ILLEGAL
-    allowed: false
-    reason: "IDLE -> EXECUTE is forbidden"
-
-  - from: ANALYZE
-    event: start_analyze
-    to: ANALYZE
-    allowed: true
-    operations:
-      prechecks: []
-      effects: [continue_analysis]
-      artifacts: [analyze/notes.md]
-      commit_policy: none
-      prompt_fragment_id: analyze_continue
-
-  - from: ANALYZE
-    event: complete_analysis
-    to: PLAN
-    allowed: true
-    operations:
-      prechecks: [issue_selected_or_created, diagnosis_exists]
-      effects: [generate_plan]
-      artifacts: [plan.md]
-      commit_policy: stage_only
-      prompt_fragment_id: analyze_to_plan
-
-  - from: ANALYZE
-    event: approve_plan
-    to: ILLEGAL
-    allowed: false
-    reason: "ANALYZE cannot jump to EXECUTE"
-
-  - from: ANALYZE
-    event: finish_execute
-    to: ILLEGAL
-    allowed: false
-    reason: "ANALYZE cannot finish execute"
-
-  - from: ANALYZE
-    event: finish_evolution
-    to: ILLEGAL
-    allowed: false
-    reason: "ANALYZE cannot finish evolution"
-
-  - from: ANALYZE
-    event: block
-    to: IDLE
-    allowed: true
-    operations:
-      prechecks: []
-      effects: [pause_analysis]
-      artifacts: []
-      commit_policy: none
-      prompt_fragment_id: analyze_to_idle
-
-  - from: ANALYZE
-    event: go_execute
-    to: ILLEGAL
-    allowed: false
-    reason: "ANALYZE -> EXECUTE is forbidden without PLAN"
-
-  - from: PLAN
-    event: start_analyze
-    to: ILLEGAL
-    allowed: false
-    reason: "PLAN cannot start analyze"
-
-  - from: PLAN
-    event: complete_analysis
-    to: ILLEGAL
-    allowed: false
-    reason: "PLAN cannot complete analysis"
-
-  - from: PLAN
-    event: approve_plan
-    to: EXECUTE
-    allowed: true
-    operations:
-      prechecks: [issue_selected, feature_branch_selected, plan_approved]
-      effects: [prepare_execute]
-      artifacts: [execution_log.md]
-      commit_policy: branch_required
-      prompt_fragment_id: plan_to_execute
-
-  - from: PLAN
-    event: finish_execute
-    to: ILLEGAL
-    allowed: false
-    reason: "PLAN cannot finish execute"
-
-  - from: PLAN
-    event: finish_evolution
-    to: ILLEGAL
-    allowed: false
-    reason: "PLAN cannot finish evolution"
-
-  - from: PLAN
-    event: block
-    to: IDLE
-    allowed: true
-    operations:
-      prechecks: []
-      effects: [pause_plan]
-      artifacts: []
-      commit_policy: none
-      prompt_fragment_id: plan_to_idle
-
-  - from: PLAN
-    event: go_execute
-    to: EXECUTE
-    allowed: true
-    operations:
-      prechecks: [issue_selected, feature_branch_selected, plan_approved]
-      effects: [prepare_execute]
-      artifacts: [execution_log.md]
-      commit_policy: branch_required
-      prompt_fragment_id: plan_to_execute
-
-  - from: EXECUTE
-    event: start_analyze
-    to: ILLEGAL
-    allowed: false
-    reason: "EXECUTE cannot start analyze"
-
-  - from: EXECUTE
-    event: complete_analysis
-    to: ILLEGAL
-    allowed: false
-    reason: "EXECUTE cannot complete analysis"
-
-  - from: EXECUTE
-    event: approve_plan
-    to: ILLEGAL
-    allowed: false
-    reason: "EXECUTE cannot approve plan"
-
-  - from: EXECUTE
-    event: finish_execute
-    to: EVOLUTION
-    allowed: true
-    operations:
-      prechecks: [issue_selected, feature_branch_selected, pr_created]
-      effects: [finalize_execution]
-      artifacts: [execution_summary.md]
-      commit_policy: push_and_pr
-      prompt_fragment_id: execute_to_evolution
-
-  - from: EXECUTE
-    event: finish_evolution
-    to: ILLEGAL
-    allowed: false
-    reason: "EXECUTE cannot finish evolution"
-
-  - from: EXECUTE
-    event: block
-    to: IDLE
-    allowed: true
-    operations:
-      prechecks: []
-      effects: [pause_execute]
-      artifacts: []
-      commit_policy: none
-      prompt_fragment_id: execute_to_idle
-
-  - from: EXECUTE
-    event: go_execute
-    to: EXECUTE
-    allowed: true
-    operations:
-      prechecks: [issue_selected, feature_branch_selected]
-      effects: [continue_execute]
-      artifacts: []
-      commit_policy: branch_required
-      prompt_fragment_id: execute_continue
-
-  - from: EVOLUTION
-    event: start_analyze
-    to: ILLEGAL
-    allowed: false
-    reason: "EVOLUTION cannot start analyze"
-
-  - from: EVOLUTION
-    event: complete_analysis
-    to: ILLEGAL
-    allowed: false
-    reason: "EVOLUTION cannot complete analysis"
-
-  - from: EVOLUTION
-    event: approve_plan
-    to: ILLEGAL
-    allowed: false
-    reason: "EVOLUTION cannot approve plan"
-
-  - from: EVOLUTION
-    event: finish_execute
-    to: ILLEGAL
-    allowed: false
-    reason: "EVOLUTION cannot finish execute"
-
-  - from: EVOLUTION
-    event: finish_evolution
-    to: IDLE
-    allowed: true
-    operations:
-      prechecks: [retrospective_recorded]
-      effects: [close_cycle]
-      artifacts: [retrospective.md]
-      commit_policy: none
-      prompt_fragment_id: evolution_to_idle
-
-  - from: EVOLUTION
-    event: block
-    to: IDLE
-    allowed: true
-    operations:
-      prechecks: []
-      effects: [pause_evolution]
-      artifacts: []
-      commit_policy: none
-      prompt_fragment_id: evolution_to_idle
-
-  - from: EVOLUTION
-    event: go_execute
-    to: ILLEGAL
-    allowed: false
-    reason: "EVOLUTION -> EXECUTE is forbidden"
-
-preconditions:
-  issue_selected_or_created:
-    description: "Issue exists or has been created"
-    kind: issue
-  diagnosis_exists:
-    description: "diagnosis.md exists for current issue"
-    kind: filesystem
-  issue_selected:
-    description: "Issue selected in current context"
-    kind: issue
-  feature_branch_selected:
-    description: "Current branch is issue-linked and not main"
-    kind: git
-  plan_approved:
-    description: "User approved plan"
-    kind: user-approval
-  pr_created:
-    description: "Pull request exists for issue branch"
-    kind: github
-  retrospective_recorded:
-    description: "Retrospective document exists"
-    kind: filesystem
-
-prompt_fragments:
-  idle_to_analyze: { role: SOCRATES, template: "analyze.clarification" }
-  idle_block: { role: APE, template: "idle.blocked" }
-  analyze_continue: { role: SOCRATES, template: "analyze.iterate" }
-  analyze_to_plan: { role: DESCARTES, template: "plan.from_diagnosis" }
-  analyze_to_idle: { role: APE, template: "analyze.pause" }
-  plan_to_execute: { role: BASHO, template: "execute.phase" }
-  plan_to_idle: { role: APE, template: "plan.pause" }
-  execute_to_evolution: { role: DARWIN, template: "evolution.from_execution" }
-  execute_to_idle: { role: APE, template: "execute.pause" }
-  execute_continue: { role: BASHO, template: "execute.continue" }
-  evolution_to_idle: { role: APE, template: "idle.resume" }
-''');
+  file.writeAsStringSync(source.readAsStringSync());
 }

--- a/code/cli/test/tui_test.dart
+++ b/code/cli/test/tui_test.dart
@@ -26,6 +26,7 @@ void main() {
       expect(output.diagram, contains('Analyze'));
       expect(output.diagram, contains('Plan'));
       expect(output.diagram, contains('Execute'));
+      expect(output.diagram, contains('End'));
       expect(output.diagram, contains('EVOLUTION'));
     });
 

--- a/code/site/agents.html
+++ b/code/site/agents.html
@@ -33,7 +33,7 @@
     <header class="page-hero">
       <h1>Four apes, not nine.</h1>
       <p class="page-subhead">
-        Inquiry started with nine named agents. Two months of building Inquiry with Inquiry collapsed the roster to four. Here's who's on the team, and the honest story of who didn't make it.
+        Inquiry started with nine named agents. The sub-agents are still called apes in the lore because APE was the system's early working name. Two months of bootstrapping the system collapsed the roster to four. Here's who's on the team, and the honest story of who didn't make it.
       </p>
     </header>
 
@@ -179,7 +179,7 @@
     <section aria-labelledby="collapse-heading">
       <h2 id="collapse-heading">Lore vs reality</h2>
       <p class="section-intro">
-        The original <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/lore.md"><code>lore.md</code></a> sketched nine apes. After two months of building Inquiry with Inquiry, the roster collapsed to four. This is honest accounting, not a roadmap to revive the deferred ones. Most were absorbed by simpler agents that turned out to do the job better.
+        The original <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/lore.md"><code>lore.md</code></a> sketched nine apes. The historical bootstrap thesis was "APE builds APE" because APE was the system's initial codename; Inquiry is the current system name. After two months of building the system through its own cycle, the roster collapsed to four. This is honest accounting, not a roadmap to revive the deferred ones. Most were absorbed by simpler agents that turned out to do the job better.
       </p>
       <div class="table-wrapper">
         <table class="data-table">
@@ -277,8 +277,8 @@
           <p>The FSM, the transition contract, and how the four apes connect.</p>
         </a>
         <a href="ape-builds-ape.html" class="deeper-card">
-          <h3>Inquiry builds Inquiry →</h3>
-          <p>The empirical bootstrap — where the collapse from nine to four came from.</p>
+          <h3>Bootstrap thesis: APE builds APE →</h3>
+          <p>The historical bootstrap story, preserved under its original phrase without displacing Inquiry as the current name.</p>
         </a>
       </div>
     </section>
@@ -286,7 +286,7 @@
     <footer>
       <a href="index.html">Home</a>·
       <a href="https://github.com/siliconbrainedmachines/inquiry">GitHub</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/roadmap.md">Roadmap</a>·
+      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
       MIT License
     </footer>
   </div>

--- a/code/site/ape-builds-ape.html
+++ b/code/site/ape-builds-ape.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>APE builds APE — Finite APE Machine</title>
-  <meta name="description" content="The empirical bootstrap: APE is being built using APE. Four stages from implicit methodology to a machine-verifiable contract. Evidence, and what's still missing.">
+  <title>APE builds APE — historical bootstrap thesis</title>
+  <meta name="description" content="The historical bootstrap thesis from the period when APE was the system's working name. Inquiry is the current identity; this page preserves the original phrase as bootstrap history.">
   <meta name="theme-color" content="#0a0e1a">
 
-  <meta property="og:title" content="APE builds APE — Finite APE Machine">
-  <meta property="og:description" content="The empirical bootstrap. Four stages. Evidence. What's still missing.">
+  <meta property="og:title" content="APE builds APE — historical bootstrap thesis">
+  <meta property="og:description" content="The original bootstrap thesis, preserved as history while Inquiry remains the current system identity.">
   <meta property="og:type" content="article">
 
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="APE builds APE — Finite APE Machine">
-  <meta name="twitter:description" content="The empirical bootstrap. Four stages. Evidence. What's still missing.">
+  <meta name="twitter:title" content="APE builds APE — historical bootstrap thesis">
+  <meta name="twitter:description" content="The original bootstrap thesis, preserved as history while Inquiry remains the current system identity.">
 
   <link rel="icon" type="image/svg+xml" href="img/favicon.svg">
 
@@ -27,13 +27,13 @@
 <body>
   <div class="container">
     <nav class="page-nav" aria-label="Breadcrumb">
-      <a href="index.html">← Finite <span class="ape">APE</span> Machine</a>
+      <a href="index.html">← Inquiry</a>
     </nav>
 
     <header class="page-hero">
       <h1>APE builds APE.</h1>
       <p class="page-subhead">
-        After two months of using APE to build APE, the lore collapsed, the agents sharpened, and the framework improved itself one cycle at a time. This is what that looks like in practice — and what's still missing before it becomes a paper.
+        This page preserves the original bootstrap thesis from the period when APE was the system's working name. Inquiry is the current public identity; "APE builds APE" survives here only as historical shorthand for the self-hosting bootstrap and the lore of the sub-agents.
       </p>
     </header>
 
@@ -70,7 +70,7 @@
           </div>
           <h3>Custom agent</h3>
           <p>Deploy infrastructure (<code>iq target get</code>) stabilized as a single-target Copilot deployment. The cycle became self-enforcing — the agent refused to skip states, demanded issue numbers, required user gates. The system began constraining its own development.</p>
-          <div class="stage-evidence">Evidence: every version from v0.0.7+ has <code>docs/issues/NNN-slug/</code> artifacts.</div>
+          <div class="stage-evidence">Evidence: early cycle versions used <code>docs/issues/NNN-slug/</code> artifacts; current cycles use <code>docs/cleanrooms/NNN-slug/</code>.</div>
         </li>
 
         <li class="stage">
@@ -79,7 +79,7 @@
             <span class="stage-range">v0.0.11+</span>
           </div>
           <h3>CLI + contract</h3>
-          <p>Runtime infrastructure arrived: FSM transition contract (YAML), programmatic transitions with precondition validation (<code>iq state transition</code>), declarative effects, and evolution infrastructure (<code>.inquiry/config.yaml</code>, <code>.inquiry/mutations.md</code>). The contract says what's legal; tests prove the contract holds. APE is always used to build APE — every feature, fix, and improvement goes through the full cycle.</p>
+          <p>Runtime infrastructure arrived: FSM transition contract (YAML), programmatic transitions with precondition validation (<code>iq state transition</code>), declarative effects, and evolution infrastructure (<code>.inquiry/config.yaml</code>, <code>.inquiry/mutations.md</code>). The contract says what's legal; tests prove the contract holds. The system now named Inquiry is used to build itself — the original bootstrap thesis called this "APE builds APE" because APE was the project's working name at the time.</p>
           <div class="stage-evidence">Evidence: <code>transition_contract.yaml</code>, 131 passing tests, 12 GitHub releases, 69+ issues and PRs.</div>
         </li>
       </ol>
@@ -113,7 +113,7 @@
         </div>
         <div class="stat">
           <div class="stat-num">v0.0.7+</div>
-          <div class="stat-label">with cycle artifacts<br><span class="stat-sub"><code>docs/issues/NNN-slug/</code></span></div>
+          <div class="stat-label">with cycle artifacts<br><span class="stat-sub"><code>docs/cleanrooms/NNN-slug/</code> today</span></div>
         </div>
       </div>
     </section>
@@ -139,7 +139,7 @@
       <dl class="gap-list">
         <dt>1. Structured per-cycle metrics</dt>
         <dd>
-          The cycle produces artifacts, but there's no machine-readable <code>metrics.yaml</code> capturing time-to-plan, plan completion rate, test pass delta, or reviewer overrides. <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/roadmap.md">Roadmap item #72</a>.
+          The cycle produces artifacts, but there's no machine-readable <code>metrics.yaml</code> capturing time-to-plan, plan completion rate, test pass delta, or reviewer overrides. <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">Roadmap item #72</a>.
         </dd>
         <dt>2. Thirty clean cycles of data</dt>
         <dd>
@@ -170,7 +170,7 @@
           <p>The FSM, the transition contract, and why methodology beats model.</p>
         </a>
         <a href="agents.html" class="deeper-card">
-          <h3>Meet the APEs →</h3>
+          <h3>Meet the agents →</h3>
           <p>The four active agents that survived the collapse — and the five that didn't.</p>
         </a>
         <a href="evolution.html" class="deeper-card">
@@ -183,7 +183,7 @@
     <footer>
       <a href="index.html">Home</a>·
       <a href="https://github.com/siliconbrainedmachines/inquiry">GitHub</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/roadmap.md">Roadmap</a>·
+      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
       MIT License
     </footer>
   </div>

--- a/code/site/docs/spec/banner.md
+++ b/code/site/docs/spec/banner.md
@@ -1,8 +1,12 @@
 # Finite APE Machine Banner Specification
 
-Status: draft  
+Status: draft historical brand direction  
 Owner: brand / site / CLI  
 Last updated: 2026-04-19
+
+> Status note: This document preserves an earlier brand direction centered on the public lockup `Finite APE Machine`. It does not describe the current public-facing identity, which now ships as `Inquiry` across the site, README, CLI, and VS Code surfaces.
+>
+> Treat this file as a design archive and exploration document. If any part of it is revived, it must be reconciled with the current Inquiry identity and the repository's canonical doctrine in `docs/index.md`, `docs/architecture.md`, and `docs/spec/finite-ape-machine.md` before being treated as current brand guidance.
 
 ## Purpose
 

--- a/code/site/evolution.html
+++ b/code/site/evolution.html
@@ -3,16 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Evolution — Finite APE Machine</title>
+  <title>Evolution — Inquiry</title>
   <meta name="description" content="How the EVOLUTION state works: opt-in, off by default. What DARWIN reads, what it proposes, and why your code never leaves your machine.">
   <meta name="theme-color" content="#0a0e1a">
 
-  <meta property="og:title" content="Evolution — Finite APE Machine">
+  <meta property="og:title" content="Evolution — Inquiry">
   <meta property="og:description" content="Opt-in. Off by default. Your code never leaves your machine.">
   <meta property="og:type" content="article">
 
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="Evolution — Finite APE Machine">
+  <meta name="twitter:title" content="Evolution — Inquiry">
   <meta name="twitter:description" content="Opt-in. Off by default. Your code never leaves your machine.">
 
   <link rel="icon" type="image/svg+xml" href="img/favicon.svg">
@@ -27,20 +27,20 @@
 <body>
   <div class="container">
     <nav class="page-nav" aria-label="Breadcrumb">
-      <a href="index.html">← Finite <span class="ape">APE</span> Machine</a>
+      <a href="index.html">← Inquiry</a>
     </nav>
 
     <header class="page-hero">
       <h1>Opt-in. Off by default.</h1>
       <p class="page-subhead">
-        EVOLUTION is the last state of the APE cycle. When enabled, DARWIN proposes changes to APE itself as issues in the APE repo. Your code never leaves your machine.
+        EVOLUTION is the final optional state of the Inquiry cycle. When enabled, DARWIN proposes changes to the methodology itself as public issues in the Inquiry repository. Your code never leaves your machine.
       </p>
     </header>
 
     <section aria-labelledby="what-heading">
       <h2 id="what-heading">What DARWIN does</h2>
       <p>
-        After <code>EXECUTE</code> and <code>END</code>, if <code>evolution.enabled</code> is true, DARWIN reads the cycle's artifacts — <code>diagnosis.md</code>, <code>plan.md</code>, <code>mutations.md</code> — and composes one or more mutation proposals. Those proposals are filed as GitHub issues on the APE repo. Each issue describes what DARWIN thinks should change about the framework: new states, modified agent prompts, better preconditions, deprecated apes.
+        After <code>EXECUTE</code> and <code>END</code>, if <code>evolution.enabled</code> is true, DARWIN reads the persisted cycle artifacts — notably <code>docs/cleanrooms/&lt;issue&gt;/analyze/diagnosis.md</code>, <code>docs/cleanrooms/&lt;issue&gt;/plan.md</code>, and <code>.inquiry/mutations.md</code> — and composes one or more mutation proposals. Those proposals are filed as GitHub issues in the Inquiry repository. Each issue describes what DARWIN thinks should change about the framework: new states, modified agent prompts, better preconditions, or deprecated agents.
       </p>
       <p>
         The proposals aren't applied automatically. They enter the same review flow as any GitHub issue — the maintainer decides whether to accept, reject, or modify. The <a href="agents.html">collapse from nine lore apes to four</a> happened through this mechanism.
@@ -50,16 +50,16 @@
     <section aria-labelledby="collect-heading">
       <h2 id="collect-heading">What gets collected</h2>
       <p class="section-intro">
-        The scope is narrow and explicit. DARWIN only reads files inside <code>.inquiry/</code>.
+        The scope is narrow and explicit. DARWIN reads the cycle artifacts required for process evaluation, not arbitrary project content.
       </p>
       <ul class="privacy-list">
         <li class="yes">
           <span class="privacy-icon" aria-hidden="true">✓</span>
-          <span>Artifacts from <code>.inquiry/</code>: <code>diagnosis.md</code>, <code>plan.md</code>, <code>mutations.md</code></span>
+          <span>Cycle artifacts from <code>docs/cleanrooms/&lt;issue&gt;/</code>: <code>diagnosis.md</code>, <code>plan.md</code>, and related metrics files when present</span>
         </li>
         <li class="yes">
           <span class="privacy-icon" aria-hidden="true">✓</span>
-          <span>DARWIN's own synthesis of the cycle — reasoning composed from those artifacts</span>
+          <span>Runtime notes from <code>.inquiry/mutations.md</code> and DARWIN's own synthesis of the cycle</span>
         </li>
         <li class="no">
           <span class="privacy-icon" aria-hidden="true">✗</span>
@@ -67,7 +67,7 @@
         </li>
         <li class="no">
           <span class="privacy-icon" aria-hidden="true">✗</span>
-          <span>Paths, filenames, or metadata from anywhere outside <code>.inquiry/</code></span>
+          <span>Arbitrary paths, filenames, or metadata outside the declared cycle artifacts</span>
         </li>
         <li class="no">
           <span class="privacy-icon" aria-hidden="true">✗</span>
@@ -79,7 +79,7 @@
         </li>
       </ul>
       <div class="callout callout--ok">
-        <strong>Audit everything before it ships.</strong> DARWIN pauses with the draft issue body for your review. You see the exact content being proposed; nothing goes out without your approval. Fully automated filing is scoped for <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/roadmap.md">roadmap</a> item #57 — until that lands, the review step is mandatory.
+        <strong>Audit everything before it ships.</strong> DARWIN pauses with the draft issue body for your review. You see the exact content being proposed; nothing goes out without your approval. Fully automated filing is scoped for <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">roadmap</a> item #57 — until that lands, the review step is mandatory.
       </div>
     </section>
 
@@ -106,17 +106,17 @@
         Each cycle should leave APE measurably better.
       </blockquote>
       <p>
-        This is the antifragility thesis applied to the framework itself. Without an evolution loop, APE is exactly what it was — locked, static, aging. With it, operational friction becomes proposed improvements. Every time a cycle hits a rough edge that the maintainer had to work around, DARWIN can file a proposal to smooth it.
+        This is the antifragility thesis applied to the framework itself. Without an evolution loop, the methodology is exactly what it was — locked, static, aging. With it, operational friction becomes proposed improvements. Every time a cycle hits a rough edge that the maintainer had to work around, DARWIN can file a proposal to smooth it.
       </p>
       <p>
-        The guarantee: those proposals are public, auditable, and subject to review. Nothing disappears silently. Nothing happens in a private ops dashboard. The evolution story of APE is told in its issue tracker, in your language, at your approval.
+        The guarantee: those proposals are public, auditable, and subject to review. Nothing disappears silently. Nothing happens in a private ops dashboard. The evolution story of Inquiry is told in its issue tracker, in your language, at your approval.
       </p>
     </section>
 
     <section aria-labelledby="summary-heading">
       <h2 id="summary-heading">Privacy summary</h2>
       <p>
-        The one-paragraph version you can quote anywhere: <strong>EVOLUTION is off by default. When enabled, DARWIN reads only files inside <code>.inquiry/</code>. Proposals are filed as public issues on the APE repo, with your approval before each filing. No telemetry. No analytics. No third-party service. Your source code stays on your machine.</strong>
+        The one-paragraph version you can quote anywhere: <strong>EVOLUTION is off by default. When enabled, DARWIN reads only the declared cycle artifacts in <code>docs/cleanrooms/&lt;issue&gt;/</code> plus <code>.inquiry/mutations.md</code>. Proposals are filed as public issues in the Inquiry repository, with your approval before each filing. No telemetry. No analytics. No third-party service. Your source code stays on your machine.</strong>
       </p>
     </section>
 
@@ -129,11 +129,11 @@
         </a>
         <a href="methodology.html" class="deeper-card">
           <h3>Methodology →</h3>
-          <p>How EVOLUTION fits into the five-state cycle, and the transition contract that gates it.</p>
+          <p>How EVOLUTION fits into the current operational cycle, and the transition contract that gates it.</p>
         </a>
         <a href="ape-builds-ape.html" class="deeper-card">
-          <h3>APE builds APE →</h3>
-          <p>What DARWIN has already produced — the collapse from nine apes to four was its work.</p>
+          <h3>Bootstrap thesis: APE builds APE →</h3>
+          <p>What DARWIN already changed during the historical bootstrap that reduced nine lore apes to four active ones.</p>
         </a>
       </div>
     </section>
@@ -141,7 +141,7 @@
     <footer>
       <a href="index.html">Home</a>·
       <a href="https://github.com/siliconbrainedmachines/inquiry">GitHub</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/roadmap.md">Roadmap</a>·
+      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
       MIT License
     </footer>
   </div>

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,8 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More targets coming soon.</p>
-      <span class="badge">v0.1.2</span>
+      <span class="badge">v0.1.3</span>
+      <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">
         <div class="os-tabs" role="tablist" aria-label="Operating system">
@@ -53,7 +54,7 @@
             <button class="copy-btn" onclick="copy(this)" aria-label="Copy install command">Copy</button>
             <code>curl -fsSL https://inquiry.si14bm.com/install.sh | bash</code>
           </div>
-          <p class="install-note">Installs to <code>~/.inquiry/</code> and deploys APE agents to your AI coding tool.</p>
+          <p class="install-note">Installs to <code>~/.inquiry/</code> and deploys Inquiry agents to your AI coding tool.</p>
         </div>
       </div>
 
@@ -63,7 +64,7 @@
     </header>
 
     <p class="intro">
-      Inquiry structures your AI coding assistant as a <strong>five-state finite machine</strong> — one specialized agent per phase, transitions verified by the CLI. The bet is <strong>methodology over model</strong>: if the framework carries the weight, a smaller or free model following it should stay useful where freestyling falls apart. That's the thesis Inquiry exists to test.
+      Inquiry structures AI-assisted work as a <strong>finite-state system with an explicit END gate and optional EVOLUTION pass</strong>. Inquiry names the cycle-level process, APE names the orchestrating methodology, and the Finite APE Machine names the engineered system that operationalizes both. The bet is <strong>methodology over model</strong>: if the framework carries the weight, a smaller or free model following it should stay useful where freestyling falls apart.
     </p>
 
     <section id="cycle">
@@ -129,6 +130,10 @@
     <section id="deeper">
       <h2>Go deeper</h2>
       <div class="deeper">
+        <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/index.md" class="deeper-card">
+          <h3>Documentation map →</h3>
+          <p>The authority-aware entry into architecture, research, specs, lore, and cleanrooms.</p>
+        </a>
         <a href="agents.html" class="deeper-card">
           <h3>Meet the agents →</h3>
           <p>Four active agents — SOCRATES, DESCARTES, BASHŌ, DARWIN — and the honest story of five that collapsed.</p>
@@ -137,9 +142,9 @@
           <h3>Methodology →</h3>
           <p>The FSM, the transition contract, memory-as-code, and the semantic risk matrix.</p>
         </a>
-        <a href="ape-builds-ape.html" class="deeper-card">
-          <h3>Inquiry builds Inquiry →</h3>
-          <p>The empirical bootstrap: APE is being built using APE. Each cycle is evidence.</p>
+        <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/spec/finite-ape-machine.md" class="deeper-card">
+          <h3>Finite APE Machine spec →</h3>
+          <p>The current technical overview of the finite-state system and its supporting specifications.</p>
         </a>
       </div>
     </section>
@@ -150,7 +155,7 @@
 
     <footer>
       <a href="https://github.com/siliconbrainedmachines/inquiry">GitHub</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/roadmap.md">Roadmap</a>·
+      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
       <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/spec/finite-ape-machine.md">Spec</a>·
       MIT License
     </footer>

--- a/code/site/install.ps1
+++ b/code/site/install.ps1
@@ -9,7 +9,7 @@
 #   3. Extracts to $env:LOCALAPPDATA\inquiry\
 #   4. Adds inquiry\bin\ to the user PATH
 #   5. Creates `iq.cmd` batch shim
-#   6. Runs `inquiry target get`
+#   6. Runs `inquiry target get` for the active target (Copilot today)
 #   7. Verifies with `inquiry version`
 
 $ErrorActionPreference = 'Stop'
@@ -85,7 +85,7 @@ if ($userPath -notlike "*$binDir*") {
 
 # ─── Deploy and verify ───────────────────────────────────────────────────────
 
-Write-Host '>>> Deploying Inquiry to all targets...'
+Write-Host '>>> Deploying Inquiry to the active target...'
 & (Join-Path $binDir 'inquiry.exe') target get
 
 Write-Host '>>> Verifying installation...'

--- a/code/site/install.sh
+++ b/code/site/install.sh
@@ -10,7 +10,7 @@
 #   3. Extracts to ~/.inquiry/
 #   4. Symlinks to ~/.local/bin (XDG standard, in default PATH)
 #   5. Symlinks `iq` alias
-#   6. Runs `inquiry target get`
+#   6. Runs `inquiry target get` for the active target (Copilot today)
 #   7. Verifies with `inquiry version`
 
 set -euo pipefail
@@ -112,7 +112,7 @@ done
 
 # ─── Deploy and verify ───────────────────────────────────────────────────────
 
-echo ">>> Deploying Inquiry to all targets..."
+echo ">>> Deploying Inquiry to the active target..."
 "$BIN_DIR/inquiry" target get
 
 echo ">>> Verifying installation..."

--- a/code/site/methodology.html
+++ b/code/site/methodology.html
@@ -4,16 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Methodology — Inquiry</title>
-  <meta name="description" content="How Inquiry works: a five-state finite machine, a declarative transition contract, memory as code, and the antifragility thesis.">
+  <meta name="description" content="How Inquiry works: a six-state operational model, a declarative transition contract, memory as code, and the antifragility thesis.">
   <meta name="theme-color" content="#0a0e1a">
 
   <meta property="og:title" content="Methodology — Inquiry">
-  <meta property="og:description" content="A five-state FSM, a declarative transition contract, memory as code.">
+  <meta property="og:description" content="A six-state operational model, a declarative transition contract, and memory as code.">
   <meta property="og:type" content="article">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Methodology — Inquiry">
-  <meta name="twitter:description" content="A five-state FSM, a declarative transition contract, memory as code.">
+  <meta name="twitter:description" content="A six-state operational model, a declarative transition contract, and memory as code.">
 
   <link rel="icon" type="image/svg+xml" href="img/favicon.svg">
 
@@ -35,12 +35,15 @@
       <p class="page-subhead">
         Inquiry treats your AI coding assistant as a finite state machine with a declarative transition contract. The CLI enforces pre- and post-conditions. Intelligence emerges from orchestration and memory — not from any single agent's capability.
       </p>
+      <p class="page-subhead">
+        This page is a public explainer. For the canonical documentation map, see <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/index.md">docs/index.md</a>.
+      </p>
     </header>
 
     <section aria-labelledby="fsm-heading">
-      <h2 id="fsm-heading">The five-state FSM</h2>
+      <h2 id="fsm-heading">The operational cycle</h2>
       <p class="section-intro">
-        Six states if you count rest. <code>IDLE</code> is the entry and exit. <code>ANALYZE</code>, <code>PLAN</code>, <code>EXECUTE</code> are the core. <code>END</code> is the PR gate. <code>EVOLUTION</code> is opt-in. The forward flow is linear; backward edges from <code>PLAN</code> and <code>EXECUTE</code> to <code>ANALYZE</code> exist because re-analysis is legal, not a recovery hack.
+        The current operational model is a six-state cycle. <code>IDLE</code> is the entry and exit. <code>ANALYZE</code>, <code>PLAN</code>, and <code>EXECUTE</code> are the core work phases. <code>END</code> is the explicit PR gate. <code>EVOLUTION</code> is opt-in. The forward flow is linear; backward edges from <code>PLAN</code> and <code>EXECUTE</code> to <code>ANALYZE</code> exist because re-analysis is legal, not a recovery hack.
       </p>
       <figure class="fsm-diagram">
         <img src="img/fsm.svg" alt="Inquiry finite state machine diagram showing IDLE → ANALYZE → PLAN → EXECUTE → END → IDLE cycle, with backward transitions from PLAN and EXECUTE to ANALYZE, and an opt-in EVOLUTION state after END.">
@@ -107,14 +110,15 @@
           <ul class="memory-list">
             <li><code>state.yaml</code> — current FSM state and last transition</li>
             <li><code>config.yaml</code> — feature flags (<code>evolution.enabled</code>, target, etc.)</li>
-            <li><code>mutations.md</code> — history of DARWIN's accepted mutations</li>
-            <li><code>diagnosis.md</code>, <code>plan.md</code> — active cycle's artifacts</li>
+            <li><code>mutations.md</code> — human notes for DARWIN's evaluation pass</li>
+            <li>Runtime coordination state for the active cycle</li>
           </ul>
         </div>
         <div class="memory-col">
-          <h3><code>docs/</code> — project knowledge</h3>
+          <h3><code>docs/</code> — project knowledge and cycle artifacts</h3>
           <ul class="memory-list">
             <li>ADRs, specs, runbooks — whatever the project needs long-term</li>
+            <li><code>docs/cleanrooms/&lt;issue&gt;/</code> holds per-cycle analysis, plan, and metrics artifacts</li>
             <li>Indexed by the agents via the <code>memory-read</code> skill</li>
             <li><code>index.md</code> per directory acts as a primary index</li>
             <li>Frontmatter YAML acts as a schema (enforced by a future skill)</li>
@@ -132,7 +136,7 @@
         Spec-only today. The idea: <code>iq state transition</code> should gate on human approval only when the engineering risk warrants it. Low-risk mechanical transitions (scaffolding, formatting, test scaffolding) proceed silently. High-risk ones (schema changes, production deploys, external API mutations) demand explicit approval.
       </p>
       <div class="callout callout--warn">
-        <strong>Roadmap item.</strong> Until the matrix is implemented, every state transition requires operator confirmation. The default is safe but verbose. See the <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/roadmap.md">roadmap</a> under long-term items.
+        <strong>Roadmap item.</strong> Until the matrix is implemented, every state transition requires operator confirmation. The default is safe but verbose. See the <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">roadmap</a> under long-term items.
       </div>
     </section>
 
@@ -145,7 +149,7 @@
         Three scenarios, same conclusion. Cloud models get expensive? Inquiry works with local ones. Frontier models plateau? DARWIN becomes the only improvement mechanism left. Models keep improving? Inquiry amplifies the gains without rewriting the runbook. The framework benefits from disorder — antifragile across the AI market.
       </p>
       <p>
-        The thesis Inquiry exists to test: given an identical task, a smaller model running Inquiry outperforms a frontier model freestyling. The evidence lives in a <code>metrics.yaml</code> dataset that doesn't fully exist yet — the reproducibility score sits at 2/10 until 30 clean cycles and a multi-target test matrix land. See <a href="ape-builds-ape.html">Inquiry builds Inquiry →</a>.
+        The thesis Inquiry exists to test: given an identical task, a smaller model running Inquiry outperforms a frontier model freestyling. The evidence lives in a <code>metrics.yaml</code> dataset that doesn't fully exist yet — the reproducibility score sits at 2/10 until 30 clean cycles and a multi-target test matrix land. See the historical bootstrap thesis, <a href="ape-builds-ape.html">APE builds APE →</a>.
       </p>
     </section>
 
@@ -157,8 +161,12 @@
           <p>The four agents that run each phase, and the five that collapsed.</p>
         </a>
         <a href="ape-builds-ape.html" class="deeper-card">
-          <h3>Inquiry builds Inquiry →</h3>
-          <p>The empirical bootstrap. Evidence that the methodology works — or what's still missing.</p>
+          <h3>Bootstrap thesis: APE builds APE →</h3>
+          <p>The historical bootstrap story and the evidence it produced, without making APE the current product name.</p>
+        </a>
+        <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/architecture.md" class="deeper-card">
+          <h3>Read the architecture →</h3>
+          <p>The canonical system-level explanation of APE as the orchestrating methodology.</p>
         </a>
         <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/spec/finite-ape-machine.md" class="deeper-card">
           <h3>Read the spec →</h3>
@@ -170,7 +178,7 @@
     <footer>
       <a href="index.html">Home</a>·
       <a href="https://github.com/siliconbrainedmachines/inquiry">GitHub</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/roadmap.md">Roadmap</a>·
+      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
       MIT License
     </footer>
   </div>

--- a/code/vscode/CHANGELOG.md
+++ b/code/vscode/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.3] - 2026-04-23
+
+### Changed
+- Marketplace metadata aligned with the current Inquiry documentation map: description now includes the explicit END gate and homepage points to the public Inquiry site
+- README and internal extension docs now route readers to canonical repository docs instead of acting like primary doctrine
+- Integration coverage is now exercised inside the VS Code host for activation, mutation notes, evolution toggling, and status-bar behavior instead of remaining as skipped placeholders
+
+### Fixed
+- Historical design notes now explicitly mark old `ape` vocabulary and `docs/issues/*/plan.md` examples as archive-only guidance
+- The integration suite no longer reports skipped placeholder cases for the currently shipped extension features
+
 ## [0.1.2] - 2026-04-22
 
 ### Changed

--- a/code/vscode/README.md
+++ b/code/vscode/README.md
@@ -3,8 +3,10 @@
 **Analyze. Plan. Execute.**
 
 > Select **@inquiry** as your GitHub Copilot custom agent.
-> Every task follows a strict cycle: **ANALYZE → PLAN → EXECUTE**.
+> Every task follows a strict cycle: **ANALYZE → PLAN → EXECUTE → END**.
 > No freestyling. No hallucinated plans. Structure from analysis to PR.
+
+This README is the extension's public entry surface. For the canonical repository documentation map, start at [../docs/index.md](../docs/index.md).
 
 ---
 
@@ -18,7 +20,7 @@
 | **PLAN** | Decomposes into checkable steps with tests | `plan.md` |
 | **EXECUTE** | Implements exactly what the plan says | code + commits |
 
-Each phase has a dedicated agent. Transitions are enforced — no skipping steps.
+The extension is a lightweight integration surface around the Inquiry CLI and the Inquiry custom agent for GitHub Copilot. The canonical explanations of Inquiry, APE, the Finite APE Machine, and Thinking Tools live in the repository documentation, not in this README.
 
 ---
 
@@ -29,7 +31,7 @@ Each phase has a dedicated agent. Transitions are enforced — no skipping steps
 3. The extension installs the CLI if missing, runs `iq init`, creates `.inquiry/`
 4. Open Copilot Chat → select **@inquiry** → describe your task
 
-That's it. APE takes over: analysis first, then plan, then execute.
+That's it. The Inquiry agent takes over inside Copilot Chat: analysis first, then plan, then execute.
 
 ---
 
@@ -55,13 +57,14 @@ The status bar shows the current FSM phase in real time:
 
 - VS Code ≥ 1.85
 - Windows or Linux
-- GitHub Copilot (required) — APE ships as a custom agent
+- GitHub Copilot (required) — Inquiry ships as a custom agent
 
 ---
 
 ## Links
 
 - [Website](https://www.si14bm.com/inquiry/) · [GitHub](https://github.com/siliconbrainedmachines/inquiry) · [Issues](https://github.com/siliconbrainedmachines/inquiry/issues)
+- [Docs map](https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/index.md) · [Architecture](https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/architecture.md) · [Finite APE Machine spec](https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/spec/finite-ape-machine.md)
 
 For the full methodology, see [si14bm.com/inquiry](https://www.si14bm.com/inquiry/).
 

--- a/code/vscode/docs/ape_vscode_extension.md
+++ b/code/vscode/docs/ape_vscode_extension.md
@@ -9,6 +9,10 @@ author: copilot
 
 # APE VS Code Extension — Architecture & Specification
 
+> Status note: This document is a historical and aspirational design draft. It does not match the currently published extension manifest in [../package.json](../package.json), which today exposes only `inquiry.init`, `inquiry.toggleEvolution`, and `inquiry.addMutation`, activates on `workspaceContains:.inquiry/`, and publishes the extension under the Inquiry name.
+>
+> Treat this file as a design archive, not as the authoritative description of current extension behavior. Internal examples here that mention broader command inventories, `ape` vocabulary, or `docs/issues/*/plan.md` paths are historical design assumptions, not current implementation guidance. For the current public entry surface, see [../README.md](../README.md). For the canonical repository doctrine, see [../../docs/index.md](../../docs/index.md), [../../docs/architecture.md](../../docs/architecture.md), and [../../docs/spec/finite-ape-machine.md](../../docs/spec/finite-ape-machine.md).
+
 > Extensión de VS Code para el framework APE (Finite APE Machine).
 > Basada en el análisis de la extensión Flutter/Dart-Code (ver `flutter_vscode_extension.md`).
 > Lenguaje: TypeScript, empaquetado con webpack, publicada como `.vsix`.

--- a/code/vscode/package-lock.json
+++ b/code/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inquiry-vscode",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inquiry-vscode",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"

--- a/code/vscode/package.json
+++ b/code/vscode/package.json
@@ -2,8 +2,8 @@
   "name": "inquiry-vscode",
   "displayName": "Inquiry",
   "publisher": "siliconbrainedmachines",
-  "version": "0.1.2",
-  "description": "Inquiry — Analyze. Plan. Execute. Structured AI-assisted development for GitHub Copilot.",
+  "version": "0.1.3",
+  "description": "Inquiry — Analyze. Plan. Execute. End. Structured AI-assisted development for GitHub Copilot.",
   "license": "MIT",
   "icon": "assets/icon.png",
   "repository": {
@@ -11,7 +11,7 @@
     "url": "https://github.com/siliconbrainedmachines/inquiry"
   },
   "bugs": { "url": "https://github.com/siliconbrainedmachines/inquiry/issues" },
-  "homepage": "https://github.com/siliconbrainedmachines/inquiry",
+  "homepage": "https://www.si14bm.com/inquiry/",
   "categories": ["Other"],
   "keywords": ["inquiry", "agent", "github-copilot", "copilot", "ai", "methodology"],
   "engines": {

--- a/code/vscode/test/integration/activation.test.ts
+++ b/code/vscode/test/integration/activation.test.ts
@@ -3,13 +3,13 @@ import { strict as assert } from 'assert';
 // extension.ts imports 'vscode' at module level — these tests
 // can only run inside the VS Code test runner (@vscode/test-electron).
 describe('extension exports', () => {
-  it.skip('activate is a function', () => {
+  it('activate is a function', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { activate } = require('../../src/extension');
     assert.strictEqual(typeof activate, 'function');
   });
 
-  it.skip('deactivate is a function', () => {
+  it('deactivate is a function', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { deactivate } = require('../../src/extension');
     assert.strictEqual(typeof deactivate, 'function');

--- a/code/vscode/test/integration/add-mutation.test.ts
+++ b/code/vscode/test/integration/add-mutation.test.ts
@@ -1,22 +1,79 @@
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'mocha';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'mocha';
 
-// These integration tests require @vscode/test-electron runner.
-// Marked as SKIP until Phase 5 smoke test sets up the full runner.
+import { addMutation } from '../../src/commands';
+import { createTempWorkspace, removeTempWorkspace, stubWindowMethod } from './helpers';
 
 describe('addMutation integration', function () {
-  it.skip('addMutation muestra InputBox y appends texto a mutations.md', () => {
-    // Requires vscode API: window.showInputBox, fs.appendFileSync
-    assert.ok(true);
+  let root = '';
+  let inquiryPath = '';
+  let restoreInputBox: (() => void) | undefined;
+  let restoreInfo: (() => void) | undefined;
+  let infoMessages: string[] = [];
+
+  beforeEach(() => {
+    const temp = createTempWorkspace('inquiry-vscode-add-mutation-');
+    root = temp.root;
+    inquiryPath = temp.inquiryPath;
+    infoMessages = [];
   });
 
-  it.skip('addMutation crea mutations.md si no existe', () => {
-    // Requires vscode API: window.showInputBox, fs operations
-    assert.ok(true);
+  afterEach(() => {
+    restoreInputBox?.();
+    restoreInfo?.();
+    restoreInputBox = undefined;
+    restoreInfo = undefined;
+    removeTempWorkspace(root);
   });
 
-  it.skip('addMutation con cancel (undefined) no modifica archivo', () => {
-    // Requires vscode API: window.showInputBox returning undefined
-    assert.ok(true);
+  it('addMutation muestra InputBox y appends texto a mutations.md', async () => {
+    const mutationsPath = path.join(inquiryPath, 'mutations.md');
+    fs.writeFileSync(mutationsPath, '# Mutations\n', 'utf-8');
+
+    restoreInputBox = stubWindowMethod('showInputBox', async () => 'Observed drift');
+    restoreInfo = stubWindowMethod('showInformationMessage', async (message: string) => {
+      infoMessages.push(message);
+      return undefined;
+    });
+
+    await addMutation(inquiryPath);
+
+    const content = fs.readFileSync(mutationsPath, 'utf-8');
+    assert.match(content, /^# Mutations\n- \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\] Observed drift\n$/);
+    assert.deepStrictEqual(infoMessages, ['Inquiry: Mutation note added']);
+  });
+
+  it('addMutation crea mutations.md si no existe', async () => {
+    const mutationsPath = path.join(inquiryPath, 'mutations.md');
+
+    restoreInputBox = stubWindowMethod('showInputBox', async () => 'Fresh note');
+    restoreInfo = stubWindowMethod('showInformationMessage', async (message: string) => {
+      infoMessages.push(message);
+      return undefined;
+    });
+
+    await addMutation(inquiryPath);
+
+    assert.ok(fs.existsSync(mutationsPath));
+    const content = fs.readFileSync(mutationsPath, 'utf-8');
+    assert.match(content, /^- \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\] Fresh note\n$/);
+    assert.deepStrictEqual(infoMessages, ['Inquiry: Mutation note added']);
+  });
+
+  it('addMutation con cancel (undefined) no modifica archivo', async () => {
+    const mutationsPath = path.join(inquiryPath, 'mutations.md');
+
+    restoreInputBox = stubWindowMethod('showInputBox', async () => undefined);
+    restoreInfo = stubWindowMethod('showInformationMessage', async (message: string) => {
+      infoMessages.push(message);
+      return undefined;
+    });
+
+    await addMutation(inquiryPath);
+
+    assert.ok(!fs.existsSync(mutationsPath));
+    assert.deepStrictEqual(infoMessages, []);
   });
 });

--- a/code/vscode/test/integration/helpers.ts
+++ b/code/vscode/test/integration/helpers.ts
@@ -1,0 +1,65 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+
+export function createTempWorkspace(prefix: string): {
+  root: string;
+  inquiryPath: string;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const inquiryPath = path.join(root, '.inquiry');
+  fs.mkdirSync(inquiryPath, { recursive: true });
+  return { root, inquiryPath };
+}
+
+export function removeTempWorkspace(root: string): void {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+export function stubWindowMethod(
+  name: 'showInputBox' | 'showInformationMessage',
+  impl: unknown,
+): () => void {
+  const windowAny = vscode.window as unknown as Record<string, unknown>;
+  const original = windowAny[name];
+  const hadOwn = Object.prototype.hasOwnProperty.call(windowAny, name);
+
+  Object.defineProperty(windowAny, name, {
+    value: impl,
+    configurable: true,
+    writable: true,
+  });
+
+  return () => {
+    if (hadOwn) {
+      Object.defineProperty(windowAny, name, {
+        value: original,
+        configurable: true,
+        writable: true,
+      });
+      return;
+    }
+
+    delete windowAny[name];
+  };
+}
+
+export function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 3000,
+  intervalMs = 25,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await delay(intervalMs);
+  }
+  throw new Error('Timed out waiting for condition');
+}

--- a/code/vscode/test/integration/smoke.test.ts
+++ b/code/vscode/test/integration/smoke.test.ts
@@ -1,14 +1,28 @@
 import { strict as assert } from 'node:assert';
+import * as vscode from 'vscode';
 import { describe, it } from 'mocha';
 
 // Smoke test: requires @vscode/test-electron runner.
-// Marked as SKIP until Phase 5 sets up the full integration runner.
 
 describe('extension module', function () {
-  it.skip('exports activate and deactivate', () => {
-    // Requires vscode module — only runnable inside VS Code host
+  it('activate registers the init command in the VS Code host', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const extension = require('../../src/extension');
-    assert.strictEqual(typeof extension.activate, 'function');
-    assert.strictEqual(typeof extension.deactivate, 'function');
+    const context = {
+      subscriptions: [] as vscode.Disposable[],
+      environmentVariableCollection: {
+        prepend: () => {},
+        description: '',
+      },
+    } as unknown as vscode.ExtensionContext;
+
+    extension.activate(context);
+
+    const commands = await vscode.commands.getCommands(true);
+    assert.ok(commands.includes('inquiry.init'));
+
+    for (const disposable of context.subscriptions) {
+      disposable.dispose();
+    }
   });
 });

--- a/code/vscode/test/integration/status-bar.test.ts
+++ b/code/vscode/test/integration/status-bar.test.ts
@@ -1,22 +1,72 @@
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'mocha';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type * as vscode from 'vscode';
+import { afterEach, beforeEach, describe, it } from 'mocha';
 
-// These integration tests require @vscode/test-electron runner.
-// Marked as SKIP until Phase 5 smoke test sets up the full runner.
+import { createStatusBar } from '../../src/status-bar';
+import { createTempWorkspace, delay, removeTempWorkspace, waitFor } from './helpers';
 
 describe('StatusBar integration', function () {
-  it.skip('createStatusBar crea un StatusBarItem visible', () => {
-    // Requires vscode API: window.createStatusBarItem
-    assert.ok(true);
+  this.timeout(5000);
+
+  let root = '';
+  let inquiryPath = '';
+
+  beforeEach(() => {
+    const temp = createTempWorkspace('inquiry-vscode-status-bar-');
+    root = temp.root;
+    inquiryPath = temp.inquiryPath;
   });
 
-  it.skip('updateStatusBar con ApeState actualiza text y tooltip del item', () => {
-    // Requires vscode API: StatusBarItem.text, StatusBarItem.tooltip
-    assert.ok(true);
+  afterEach(() => {
+    removeTempWorkspace(root);
   });
 
-  it.skip('dispose limpia el item y el watcher', () => {
-    // Requires vscode API: Disposable.dispose, FileSystemWatcher
-    assert.ok(true);
+  it('createStatusBar crea un StatusBarItem visible', async () => {
+    const context = { subscriptions: [] as vscode.Disposable[] } as unknown as vscode.ExtensionContext;
+    const [item, watcher] = createStatusBar(context, root) as [vscode.StatusBarItem, vscode.FileSystemWatcher];
+
+    await waitFor(() => item.text.includes('Inquiry: IDLE'));
+
+    assert.match(item.text, /Inquiry: IDLE/);
+    assert.strictEqual(String(item.tooltip), 'Inquiry: IDLE');
+    assert.strictEqual(context.subscriptions.length, 2);
+
+    watcher.dispose();
+    item.dispose();
+  });
+
+  it('updateStatusBar con ApeState actualiza text y tooltip del item', async () => {
+    const statePath = path.join(inquiryPath, 'state.yaml');
+    fs.writeFileSync(statePath, 'cycle:\n  phase: PLAN\n  task: "042"\n', 'utf-8');
+    const context = { subscriptions: [] as vscode.Disposable[] } as unknown as vscode.ExtensionContext;
+    const [item, watcher] = createStatusBar(context, root) as [vscode.StatusBarItem, vscode.FileSystemWatcher];
+
+    await waitFor(() => item.text.includes('PLAN #042'));
+
+    assert.match(item.text, /Inquiry: PLAN #042/);
+    assert.strictEqual(String(item.tooltip), 'Inquiry: PLAN — Task #042');
+
+    watcher.dispose();
+    item.dispose();
+  });
+
+  it('dispose limpia el item y el watcher', async () => {
+    const statePath = path.join(inquiryPath, 'state.yaml');
+    fs.writeFileSync(statePath, 'cycle:\n  phase: ANALYZE\n  task: "042"\n', 'utf-8');
+    const context = { subscriptions: [] as vscode.Disposable[] } as unknown as vscode.ExtensionContext;
+    const [item, watcher] = createStatusBar(context, root) as [vscode.StatusBarItem, vscode.FileSystemWatcher];
+
+    await waitFor(() => item.text.includes('ANALYZE #042'));
+    const beforeDispose = item.text;
+
+    watcher.dispose();
+    item.dispose();
+
+    fs.writeFileSync(statePath, 'cycle:\n  phase: EXECUTE\n  task: "042"\n', 'utf-8');
+    await delay(250);
+
+    assert.strictEqual(item.text, beforeDispose);
   });
 });

--- a/code/vscode/test/integration/toggle-evolution.test.ts
+++ b/code/vscode/test/integration/toggle-evolution.test.ts
@@ -1,22 +1,72 @@
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'mocha';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'mocha';
 
-// These integration tests require @vscode/test-electron runner.
-// Marked as SKIP until Phase 5 smoke test sets up the full runner.
+import { toggleEvolution } from '../../src/commands';
+import { createTempWorkspace, removeTempWorkspace, stubWindowMethod } from './helpers';
 
 describe('toggleEvolution integration', function () {
-  it.skip('toggleEvolution lee config.yaml, invierte enabled, escribe el nuevo valor', () => {
-    // Requires vscode API: fs + full command handler
-    assert.ok(true);
+  let root = '';
+  let inquiryPath = '';
+  let restoreInfo: (() => void) | undefined;
+  let infoMessages: string[] = [];
+
+  beforeEach(() => {
+    const temp = createTempWorkspace('inquiry-vscode-toggle-evolution-');
+    root = temp.root;
+    inquiryPath = temp.inquiryPath;
+    infoMessages = [];
   });
 
-  it.skip('toggleEvolution crea config.yaml con enabled=true si no existe', () => {
-    // Requires vscode API: fs + full command handler
-    assert.ok(true);
+  afterEach(() => {
+    restoreInfo?.();
+    restoreInfo = undefined;
+    removeTempWorkspace(root);
   });
 
-  it.skip('toggleEvolution muestra notification con el nuevo estado', () => {
-    // Requires vscode API: window.showInformationMessage
-    assert.ok(true);
+  it('toggleEvolution lee config.yaml, invierte enabled, escribe el nuevo valor', async () => {
+    const configPath = path.join(inquiryPath, 'config.yaml');
+    fs.writeFileSync(configPath, 'evolution:\n  enabled: false\n', 'utf-8');
+    restoreInfo = stubWindowMethod('showInformationMessage', async (message: string) => {
+      infoMessages.push(message);
+      return undefined;
+    });
+
+    await toggleEvolution(inquiryPath);
+
+    const content = fs.readFileSync(configPath, 'utf-8');
+    assert.match(content, /enabled: true/);
+    assert.deepStrictEqual(infoMessages, ['Inquiry: Evolution enabled']);
+  });
+
+  it('toggleEvolution crea config.yaml con enabled=true si no existe', async () => {
+    const configPath = path.join(inquiryPath, 'config.yaml');
+    restoreInfo = stubWindowMethod('showInformationMessage', async (message: string) => {
+      infoMessages.push(message);
+      return undefined;
+    });
+
+    await toggleEvolution(inquiryPath);
+
+    assert.ok(fs.existsSync(configPath));
+    const content = fs.readFileSync(configPath, 'utf-8');
+    assert.match(content, /enabled: true/);
+    assert.deepStrictEqual(infoMessages, ['Inquiry: Evolution enabled']);
+  });
+
+  it('toggleEvolution muestra notification con el nuevo estado', async () => {
+    const configPath = path.join(inquiryPath, 'config.yaml');
+    fs.writeFileSync(configPath, 'evolution:\n  enabled: true\n', 'utf-8');
+    restoreInfo = stubWindowMethod('showInformationMessage', async (message: string) => {
+      infoMessages.push(message);
+      return undefined;
+    });
+
+    await toggleEvolution(inquiryPath);
+
+    const content = fs.readFileSync(configPath, 'utf-8');
+    assert.match(content, /enabled: false/);
+    assert.deepStrictEqual(infoMessages, ['Inquiry: Evolution disabled']);
   });
 });

--- a/docs/adr/0002-ape-builds-ape.md
+++ b/docs/adr/0002-ape-builds-ape.md
@@ -6,6 +6,8 @@ Date: 2026-03-30
 
 Accepted
 
+> Historical naming note: this ADR preserves the original bootstrap thesis "APE Builds APE" because APE was the system's working name when the decision was made. Inquiry is the current public identity of the system.
+
 ## Context
 
 Finite APE Machine is a methodology framework for AI-assisted development. The framework itself must be developed. The question is whether to use the APE methodology to build APE, even though the tooling (CLI, agents, Memory as Code) does not yet exist.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # Architecture
 
+> This document is the current canonical system-level explanation of APE as the orchestrating methodology.
+>
 > How APE orchestrates AI coding agents through a finite state machine.
 
 ## The system in one diagram
@@ -66,7 +68,7 @@
 │  .inquiry/state.yaml        ← current FSM state (IDLE, ANALYZE, etc.)   │
 │  .inquiry/config.yaml       ← cycle config (evolution.enabled, etc.)    │
 │  .inquiry/mutations.md      ← human notes for DARWIN                    │
-│  docs/issues/NNN-slug/  ← per-cycle artifacts (plan.md, metrics)    │
+│  docs/cleanrooms/NNN-slug/ ← per-cycle artifacts (analyze/, plan.md, metrics.yaml) │
 │  docs/spec/             ← canonical specifications                  │
 └─────────────────────────────────────────────────────────────────────┘
 ```

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/ANALISIS_ESTADO.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/ANALISIS_ESTADO.md
@@ -1,0 +1,512 @@
+# Análisis del Estado Actual — Finite APE Machine (Inquiry)
+
+**Fecha:** Abril 22, 2026  
+**Versión:** 0.1.2
+
+---
+
+## Resumen Ejecutivo
+
+**Inquiry** es una metodología de desarrollo asistido por IA que modela el proceso de codificación como una **máquina de estados finita (FSM)** de 5 estados: `IDLE → ANALYZE → PLAN → EXECUTE → END → EVOLUTION → IDLE`.
+
+El proyecto consta de tres componentes principales:
+1. **CLI** (Dart) — motor de la metodología, orquesta transiciones de estado
+2. **Sitio web** (HTML/CSS/JS) — landing page, documentación, descargas
+3. **Extensión VS Code** (TypeScript) — interfaz visual integrada en el editor
+
+**Estado:** MVP funcional en v0.1.2 con **131 tests**, cross-platform (Windows + Linux), single-target (Copilot) por decisión arquitectónica (ADR D20).
+
+---
+
+## 1. La Metodología (en `docs/`)
+
+### 1.1 Fundamentos filosóficos
+
+La metodología se basa en la **teoría de la investigación de Peirce** (Abducción → Deducción → Inducción):
+
+| Fase APE | Ape | Función | Salida | Mapeo Peirce |
+|----------|-----|---------|--------|-------------|
+| **ANALYZE** | SOCRATES | Aclarar el problema mediante diálogo (mayéutica) | `diagnosis.md` | Abducción |
+| **PLAN** | DESCARTES | Descomponer, ordenar, verificar, enumerar | `plan.md` | Deducción |
+| **EXECUTE** | BASHŌ | Implementación mínima y hermosa bajo restricciones de tests | código + commits | Inducción |
+| **END** | — | Gate de PR: crear y mergear | PR merged | — |
+| **EVOLUTION** | DARWIN | Selección natural: proponer mutaciones | issues en repo APE | Metaaprendizaje |
+
+### 1.2 Principios clave
+
+**1. Metodología > Modelo**
+- Apostar que un modelo pequeño siguiendo un runbook estructurado supera a un modelo frontier improvisando
+- La metodología es el artefacto duradero, no el modelo de IA
+
+**2. Memory as Code**
+- Conocimiento del proyecto versionado en el repo, no en DBs vectoriales en la nube
+- Queryable, reproducible, agnóstico de infraestructura
+
+**3. Antifragilidad**
+- Cada ciclo debe dejar APE mediblemente mejor
+- DARWIN propone mutaciones basadas en evidencia (metrics.yaml, issues de evolución)
+
+**4. AAD/AAE/AAM**
+- **AAD** (Agent-Aided Design): ANALYZE — soberanía humana
+- **AAE** (Agent-Aided Engineering): PLAN + test definition — colaboración profunda
+- **AAM** (Agent-Aided Manufacturing): EXECUTE — IA dominante, humano supervisa
+
+### 1.3 Documentación de la metodología
+
+```
+docs/
+├── spec/
+│   ├── finite-ape-machine.md          ← Manifesto + teoría de control
+│   ├── agent-lifecycle.md             ← Ciclo de vida del agente
+│   ├── memory-as-code-spec.md         ← Arquitectura de memoria
+│   ├── cli-as-api.md                  ← Principio: skills → comandos CLI
+│   ├── target-specific-agents.md      ← Estrategia de deployment multi-target
+│   └── index.md                       ← Índice de specs
+├── research/
+│   ├── ape_builds_ape/                ← Bootstrap empírico (APE construyendo APE)
+│   ├── inquiry/                       ← Fundamentación de Peirce
+│   └── swebok/                        ← Referencias de ingeniería
+├── adr/                               ← Architecture Decision Records (Nygard format)
+│   ├── 0001-record-architecture-decisions.md
+│   ├── 0002-ape-builds-ape.md
+│   └── ...
+├── cleanrooms/                        ← Por-ciclo work-in-progress
+│   ├── 002-ape-init/
+│   ├── 003-ape-init-v2/
+│   └── ...
+└── roadmap.md                         ← Dirección futura (v0.1.x → v0.5.0 → v1.0+)
+```
+
+**Estado:** La metodología está **bien documentada** en `docs/spec/`. Cada decisión arquitectónica tiene respaldo en `docs/adr/`. El bootstrap empírico está en marcha en `docs/research/ape_builds_ape/`.
+
+---
+
+## 2. Componente 1: CLI (Dart)
+
+### 2.1 Qué es
+
+Ejecutable multiplataforma (`inquiry.exe` en Windows, `inquiry` en Linux) que orquesta el FSM. Es el **motor central** de la metodología.
+
+### 2.2 Estructura
+
+```
+code/cli/
+├── lib/
+│   ├── fsm_contract.dart              ← Máquina de estados declarativa
+│   ├── inquiry_cli.dart               ← Entry point
+│   ├── modules/                       ← Modularización (global, target, state)
+│   │   ├── global/                    ← Comandos globales (init, doctor, version)
+│   │   ├── target/                    ← Deployment (target get/clean)
+│   │   └── state/                     ← Transiciones de estado FSM
+│   ├── src/                           ← Utilidades (YAML parsing, efectos, prechecks)
+│   └── targets/                       ← Adapters para múltiples herramientas
+├── bin/
+│   └── main.dart                      ← CLI entry
+├── test/                              ← 131 tests
+├── pubspec.yaml
+├── analysis_options.yaml
+├── CHANGELOG.md
+└── README.md
+```
+
+### 2.3 Módulos principales
+
+| Módulo | Responsabilidad |
+|--------|-----------------|
+| **global** | `iq init`, `iq doctor`, `iq version`, `iq upgrade`, `iq uninstall`, `iq` (TUI) |
+| **target** | `iq target get` (deploy agents/skills a Copilot), `iq target clean` |
+| **state** | `iq state transition --event <e>` (cambios de estado determinísticos) |
+
+### 2.4 Dependencias
+
+- `cli_router` — enrutamiento puro de comandos
+- `modular_cli_sdk` — framework para CLI (orchestration, DTO, output)
+- `yaml` — parsing de `state.yaml`, `config.yaml`, transition_contract.yaml
+- Dart SDK 3.8.1+
+
+### 2.5 Compilación y distribución
+
+**Build:**
+- Windows: `dart compile exe bin/main.dart -o inquiry.exe`
+- Linux/macOS: `dart compile exe bin/main.dart -o inquiry`
+- Multiplatform via GitHub Actions (Windows + Linux + macOS Intel/ARM)
+
+**Distribución:**
+- GitHub Releases (binarios precompilados)
+- Scripts de instalación: `install.ps1` (Windows), `install.sh` (Linux)
+- Almacenamiento en `~/.inquiry/bin/` (con fallback a `%LOCALAPPDATA%\inquiry\`)
+
+### 2.6 Comandos actuales (v0.1.2)
+
+```bash
+iq                              # TUI banner con estado FSM actual
+iq init                         # Crear .inquiry/ (idempotente)
+iq doctor                       # Verificar prerequisitos (git, gh, gh auth)
+iq version                      # Mostrar versión
+iq upgrade                      # Descargar última release
+iq uninstall                    # Remover CLI
+iq target get                   # Desplegar agent + skills a Copilot
+iq target clean                 # Limpiar archivos desplegados
+iq state transition --event <e> # Ejecutar transición FSM con prechecks/efectos
+```
+
+### 2.7 Comandos planeados (roadmap)
+
+- `iq memory query` — busca indexadas en `docs/`
+- `iq memory validate` — validación de schema YAML
+- `iq memory write` — creación guiada de documentos
+- `iq task` — wrapper en `gh issue/pr create/merge` con prechecks
+
+### 2.8 Estado actual
+
+✅ **Estable**: Transiciones FSM, deployment de targets, TUI, doctor  
+🟡 **En desarrollo**: `memory-*` commands, metrics collection (issue #72)  
+⏳ **Planeado**: Multi-target wiring (ADR D20 — deferred), local-first (v1.0)
+
+---
+
+## 3. Componente 2: Sitio Web
+
+### 3.1 Qué es
+
+Landing page, documentación visual, y scripts de instalación. Punto de entrada público.
+
+### 3.2 Estructura
+
+```
+code/site/
+├── index.html                         ← Landing principal
+├── agents.html                        ← Presentación de los 4 apes
+├── methodology.html                   ← Explicación de FSM + AAD/AAE/AAM
+├── ape-builds-ape.html                ← Bootstrap empírico
+├── evolution.html                     ← DARWIN y mutaciones
+├── install.ps1                        ← Script de instalación (Windows)
+├── install.sh                         ← Script de instalación (Linux/macOS)
+├── CNAME                              ← inquiry.si14bm.com
+├── css/
+│   ├── shared.css
+│   ├── landing.css
+│   └── ...
+├── js/
+│   └── main.js
+├── img/
+│   ├── fsm.svg                        ← Diagrama de la máquina de estados
+│   ├── favicon.svg
+│   └── ...
+└── docs/                              ← Redirecciones a GitHub docs/
+```
+
+### 3.3 Características
+
+- **Responsive design** (mobile-first)
+- **Copy-paste install commands** por OS (Windows → PowerShell, Linux → Bash)
+- **FSM diagram interactivo** (SVG)
+- **Links a metodología, roadmap, spec**
+- **Meta tags** para SEO (og:, twitter:)
+
+### 3.4 Hosting
+
+- Dominio: `inquiry.si14bm.com`
+- Hosteado en GitHub Pages (rama `main` + CNAME)
+- Build: estático (sin SSG, pure HTML/CSS/JS)
+
+### 3.5 Estado actual
+
+✅ **Completo**: Landing, copy-paste installs, links a documentación  
+🟡 **Pendiente**: Deep-dive pages (agents, methodology, evolution) — existen pero necesitan más pulido
+
+---
+
+## 4. Componente 3: Extensión VS Code
+
+### 4.1 Qué es
+
+Plugin de VS Code que proporciona interfaz visual (sidebar, command palette, status bar) para la metodología APE. **No es obligatoria** — la CLI es suficiente.
+
+### 4.2 Visión
+
+Convertir VS Code en el "centro de mando" del ciclo APE sin sacrificar la opción de usar la terminal.
+
+| Sin extensión | Con extensión |
+|---------------|---------------|
+| `iq doctor` en terminal | Panel visual con checks/fails |
+| `iq state transition -e start_analysis` en terminal | Click en botón |
+| Editar `.inquiry/mutations.md` manualmente | Editor inline con timestamp |
+| Desconocer el estado actual | Status bar: `APE: ANALYZE #42` |
+
+### 4.3 Estructura
+
+```
+code/vscode/
+├── package.json                       ← Manifiesto (v0.1.2, 25 comandos, 3 views)
+├── tsconfig.json
+├── webpack.config.js                  ← Build: TS → JS → out/dist/extension.js
+├── CHANGELOG.md
+├── README.md
+│
+├── src/
+│   ├── extension.ts                   ← activate() / deactivate()
+│   ├── config.ts                      ← Wrapper sobre vscode.workspace.getConfiguration
+│   ├── constants.ts                   ← Context keys, paths, nombres
+│   │
+│   ├── cli/
+│   │   ├── detector.ts                ← Buscar inquiry.exe en PATH
+│   │   ├── installer.ts               ← Descargar desde GitHub Releases
+│   │   ├── runner.ts                  ← Ejecutar comandos CLI y parsear output
+│   │   └── version.ts                 ← Semver compare
+│   │
+│   ├── commands/                      ← Implementación de comandos VS Code
+│   │   ├── init.ts
+│   │   ├── cycle.ts                   ← analyze, plan, execute, evolve, end
+│   │   ├── mutations.ts
+│   │   ├── doctor.ts
+│   │   ├── install.ts
+│   │   ├── target.ts
+│   │   └── state.ts
+│   │
+│   ├── views/                         ← Sidebar panels
+│   │   ├── cycle-status.ts            ← WebView — FSM diagram
+│   │   ├── plan-tree.ts               ← TreeView — plan.md checkboxes
+│   │   ├── doctor-tree.ts             ← TreeView — prerequisite checks
+│   │   └── mutations-editor.ts        ← WebView — mutations.md editor
+│   │
+│   ├── status-bar/
+│   │   └── cycle-indicator.ts         ← "APE: IDLE" / "APE: ANALYZE #42"
+│   │
+│   ├── watchers/
+│   │   ├── state-watcher.ts           ← Watch .inquiry/state.yaml → refresh
+│   │   ├── config-watcher.ts
+│   │   └── plan-watcher.ts
+│   │
+│   └── utils/
+│       ├── fs.ts, yaml.ts, github.ts
+│
+├── media/
+│   ├── ape-icon.svg
+│   ├── states/                        ← Íconos por estado FSM
+│   └── webview/
+│
+├── test/
+└── docs/
+    ├── ape_vscode_extension.md        ← Especificación
+    └── flutter_vscode_extension.md    ← Análisis de Flutter extension (referencia)
+```
+
+### 4.4 Activation Events
+
+```json
+"activationEvents": [
+  "workspaceContains:.inquiry/",
+  "onCommand:inquiry.init",
+  "onCommand:ape.install",
+  "onCommand:ape.doctor"
+]
+```
+
+Activa cuando:
+- El workspace contiene `.inquiry/` (proyecto APE existente)
+- Usuario ejecuta manualmente un comando APE
+
+### 4.5 Context Keys (cuando clauses)
+
+Control condicional de UI mediante contexto:
+
+```
+"ape:cliInstalled"       → visibility de comandos
+"ape:projectLoaded"      → visibility de sidebar
+"ape:currentState"       → qué botones mostrar
+"ape:cycleActive"        → habilitar/deshabilitar transiciones
+"ape:evolutionEnabled"   → mostrar panel de evolution
+```
+
+### 4.6 Comandos principales
+
+| Comando | Categoría | Cuando |
+|---------|-----------|--------|
+| `inquiry.init` | Setup | siempre |
+| `ape.doctor` | Setup | siempre |
+| `ape.install` / `ape.update` | Setup | si no instalado / versión vieja |
+| `ape.target.get` | Setup | si instalado |
+| `ape.startAnalysis` | Ciclo | IDLE + proyecto cargado |
+| `ape.approveDiagnosis` | Ciclo | ANALYZE + diagnosis.md existe |
+| `ape.approvePlan` | Ciclo | PLAN + plan.md existe |
+| `ape.approveExecution` | Ciclo | EXECUTE |
+| `ape.createPR` | Ciclo | END |
+| `ape.abortCycle` | Ciclo | cualquier estado activo |
+| `ape.returnToAnalysis` | Ciclo | PLAN o EXECUTE (transiciones backward) |
+| `ape.evolution.toggle` | Config | proyecto cargado |
+
+### 4.7 Views (Sidebar)
+
+- **Cycle Status** — WebView con diagrama FSM interactivo
+- **Plan Tree** — TreeView con checkboxes del plan.md
+- **Doctor Tree** — TreeView con estado de prerequisitos
+- **Mutations Editor** — WebView para editar mutations.md
+
+### 4.8 State actual
+
+🟡 **En desarrollo** (v0.1.2): Estructura definida, no todos los comandos/views implementados  
+⏳ **Prioritario**: Completar panels de sidebar, watchers de archivo, UX de installer
+
+---
+
+## 5. Capas Transversales
+
+### 5.1 `.inquiry/` — Runtime per-ciclo
+
+```
+.inquiry/
+├── state.yaml                         ← Estado FSM actual (IDLE, ANALYZE, etc.)
+├── config.yaml                        ← Configuración (evolution.enabled, etc.)
+└── mutations.md                       ← Notas para DARWIN (evol. phase)
+```
+
+**Responsabilidad:**
+- Estado actual persiste aquí
+- CLI lee esto para saber qué transición es válida
+- Agent + skills consultan para saber la fase actual
+
+### 5.2 Agentes Desplegados
+
+```
+~/.copilot/agents/
+└── inquiry.agent.md                   ← Orquestador single (léase: "multiple conductas")
+
+~/.copilot/skills/
+├── issue-start/SKILL.md               ← Protocolo: crear rama, iniciar análisis
+├── issue-end/SKILL.md                 ← Protocolo: crear PR, mergear
+├── memory-read/SKILL.md               ← Protocolo: query indexada en docs/
+└── memory-write/SKILL.md              ← Protocolo: crear docs con YAML frontmatter
+```
+
+**Nota importante:** No son 4 agentes separados. Es **un solo `inquiry.agent.md`** que se comporta diferente según el estado en `.inquiry/state.yaml`. El design simplifica coordination.
+
+### 5.3 `docs/issues/NNN-slug/` — Artifacts por ciclo
+
+```
+docs/issues/
+├── 001-nombre-primer-issue/
+│   ├── analysis/
+│   │   └── index.md (SOCRATES output)
+│   ├── plan.md (DESCARTES output + checkboxes)
+│   ├── metrics.yaml (DARWIN input para evolución #72)
+│   └── evolution/
+│       └── mutations.md (qué cambios propone DARWIN)
+├── 002-segundo-issue/
+│   └── ...
+```
+
+---
+
+## 6. Estado General del Proyecto
+
+### 6.1 Versión Actual
+
+**v0.1.2** (Abril 2026)
+- 131 tests
+- 12 GitHub releases
+- Cross-platform (Windows + Linux; macOS future)
+- Single-target MVP (solo Copilot, per ADR D20)
+
+### 6.2 Hito de Completitud
+
+| Componente | Estado | Completitud |
+|------------|--------|-------------|
+| **Metodología** | ✅ Documentada | 90% |
+| **CLI Core** | ✅ Estable | 85% |
+| **CLI Commands** | 🟡 Parcial | 70% (memory-* pending) |
+| **Sitio Web** | ✅ Funcional | 75% |
+| **VS Code Ext** | 🟡 WIP | 50% (estructura, no UI complete) |
+| **Tests** | ✅ Buena cobertura | 80% |
+
+### 6.3 Roadmap
+
+**v0.1.x (Near-term):**
+- ✅ 5-state FSM completo
+- ✅ Comandos globales + target deployment
+- 🟡 #47–#49: Cycle memory infrastructure
+- 🟡 #46: Subagent delegation (ANALYZE phase)
+- 🟡 #72: `metrics.yaml` collection (reproducibility)
+
+**v0.5.0 (Mid-term):**
+- `iq memory` CLI (query, validate, write)
+- `iq task` CLI (wrapper en gh issue/pr)
+- Multi-target reactivation (Claude, Crush, Gemini)
+- Antifragility validation harness
+
+**v1.0+ (Long-term):**
+- Local-first APE (Gemma, Qwen, etc.)
+- Bootstrap-validation paper
+- DARWIN community-level learning
+- Risk-matrix-driven UX
+
+---
+
+## 7. Decisiones Arquitectónicas Clave
+
+| ID | Decisión | Estado |
+|----|----------|--------|
+| **D1** | One agent, many behaviors (state-driven) | ✅ Implementado |
+| **D2** | Total FSM (every state×event explicit) | ✅ Implementado |
+| **D3** | CLI enforces, agent proposes | ✅ Implementado |
+| **D4** | Skills as step-by-step protocols (markdown) | ✅ Implementado |
+| **D5** | Memory in repo (no external vector DB) | ✅ Implementado |
+| **D6** | Single target until MVP (Copilot only) | ✅ Implementado |
+| **D7** | EVOLUTION opt-in (config.yaml flag) | ✅ Implementado |
+| **D20** | Target-specific agents (ADR) | ✅ Deferred multi-target |
+
+---
+
+## 8. Necesidades Identificadas
+
+### 8.1 Documentación
+
+✅ **Bien cubierta:**
+- Metodología (docs/spec/)
+- ADRs (docs/adr/)
+- Bootstrap empírico (docs/research/ape_builds_ape/)
+
+🟡 **Mejorables:**
+- Guía de usuario (README en sitio web es bueno, pero falta "cómo usar APE paso a paso")
+- Troubleshooting (qué hacer si algo falla)
+- Developer guide (cómo extender APE)
+
+### 8.2 Funcionalidad
+
+✅ **Completo:**
+- FSM core
+- Target deployment (Copilot)
+- Doctor + version
+
+🟡 **Pendiente (roadmap):**
+- `memory-*` commands (query, write, validate)
+- Metrics collection (#72)
+- VS Code extension UI (solo estructura exist, falta implementación)
+- Multi-target wiring
+
+### 8.3 Testing
+
+✅ **131 tests** con buen coverage  
+🟡 **Pendiente:**
+- Integration tests (CLI + agent interacción)
+- E2E tests (full cycle: init → analyze → plan → execute → merge)
+
+---
+
+## 9. Conclusión
+
+**Inquiry** es un proyecto **bien estructurado y documentado** en su componente metodológico. El CLI es **estable y funcional** como motor central. El sitio web es **adecuado para difusión**. La extensión VS Code es **conceptualmente sólida** pero está en fase de implementación.
+
+El proyecto está en una **posición de madurez media**:
+- ✅ La metodología está clara y tiene respaldo teórico
+- ✅ El CLI funciona y es confiable
+- 🟡 Algunos comandos importantes aún faltan (memory-*)
+- 🟡 La extensión VS Code es WIP
+- ⏳ Multi-target es future work (consciente, por ADR)
+
+**Próximos pasos sugeridos:**
+1. Completar VS Code extension UI (sidebar views, watchers)
+2. Implementar `memory-*` commands en CLI
+3. Agregar `metrics.yaml` collection para recolección de datos empíricos (#72)
+4. Escribir guía de usuario paso-a-paso
+5. Iniciar multi-target wiring (Claude, Crush) en v0.2.0+

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/PROPUESTA_DOCS.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/PROPUESTA_DOCS.md
@@ -1,0 +1,281 @@
+# Propuesta: Consolidación de Documentación de la Metodología
+
+**Fecha:** Abril 22, 2026
+
+---
+
+## Contexto
+
+La metodología de **Inquiry** está actualmente distribuida entre varios lugares:
+- `docs/spec/` — especificaciones técnicas
+- `docs/research/inquiry/` — fundamentos de Peirce
+- `README.md` raíz — elevator pitch
+- `docs/architecture.md` — cómo funciona el sistema
+- `code/site/methodology.html` — versión web
+- `docs/lore.md` — nomenclatura histórica de apes
+
+**Problema:** Un nuevo usuario tiene que recorrer múltiples archivos para entender qué es la metodología.
+
+---
+
+## Propuesta de Estructura
+
+### Paso 1: Crear `docs/METHODOLOGY.md` como punto de entrada
+
+Este archivo sería el **hub central** de la metodología, con:
+
+```markdown
+# Inquiry Methodology
+
+**Five-state finite machine for AI-aided software development.**
+
+Quick navigation:
+- [Quick Start](#quick-start)
+- [Core Concepts](#core-concepts)
+- [The Five States](#the-five-states)
+- [The Agents](#the-agents)
+- [Memory Architecture](#memory-architecture)
+- [How It Works: A Cycle](#how-it-works-a-cycle)
+- [Deep Dives](#deep-dives)
+
+## Quick Start
+
+[copy from README]
+
+## Core Concepts
+
+[4 principles: Methodology > Model, Memory as Code, Antifragility, AAD/AAE/AAM]
+
+## The Five States
+
+[table with state, agent, function, output]
+
+## The Agents
+
+[brief intro to SOCRATES, DESCARTES, BASHŌ, DARWIN + their collapse to 4]
+
+## Memory Architecture
+
+[.inquiry/, docs/issues/NNN/, docs/spec/ — roles of each]
+
+## How It Works: A Cycle
+
+[end-to-end walkthrough with concrete example]
+
+## Deep Dives
+
+- [Finite APE Machine Spec](spec/finite-ape-machine.md) — full manifesto
+- [Agent Lifecycle](spec/agent-lifecycle.md) — FSM states
+- [Memory-as-Code](spec/memory-as-code-spec.md) — structured documentation
+- [Peirce's Inquiry Theory](research/inquiry/peirce-abduction.md) — philosophical foundation
+- [Architecture](architecture.md) — how the system is built
+```
+
+### Paso 2: Reorganizar `docs/spec/index.md`
+
+Cambiar de lista plana a **tabla jerárquica con propósito**:
+
+```markdown
+# Specifications — Finite APE Machine
+
+## Core Concepts (Read First)
+
+| Document | Purpose |
+|----------|---------|
+| [Finite APE Machine](finite-ape-machine.md) | Manifesto + control theory foundations |
+| [Inquiry Methodology](../METHODOLOGY.md) | Hub — entry point to the framework |
+
+## Agent & State Machine
+
+| Document | Purpose |
+|----------|---------|
+| [Agent Lifecycle](agent-lifecycle.md) | How agents behave in each state |
+| [Cooperative Multitasking](cooperative-multitasking-model.md) | Agent coordination |
+
+## Memory & Knowledge
+
+| Document | Purpose |
+|----------|---------|
+| [Memory-as-Code Spec](memory-as-code-spec.md) | Structured documentation architecture |
+| [CLI as API](cli-as-api.md) | Skills invoke CLI, CLI enforces validation |
+
+## Implementation
+
+| Document | Purpose |
+|----------|---------|
+| [Inquiry CLI Spec](inquiry-cli-spec.md) | Command line interface + TUI |
+| [Target-Specific Agents](target-specific-agents.md) | Multi-tool deployment strategy |
+| [Orchestrator Spec](orchestrator-spec.md) | Agent prompt structure |
+
+## Philosophy & Research
+
+| Document | Purpose |
+|----------|---------|
+| [Peirce's Inquiry Theory](../research/inquiry/) | Why "Inquiry"? Abduction → Deduction → Induction |
+| [APE Builds APE](../research/ape_builds_ape/) | Bootstrap validation — empirical results |
+```
+
+### Paso 3: Mejorar `docs/lore.md`
+
+Cambiar el título y agregar disclaimer:
+
+```markdown
+# The Apes: Nomenclature & Evolution
+
+**Note:** This document is historical. For current implementation, see [Methodology](METHODOLOGY.md).
+
+## The Nine Lore Apes (Original Vision)
+
+[keep current content]
+
+## The Four Active Apes (Current Reality)
+
+[current table]
+
+## Why the Collapse Was Good
+
+[explain why fewer, sharper agents is better design]
+```
+
+### Paso 4: Crear `docs/GETTING_STARTED.md`
+
+Para el usuario que instala por primera vez:
+
+```markdown
+# Getting Started with Inquiry
+
+## Installation
+
+[install commands]
+
+## Your First Cycle: Step by Step
+
+1. **Check prerequisites**
+   ```bash
+   iq doctor
+   ```
+
+2. **Create an issue on GitHub**
+   ```
+   Title: Add user authentication
+   Description: [requirements...]
+   ```
+
+3. **Start analysis**
+   ```bash
+   iq target get
+   [Open VS Code with your repo]
+   [Click "Inquiry: Start Analysis"]
+   ```
+
+4. **Chat with SOCRATES**
+   [What SOCRATES will ask you]
+   [Output: diagnosis.md]
+
+5. **Approve diagnosis**
+   [Click "Approve Diagnosis"]
+
+6. **Chat with DESCARTES**
+   [What DESCARTES will do]
+   [Output: plan.md with checkboxes]
+
+7. **Approve plan**
+   [Click "Approve Plan"]
+
+8. **BASHŌ implements**
+   [How BASHŌ works — test-red, implement, test-green]
+   [Monitor progress via status bar]
+
+9. **Mark plan complete**
+   [Click checkboxes or "Inquiry: Finish"]
+
+10. **PR created & merged**
+    [Automatic PR creation]
+    [All your commits appear in PR]
+
+11. **Optional: Evolution**
+    [DARWIN proposes improvements — if enabled]
+
+## Next Steps
+
+- [Read the Methodology](METHODOLOGY.md)
+- [Explore the Specs](spec/)
+- [See Architecture Details](architecture.md)
+```
+
+### Paso 5: Actualizar raíz `README.md`
+
+Cambiar la estructura para claridad:
+
+```markdown
+# Inquiry
+
+**Analyze. Plan. Execute.**
+
+[Elevator pitch — 3 párrafos]
+
+## 🚀 Quick Start
+
+[install commands]
+
+## 📚 Learn Inquiry
+
+- **[Getting Started](docs/GETTING_STARTED.md)** — your first cycle step by step
+- **[Methodology](docs/METHODOLOGY.md)** — what Inquiry is and why it works
+- **[Specifications](docs/spec/)** — technical details and architecture
+- **[Roadmap](docs/roadmap.md)** — where we're going
+
+## 🏗️ Project Structure
+
+[code/, docs/, README per folder]
+
+## Status
+
+[v0.1.2, 131 tests, cross-platform, single-target MVP]
+
+## License
+
+MIT
+```
+
+---
+
+## Beneficios
+
+| Beneficio | Quién se beneficia |
+|-----------|-------------------|
+| **Hub central**: METHODOLOGY.md como punto de entrada | Usuarios nuevos, contribuidores |
+| **Jerarquía clara**: spec/index.md reorganizado | Desarrolladores, architektos |
+| **Guía paso a paso**: GETTING_STARTED.md | Usuarios que instalan por primera vez |
+| **README mejor**: links a documentación en lugar de duplicar | Todos |
+| **Menor duplicación**: un lugar para cada concepto | Mantenimiento más fácil |
+
+---
+
+## Implementación Propuesta
+
+### Fase 1 (1-2 horas)
+
+1. Crear `docs/METHODOLOGY.md` (copy + relink desde spec/)
+2. Crear `docs/GETTING_STARTED.md` (nueva guía)
+3. Actualizar `docs/spec/index.md` (reorganizar + jerquizar)
+
+### Fase 2 (30 min)
+
+1. Actualizar `README.md` raíz (links a docs/)
+2. Actualizar `docs/lore.md` (disclaimer + archivo histórico)
+
+### Fase 3 (30 min)
+
+1. QA: verificar que todos los links sean correctos
+2. Actualizar `code/site/` para usar estos links
+
+---
+
+## Decisión
+
+¿Quieres que implemente esta propuesta?
+
+- **SÍ → Procedo ahora**
+- **NO → Déjame revisar primero**
+- **CAMBIOS → Aquí están mis notas...**

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/corpus-boundary-and-ordering-policy.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/corpus-boundary-and-ordering-policy.md
@@ -1,0 +1,88 @@
+---
+id: corpus-boundary-and-ordering-policy
+title: "Corpus boundary, directory-order traversal, and minimal-definition glossary policy for issue #134"
+date: 2026-04-22
+status: active
+tags: [corpus-boundary, audit-order, glossary, documentation, evidence]
+author: socrates
+---
+
+# Corpus Boundary, Directory-Order Traversal, and Minimal-Definition Glossary Policy for Issue #134
+
+## Abstract
+
+Prior analysis established that issue #134 is a documentation-taxonomy problem under archival drift, that the relevant reader is the one seeking both philosophical and technological foundations, and that a glossary plus an auditable reading procedure are analytically necessary. The present paper fixes three narrower operational policies that now follow from both repository evidence and analysis-session clarifications dated 2026-04-22. First, the evidentiary corpus should begin at the scale of the whole workspace rather than at `docs/` alone, because explanatory material already appears in the repository root and within `code/` as well as within `docs/`. Second, directory order should be treated as part of the audit protocol, because ordered traversal must be reproducible and the repository's own path hierarchy is the most repository-native default sequence currently available. Third, first-version glossary entries should be minimal direct disambiguation statements, because the glossary's immediate analytical role is to stabilize term boundaries for the audit rather than to become a second encyclopedia of the system. [1][2][3][4][5][6][7][8][9]
+
+## 1. Why the Evidentiary Corpus Now Includes the Whole Workspace Rather Than `docs/` Alone
+
+### 1.1 Explanatory material is already distributed across root, `docs/`, and `code/`
+
+The repository root is not a neutral wrapper around the documentation set. The root `README.md` introduces Inquiry, states the APE cycle, points readers toward architecture, specification, research, ADRs, issues, and lore, and even embeds visual material from `code/site/`. This means the reader's first model of the system can already be shaped before entering `docs/`. [5]
+
+Nor is explanatory material confined to top-level documentation roots. The repository's main documentation layer remains important: the specification index defines canonical technical references, the inquiry research index defines the epistemic foundation of APE, `docs/architecture.md` explains the orchestrated finite-state system, and `docs/lore.md` explains the agents and thinking tools. Yet the workspace also contains explanatory documents inside `code/`. The site banner specification in `code/site/docs/spec/banner.md` interprets the project's strategic meaning, the Analyze-Plan-Execute triad, and the status of Socrates, Descartes, and Basho as thinking tools. The VS Code extension architecture document in `code/vscode/docs/ape_vscode_extension.md` explains how the editor extension is intended to operationalize the APE cycle. These are not mere implementation comments. They are documentary surfaces that shape interpretation of the same conceptual family at issue in #134. [1][2][3][4][5][6][7]
+
+### 1.2 A `docs/`-only corpus would therefore pre-filter evidence before analysis begins
+
+Prior analysis already established that risky or misleading documents cannot yet be identified in advance and must therefore be read rather than assumed away. Once that premise is combined with the present session's clarification that "all" means the entire workspace, including documentation and code, a `docs/`-only audit becomes analytically inconsistent. It would exclude some explanatory surfaces before the audit has earned the right to classify them as secondary, derivative, or out of scope. [8][9]
+
+The point is not that every file in the workspace will ultimately deserve equal interpretive weight. The point is that admissibility judgments must follow evidence rather than precede it. When documentation about core concepts already exists in root-level entry surfaces and in code-adjacent design documents, the corpus boundary cannot be set at `docs/` without importing a bias in favor of one documentary region before canonicity has been evaluated. [1][5][6][7][8][9]
+
+### 1.3 Analytical consequence
+
+For issue #134, the audit should begin from the whole workspace as the prima facie evidentiary corpus. Later analysis may still distinguish canonical sources from historical notes, implementation-local explanations, and low-authority derivative material. But those are downstream classification judgments. They do not justify a `docs/`-only starting boundary. [6][8][9]
+
+## 2. Why Directory Order Is Now Part of the Audit Protocol
+
+### 2.1 Ordered traversal was already necessary; the current clarification now supplies its default principle
+
+The prior navigation paper already established that reading all relevant material in order is an evidentiary commitment rather than a convenience, because sequence affects how provisional term boundaries are formed and later revised. The current analysis session adds the missing operational rule: reading order should follow directory order. This clarification does not arise from aesthetic preference. It supplies a reproducible traversal rule for a corpus that now spans the whole workspace. [8][9]
+
+### 2.2 Directory order is the most repository-native default sequence currently available
+
+The repository already expresses a path hierarchy that readers encounter as structure: the root `README.md` frames the project at entry; top-level directories such as `docs/` and `code/` divide documentary and implementation regions; local indexes such as `docs/spec/index.md` and `docs/research/inquiry/index.md` organize subcorpora within those regions. Directory order therefore turns an existing repository artifact into an explicit audit procedure. It minimizes private analyst discretion by letting the repository's own arrangement supply the default route. [1][2][5][8]
+
+This matters because issue #134 concerns not only what documents exist, but also what a reader is likely to encounter first. If sequence remains implicit or ad hoc, later judgments about duplication, canonicity, and false-understanding risk become harder to reproduce. Directory order does not guarantee the correct interpretation by itself. It does, however, make the audit's first pass inspectable by another reader who can follow the same route and challenge its results. [6][8][9]
+
+### 2.3 Analytical consequence
+
+Directory order is now part of the audit protocol because completeness without declared sequence is insufficient for reproducible analysis. The policy makes path hierarchy part of the evidence procedure rather than a private convenience of the analyst. It also creates a clear place for later disputes: if the order is wrong, the disagreement can be stated against an explicit rule rather than against an invisible personal reading path. [8][9]
+
+## 3. Why First-Version Glossary Entries Should Be Minimal Direct Disambiguation Statements
+
+### 3.1 Prior analysis established direct definition; the present clarification narrows its form
+
+Earlier analysis already established that the glossary should define terms directly rather than function merely as a hub of deferred references, and that the glossary may expand iteratively as the audit proceeds. The current analysis session adds a more exact standard for the first version: the earliest glossary definitions should be minimal direct definitions focused on disambiguation. [8][9]
+
+### 3.2 Minimality is required because the glossary's immediate task is boundary control
+
+The glossary's first analytical job is not to retell the whole repository. It is to keep adjacent terms from collapsing into one another while the audit is still determining canonical homes and duplicate surfaces. Prior taxonomy analysis already showed that Inquiry, APE, Finite APE Machine, and Thinking Tools are related but non-identical terms. A first-version glossary entry therefore succeeds when it states, as directly as possible, what the term denotes and how it differs from its nearest conceptual neighbors. That is the minimum information needed to stabilize subsequent judgments about overlap, cross-reference, and false-understanding risk. [6][7][8][9]
+
+If the glossary instead begins with expansive mini-essays, two analytical problems follow. First, the glossary starts competing with the very canonical documents whose status is still under review. Second, the audit inherits unnecessary prose volume before it has secured the narrow lexical distinctions on which later document classification depends. Minimality is therefore not a concession to incompleteness. It is a way to preserve direct definition without prematurely turning the glossary into a second documentary center. [6][7][8]
+
+### 3.3 Analytical consequence
+
+A first-version glossary entry should be a minimal direct disambiguation statement: short, explicit, and boundary-focused. It should say what the term is in the current project vocabulary and what distinction it must preserve against adjacent terms. Richer history, implementation detail, and extended exposition may follow later if the audit shows they belong there. But the first-pass glossary should stabilize vocabulary before it attempts completeness. [6][7][8][9]
+
+## 4. Conclusion
+
+Issue #134 now has three additional operating policies that materially constrain the audit. The evidentiary corpus should begin at the whole-workspace level because explanatory surfaces already exist in the repository root, in `docs/`, and within `code/`. Directory order should be part of the audit protocol because reproducible sequence is now required and the repository's own path hierarchy is the least arbitrary available default. And the first glossary should begin with minimal direct disambiguation statements because the glossary's immediate analytical role is lexical stabilization, not exhaustive exposition. These policies do not yet settle canonicity outcomes. They determine the evidentiary discipline under which those later outcomes can be trusted. [1][2][3][4][5][6][7][8][9]
+
+## References
+
+[1] Finite APE Machine repository. "Spec - Finite APE Machine." `docs/spec/index.md`.
+
+[2] Finite APE Machine repository. "Inquiry as Epistemic Foundation of APE." `docs/research/inquiry/index.md`.
+
+[3] Finite APE Machine repository. "Architecture." `docs/architecture.md`.
+
+[4] Finite APE Machine repository. "The Apes - Lore." `docs/lore.md`.
+
+[5] Finite APE Machine repository. "Inquiry." `README.md`.
+
+[6] Finite APE Machine repository. "Taxonomy and scope clarification for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/taxonomy-and-scope-clarification.md`.
+
+[7] Finite APE Machine repository. "Glossary direct-definition and audit navigation requirements for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/glossary-and-audit-navigation-requirements.md`.
+
+[8] Finite APE Machine repository. "Finite APE Machine Banner Specification." `code/site/docs/spec/banner.md`; "APE VS Code Extension - Architecture & Specification." `code/vscode/docs/ape_vscode_extension.md`.
+
+[9] Primary-source analysis-session clarifications dated 2026-04-22 for issue #134: "all" means the entire workspace, including documentation and code; reading order should follow directory order; first glossary definitions should be minimal direct definitions focused on disambiguation.

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/diagnosis.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/diagnosis.md
@@ -1,0 +1,106 @@
+---
+id: diagnosis
+title: "Diagnosis for issue #134: justified documentation status map and canonical-home recommendations"
+date: 2026-04-22
+status: active
+tags: [diagnosis, canonicality, mapping, documentation, glossary]
+author: socrates
+---
+
+# Diagnosis for Issue #134: Justified Documentation Status Map and Canonical-Home Recommendations
+
+## Abstract
+
+Issue #134 is not fundamentally a problem of missing names. It is a problem of documentary authority under accumulation and drift. The repository already contains strong current homes for some core concepts, mixed or historical strata for others, and several outward-facing surfaces that summarize current reality while still carrying stale details. The evidence now supports a precise diagnosis. Inquiry already has a strong canonical philosophical home in `docs/research/inquiry/`. APE, understood as the orchestrating methodological system, is best anchored in `docs/architecture.md`, supported by current lifecycle and coordination specifications. Finite APE Machine does not presently have a fully safe canonical overview, because the file that naturally carries that name preserves an older, more expansive architecture; that concept therefore requires rehabilitation of `docs/spec/finite-ape-machine.md` rather than blind elevation of its current contents. Thinking Tools likewise lacks a clean canonical home: `docs/lore.md` is the strongest current source, but it mixes active terminology with lore and history, so it should become a source and nomenclature document rather than the final glossary home. The reorganization required by issue #134 is therefore selective rather than symmetric across all four named concepts. [1][2][3][4][5][6][7][8][9][10]
+
+## 1. Governing Diagnosis
+
+The audit supports one central claim: the project's documentation problem is a mismatch between current concept ownership and the surfaces through which readers actually encounter the project. Some concepts already have defensible homes, but those homes are obscured by historical residue, duplicated summaries, and inconsistent outward-facing details. Other concepts do not yet have a single reliable home at all. A good reorganization should therefore preserve existing authority where it already exists, rewrite or demote mixed documents where it does not, and avoid creating new top-level concept files merely because their names appear in the issue title. [1][2][3][4][5]
+
+## 2. Concept-by-Concept Canonical-Home Map
+
+| Concept | Canonical decision | Justification | Required action |
+|---|---|---|---|
+| Inquiry | Keep `docs/research/inquiry/` as canonical home | This corpus already defines inquiry as the epistemic foundation of APE and develops the Peircean and Deweyan grounding coherently | Do not replace with a duplicate doctrinal `inquiry.md`; if needed, create only a short gateway pointing here |
+| APE | Elevate `docs/architecture.md` as canonical current home | It best connects methodology, orchestrator role, CLI, agent deployment, and repository memory at a system level for the foundations-oriented reader | Clean stale paths and tighten cross-references so architecture clearly owns the term |
+| Finite APE Machine | Reclaim `docs/spec/finite-ape-machine.md` as canonical home only after rewrite | The filename is naturally authoritative, but the current document preserves a larger legacy architecture and cannot safely govern present understanding without qualification | Rewrite the document to reflect the current model; until then treat `cooperative-multitasking-model.md` and `signal-based-coordination.md` as the practical current technical strata |
+| Thinking Tools | Create a dedicated canonical glossary/explainer document | `docs/lore.md` is currently the richest source, but it mixes nomenclature, allegory, active roster, and historical residue, which makes it too blended to serve as a clean canonical home | Introduce a dedicated Thinking Tools document; keep `docs/lore.md` as source material and historical/nomenclature companion |
+
+This map is intentionally asymmetrical. Inquiry and APE already have defensible current homes. Finite APE Machine and Thinking Tools do not. The reorganization should follow that evidence rather than imposing a symmetrical four-file outcome simply because four names were proposed at the outset. [1][3][4][5][6][7][8][9]
+
+## 3. Document Status Map
+
+| Document or surface | Status | Justification | Recommended role |
+|---|---|---|---|
+| `docs/research/inquiry/index.md` and core inquiry papers | canonical current | Strongest coherent development of inquiry as philosophical and epistemic foundation | Own Inquiry; other surfaces should reference it |
+| `docs/architecture.md` | canonical current candidate | Best current system-level explanation of APE as orchestrated methodology, though still affected by stale paths | Own APE after cleanup |
+| `docs/spec/agent-lifecycle.md` | current supporting | Aligns with current five-state/four-sub-agent model | Supporting spec under APE and Finite APE Machine |
+| `docs/spec/cooperative-multitasking-model.md` | current supporting | Clean current technical explanation of scheduler and two-level FSM structure | Supporting spec; temporary technical anchor while `finite-ape-machine.md` is rewritten |
+| `docs/spec/signal-based-coordination.md` | current supporting | Current RTOS-style signal/event explanation | Supporting spec for Finite APE Machine |
+| `docs/lore.md` | mixed current and historical | Strong on nomenclature and thinking-tool identities, but blended with allegory, extended lore, and drift | Source and historical companion, not sole canonical home for Thinking Tools |
+| `docs/spec/finite-ape-machine.md` | historical or mixed, rewrite-required | Same-name authority is undermined by older multi-agent architecture and legacy states | Rewrite and reclaim as canonical technical overview |
+| `docs/spec/orchestrator-spec.md` | historical | Preserves earlier orchestrator architecture with expanded agent roster and REVIEW-era structure | Keep as historical design record |
+| `docs/spec/memory-as-code-spec.md` | mixed historical | Still conceptually important, but tied to older agents and older write-zone assumptions | Split or revise when memory docs are reorganized |
+| `docs/spec/inquiry-cli-spec.md` | mixed planned | Contains real CLI intent but also planned surfaces and outdated assumptions | Keep as planning/specification material, not canonical current behavior |
+| `docs/spec/cli-as-api.md` | current supporting with drift | Principle remains useful, but paths and some naming are stale | Keep after path cleanup |
+| `docs/spec/target-specific-agents.md` | current supporting with drift | Strategic decision remains current, but path references are stale | Keep after path cleanup |
+| `README.md` | current derivative | Public orientation surface aligned in broad story but stale in version and artifact paths | Entry surface only; reduce operational detail |
+| `docs/roadmap.md` | strategic current, operationally mixed | Valuable for theses and evolution narrative, but stale on current version and END-state status | Strategic planning only; not current-state authority |
+| `code/site/index.html` | current derivative | Public gateway aligned with current branding and release version | Entry surface only |
+| `code/vscode/docs/ape_vscode_extension.md` | obsolete-risky draft | Draft spec diverges from actual extension manifest, naming, commands, and artifact paths | Demote, archive, or rewrite before treating as current |
+
+## 4. Consequences for the Four Proposed Documents
+
+### 4.1 `inquiry.md`
+
+The evidence does not justify a full new doctrinal `inquiry.md` as the primary home of Inquiry. The project already has that home in `docs/research/inquiry/`. If a new reader-facing document is still desired, it should be a short bridge or map to the existing inquiry corpus rather than a competing full explanation. [1][3][6]
+
+### 4.2 `ape.md`
+
+The evidence does not justify a separate `ape.md` if `docs/architecture.md` is strengthened and made explicit as the authoritative current explanation of APE. A new `ape.md` would likely duplicate the architecture document unless it were reduced to a short pointer. [1][3][4]
+
+### 4.3 `finite_ape_machine.md`
+
+Here the issue title is substantively right, but not in the naive sense. The current same-named file is not ready to act as canonical authority. It should be rewritten, not merely retained. The proper action is to reclaim that filename as the authoritative technical overview of the current finite-state, signal-driven, scheduler-based system. [4][7][8]
+
+### 4.4 `thinking_tools.md`
+
+This is the concept for which a new dedicated file is most clearly justified. The project already uses the category, but the current evidence is spread across lore and active-model documents. A dedicated Thinking Tools document would improve clarity without displacing an already-clean home, because no such home presently exists. [1][4][5][9]
+
+## 5. Minimum Reorganization Outcome That Actually Solves the Problem
+
+The smallest reorganization that satisfies the evidence is the following:
+
+1. Preserve `docs/research/inquiry/` as the canonical Inquiry corpus.
+2. Elevate and clean `docs/architecture.md` as the canonical current explanation of APE.
+3. Rewrite `docs/spec/finite-ape-machine.md` to match the current architecture and reclaim its name.
+4. Create one dedicated Thinking Tools document built from current-model evidence and supported by, but not collapsed into, `docs/lore.md`.
+5. Demote README, site, roadmap, and the VS Code extension draft to clearly non-canonical roles, each with sharper cross-references and reduced authority claims.
+
+Any broader rewrite can still be justified later, but this is the minimum evidence-aligned set of changes. It improves clarity without discarding the repository's existing authoritative strata. [1][2][6][10]
+
+## 6. Conclusion
+
+Issue #134 should end not with a cosmetic redistribution of names, but with a clearer doctrine of documentary authority. Inquiry already has a home. APE already has a plausible home. Finite APE Machine needs its natural home rewritten and reclaimed. Thinking Tools needs a true home created. Everything else should be reorganized around those authority decisions, with historical and derivative surfaces marked as such. That is the fully justified map supported by the current repository evidence. [1][2][3][4][5][6][7][8][9][10]
+
+## References
+
+[1] Finite APE Machine repository. "Taxonomy and scope clarification for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/taxonomy-and-scope-clarification.md`.
+
+[2] Finite APE Machine repository. "Obsolescence and canonicity criteria for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/obsolescence-and-canonicity-criteria.md`.
+
+[3] Finite APE Machine repository. "First-pass findings on current documentation strata for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/first-pass-findings-on-current-document-strata.md`.
+
+[4] Finite APE Machine repository. "Expanded entry-surface findings and contradiction synthesis for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/expanded-entry-surface-findings.md`.
+
+[5] Finite APE Machine repository. "Expansion triggers, initial-pass inclusion of architecture and lore, and independent glossary definitions for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/expansion-triggers-and-independent-glossary-definitions.md`.
+
+[6] Finite APE Machine repository. "Inquiry as Epistemic Foundation of APE." `docs/research/inquiry/index.md`.
+
+[7] Finite APE Machine repository. "Finite APE Machine." `docs/spec/finite-ape-machine.md`.
+
+[8] Finite APE Machine repository. "Cooperative multitasking model — two-level FSM architecture." `docs/spec/cooperative-multitasking-model.md`; "Signal-based coordination — RTOS event model for agent communication." `docs/spec/signal-based-coordination.md`.
+
+[9] Finite APE Machine repository. "Architecture." `docs/architecture.md`; "The Apes — Lore." `docs/lore.md`.
+
+[10] Finite APE Machine repository. "Inquiry." `README.md`; "Roadmap." `docs/roadmap.md`; "Inquiry — Analyze. Plan. Execute." `code/site/index.html`; "APE VS Code Extension — Architecture & Specification." `code/vscode/docs/ape_vscode_extension.md`.

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/expanded-entry-surface-findings.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/expanded-entry-surface-findings.md
@@ -1,0 +1,78 @@
+---
+id: expanded-entry-surface-findings
+title: "Expanded entry-surface findings and contradiction synthesis for issue #134"
+date: 2026-04-22
+status: active
+tags: [findings, entry-surfaces, contradictions, documentation, canonicity]
+author: socrates
+---
+
+# Expanded Entry-Surface Findings and Contradiction Synthesis for Issue #134
+
+## Abstract
+
+The initial evidentiary pass already showed that the repository contains a current-model cluster, a legacy-or-expansive cluster, and multiple signals of path drift. Expansion beyond that first pass was then warranted because outward-facing entry surfaces materially affected how a reader would understand the current project. The expanded read confirms four additional findings. First, the root README and the public site largely align around the current Inquiry-branded five-state story, so they are not mere archival leftovers. Second, they remain derivative rather than canonical, because they summarize rather than own the concepts and still contain stale details such as version drift and `docs/issues/` paths. Third, the roadmap remains strategically useful but contains operational facts that now contradict the public current-state story, especially on versioning and the END state. Fourth, the VS Code extension architecture draft is not a safe current specification surface: it preserves older APE naming, planned command vocabulary, and outdated artifact paths that diverge from the actual published extension manifest. These findings materially sharpen the status map for issue #134. [1][2][3][4][5][6][7][8]
+
+## 1. Why Expansion Beyond the First Pass Was Necessary
+
+The first-pass findings already identified two conditions that justified widening the corpus: material contradiction and canonicity conflict. A reader entering through the repository root, the public site, or the VS Code extension documentation would encounter claims about branding, state structure, commands, artifact locations, and implementation maturity that could not be settled from the first-pass corpus alone. That means expansion was not discretionary. It was required by the audit protocol previously established for issue #134. [7][8]
+
+## 2. README and Site as Current but Derivative Entry Surfaces
+
+### 2.1 Both surfaces broadly match the current public model
+
+The root README presents Inquiry rather than APE as the public identity, describes a five-state cycle including END and opt-in EVOLUTION, and presents current commands under the `iq` executable. The site landing page aligns with that same public framing: Inquiry branding, Analyze/Plan/Execute tagline, a five-state machine image that includes END, and active emphasis on GitHub Copilot as the current target. In that sense, both documents reflect the current public-facing narrative rather than an abandoned older layer. [1][3]
+
+### 2.2 Neither surface should be treated as a canonical concept home
+
+Despite that alignment, both surfaces are derivative rather than authoritative. The README is a public gateway that compresses the system into a project overview. The site is a marketing and onboarding surface that further condenses the same story for external readers. Neither document owns the concepts it presents. Both summarize technical and methodological material maintained elsewhere in the repository. Their correct role is therefore discoverability and orientation, not canonical definition. [1][3][7]
+
+### 2.3 Both surfaces still contain stale or contradictory operational detail
+
+The README declares status `v0.1.0`, while the site badge shows `v0.1.2`, the CLI package version is `0.1.2`, and the VS Code extension manifest is also `0.1.2`. The README also continues to describe per-cycle artifacts under `docs/issues/NNN-slug/`, even though the current repository workflow has moved analysis artifacts into `docs/cleanrooms/`. These defects do not make the README useless. They do mean it cannot be treated as the authoritative operational source for current documentation structure. [1][3][5][6]
+
+## 3. The Roadmap Remains Strategically Valuable but Operationally Mixed
+
+### 3.1 The roadmap still communicates real strategic intent
+
+The roadmap remains important because it captures the project's long-running theses: methodology over model, memory as code, and antifragility. It also documents the collapse from a larger lore roster into a smaller active set of four agents. These are still relevant interpretive facts for readers trying to understand why the project currently looks the way it does. [2]
+
+### 3.2 The roadmap should not govern current-state operational understanding
+
+Operationally, however, the roadmap now conflicts with newer outward-facing and implementation-facing surfaces. It describes the current state as `v0.0.14`, lists a five-state FSM that omits END, and places the addition of END in near-term issue #62. That directly conflicts with the README and public site, both of which already present END as part of the current cycle, and with the current released package versions at `0.1.2`. The roadmap therefore remains valid as a strategic and historical planning document, but not as the cleanest source for present operational facts. [1][2][3][5][6]
+
+## 4. The VS Code Extension Architecture Draft Is a Historical or Aspirational Surface, Not a Current Spec
+
+### 4.1 The draft preserves older naming and command assumptions
+
+The extension document is explicitly a draft and still names the product as an APE extension rather than an Inquiry extension. Its examples revolve around `ape` commands, `ape.exe`, `ape.doctor`, `ape.state transition`, and APE-prefixed context keys. By contrast, the actual extension manifest now publishes `Inquiry` as display name, exposes only `inquiry.init`, `inquiry.toggleEvolution`, and `inquiry.addMutation`, and activates only on `workspaceContains:.inquiry/`. These are not cosmetic differences. They show that the draft is describing a broader or earlier design than the one actually published in the codebase. [4][6]
+
+### 4.2 The draft also preserves outdated artifact-path assumptions
+
+The extension draft still proposes a `plan-watcher.ts` that watches `docs/issues/*/plan.md`. That assumption no longer matches the present analysis workflow centered on `docs/cleanrooms/`. This reproduces the same path drift already found elsewhere, but here the risk is greater because the document presents itself as an architectural specification for an implementation surface. If followed literally, it would direct work toward outdated file locations and command names. [4][7]
+
+### 4.3 Analytical consequence
+
+The VS Code extension draft should not be treated as a current canonical specification surface. At best it is a historical or aspirational design artifact. At worst it risks inducing false understanding about the implemented command surface and runtime file layout. Under the criteria already fixed for issue #134, it therefore belongs outside the current canonical set and should be explicitly demoted or rewritten before being presented as current architecture. [4][6][8]
+
+## 5. Consequences for the Status Map
+
+The expanded read sharpens the repository map in three ways. First, README and site are current derivative entry surfaces: useful, current in broad narrative, but non-canonical and partly stale in detail. Second, the roadmap is strategically current but operationally mixed, because it preserves useful historical intent alongside outdated current-state claims. Third, the VS Code extension architecture draft is a historical or obsolete-risky design surface rather than a current implementation authority. These conclusions matter because they prevent the analysis from mistaking high-visibility surfaces for canonical homes simply because readers encounter them early. [1][2][3][4][7][8]
+
+## References
+
+[1] Finite APE Machine repository. "Inquiry." `README.md`.
+
+[2] Finite APE Machine repository. "Roadmap." `docs/roadmap.md`.
+
+[3] Finite APE Machine repository. "Inquiry — Analyze. Plan. Execute." `code/site/index.html`.
+
+[4] Finite APE Machine repository. "APE VS Code Extension — Architecture & Specification." `code/vscode/docs/ape_vscode_extension.md`.
+
+[5] Finite APE Machine repository. `code/cli/pubspec.yaml`.
+
+[6] Finite APE Machine repository. `code/vscode/package.json`.
+
+[7] Finite APE Machine repository. "First-pass findings on current documentation strata for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/first-pass-findings-on-current-document-strata.md`.
+
+[8] Finite APE Machine repository. "Obsolescence and canonicity criteria for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/obsolescence-and-canonicity-criteria.md`.

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/expansion-triggers-and-independent-glossary-definitions.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/expansion-triggers-and-independent-glossary-definitions.md
@@ -1,0 +1,94 @@
+---
+id: expansion-triggers-and-independent-glossary-definitions
+title: "Expansion triggers, initial-pass inclusion of architecture and lore, and independent glossary definitions for issue #134"
+date: 2026-04-22
+status: active
+tags: [corpus-expansion, glossary, evidence, architecture, lore]
+author: socrates
+---
+
+# Expansion Triggers, Initial-Pass Inclusion of Architecture and Lore, and Independent Glossary Definitions for Issue #134
+
+## Abstract
+
+Prior analysis refined the whole-workspace corpus into a staged first pass beginning from `docs/spec/` and the relevant `docs/research/` index, with expansion beyond those indexed foundations treated as conditional rather than automatic. The current analysis session tightens that policy in three ways. First, expansion beyond the first-pass corpus should be governed by multiple explicit trigger conditions rather than by a single undifferentiated notion of evidentiary insufficiency. Second, `docs/architecture.md` and `docs/lore.md` should now be counted inside the initial evidentiary pass, because they are top-level explanatory documents that already bear directly on the concepts under review rather than merely serving as optional secondary context. Third, first-version glossary entries may now be written as clear, independent definitions rather than only as minimal direct labels, because the glossary must support comparison across documentary surfaces without forcing the reader to reconstruct basic term identity from scattered texts. These claims are grounded in repository evidence, prior analysis papers in this cleanroom, and primary-source analysis-session clarifications dated 2026-04-22. [1][2][3][4][5][6][7][8][9]
+
+## 1. Decision Frame
+
+### 1.1 The first-pass policy now needs a sharper account of both entry and expansion
+
+Earlier papers established two important constraints. The admissible evidentiary horizon for issue #134 extends beyond a narrow `docs/spec/`-only or `docs/research/`-only reading, yet first-pass analysis should still begin from a disciplined subset rather than from indiscriminate whole-workspace simultaneity. The staged-entry paper answered that need by proposing an initial pass through `docs/spec/` and the relevant `docs/research/` index, while keeping later expansion available when the initial pass left the matter unresolved. [1][2][5][6]
+
+The current session clarifies that this staged policy must now be expressed more precisely. Expansion is not triggered by one vague condition, but by several analytically distinct conditions. At the same time, the first pass is not limited to indexed subdirectories alone, because `docs/architecture.md` and `docs/lore.md` belong to the initial evidentiary surface. Finally, the glossary's first entries should not be reduced to thin labels that only gesture toward later elaboration; they may and should stand as clear independent definitions. The present paper addresses these three linked refinements as one topic: the evidentiary discipline governing how the first pass begins, when it widens, and what kind of lexical control must accompany it. [3][4][5][6][7][8][9]
+
+## 2. Why Multiple Trigger Conditions Are Acceptable for Leaving the First-Pass Corpus
+
+### 2.1 A single trigger formula would hide different failure modes of first-pass sufficiency
+
+If expansion were governed only by a single phrase such as "insufficient evidence," the policy would be directionally correct but analytically weak. Different kinds of insufficiency imply different evidentiary consequences. A definitional gap means that the first-pass corpus does not yet yield a stable answer to what a target concept is. An explicit outward reference means that an initial-pass document itself points the reader to another documentary surface as necessary for proper understanding. A material contradiction means that two initial-pass surfaces make claims that cannot both govern interpretation without further comparison. A canonicity conflict means that multiple surfaces plausibly compete to serve as the authoritative home for the same concept. These are not interchangeable problems, even if all of them justify widening the corpus. [1][2][3][4][5][6][7][9]
+
+Treating them as distinct triggers improves rigor because it converts expansion from a discretionary impression into a reproducible evidentiary judgment. Another analyst can inspect whether the widening occurred because a term remained undefined, because a document explicitly sent the reader elsewhere, because the corpus contradicted itself, or because concept ownership remained contested. A multi-trigger policy is therefore not looser than a single-trigger policy. It is stricter, because it makes the reasons for leaving the first-pass corpus inspectable and contestable. [5][6][7][9]
+
+### 2.2 Multiple triggers preserve staged discipline without pretending that every unresolved case looks the same
+
+The earlier staged-entry paper was correct to reject automatic expansion from the outset. But once the first pass has begun, the analysis can fail in more than one way. Sometimes the problem is absence: the concept is not defined well enough in the initial pass. Sometimes the problem is dependency: the initial pass explicitly points beyond itself. Sometimes the problem is conflict: the initial pass yields incompatible claims. Sometimes the problem is authority: more than one document appears to own the concept. The existence of multiple triggers therefore reflects the real structure of documentary uncertainty rather than analytical laxity. [3][4][5][6][7][9]
+
+### 2.3 Analytical consequence
+
+Leaving the first-pass corpus should now be governed by a declared set of trigger conditions: definitional gap, explicit outward reference, material contradiction, or canonicity conflict. This keeps expansion conditional rather than automatic while also preventing the analysis from collapsing distinct evidentiary problems into one opaque justification. [5][6][7][9]
+
+## 3. Why `docs/architecture.md` and `docs/lore.md` Belong in the Initial Evidentiary Pass
+
+### 3.1 These documents already carry first-order explanatory weight for the concepts under review
+
+The issue under analysis concerns the organization of documentation for Inquiry, APE, Finite APE Machine, and Thinking Tools. The specification index and inquiry research index are obvious first-pass anchors because they are repository-authored indexes for technical and philosophical foundations. But `docs/architecture.md` and `docs/lore.md` are not remote or optional commentary. The architecture document explains APE as an orchestrated finite-state system, describes the inquiry cycle, names the state-specific roles of SOCRATES, DESCARTES, BASHO, and DARWIN, and situates the relationship among the human, the inquiry CLI, the agent, and repository memory. The lore document explains APE as scheduler rather than sub-agent, assigns SOCRATES to ANALYZE, and defines the thinking-tool identities of the named agents. These are direct contributions to the meaning of the very concepts at issue. [1][2][3][4]
+
+Because of that direct explanatory weight, excluding architecture and lore from the initial pass would artificially privilege indexed subdirectories while postponing two top-level documents that already shape how a reader understands the conceptual family in question. The first pass is supposed to gather the repository's most immediate foundation surfaces, not merely the subset that happen to live under indexed subfolders. On the present evidence, architecture and lore qualify as initial-pass evidence because they already function as foundational cross-layer explanations inside `docs/`. [1][2][3][4][5][6][8][9]
+
+### 3.2 Their initial-pass inclusion is necessary precisely because expansion remains conditional
+
+If architecture and lore were treated as materials to be consulted only after a trigger fired, the initial pass would begin by omitting two documents that are already known to bear directly on the target concepts. That would force the analysis to manufacture an expansion event merely to admit evidence whose relevance is already established. A trigger-based policy should be reserved for uncertain or contingent widening, not for documentary surfaces whose first-order relevance is already plain from repository evidence and prior analysis. [3][4][5][6][7][8][9]
+
+### 3.3 Analytical consequence
+
+The initial evidentiary pass should now include four entry surfaces rather than two kinds of indexed material alone: `docs/spec/index.md`, `docs/research/inquiry/index.md`, `docs/architecture.md`, and `docs/lore.md`. This remains a staged policy because the pass is still narrower than the whole workspace, but it is a stronger staged policy because it includes the top-level explanatory documents that already participate directly in concept formation. [1][2][3][4][5][6][9]
+
+## 4. Why First Glossary Entries May Now Be Clear, Independent Definitions Rather Than Only Minimal Direct Labels
+
+### 4.1 The earlier minimal-label rule solved one problem but now undershoots the evidentiary need
+
+Prior glossary papers were right to insist that the glossary define terms directly and to resist turning it into a second encyclopedia. They also moved toward narrower first-pass formulations, including minimal direct disambiguation and what-it-is-only definitions. Those moves were justified because the glossary's immediate role was lexical stabilization while canonicity remained unsettled. [5][6][8]
+
+The current clarification strengthens rather than rejects that logic. A first glossary entry may remain brief and first-pass in scope, yet it should now be written as a clear, independent definition. The difference matters. A minimal direct label can identify a term without being fully intelligible on its own. An independent definition, by contrast, should allow a reader to understand the basic identity of the term without needing immediate rescue from another document. Once the first pass explicitly includes research, specification, architecture, and lore, and once expansion is triggered by definitional gaps and authority conflicts, the glossary must do more than pin a placeholder label onto each concept. It must furnish a stable sentence-level definition that can be used to compare later evidence across surfaces. [1][2][3][4][5][6][8][9]
+
+### 4.2 Independence is required because glossary entries now function as comparison baselines
+
+The glossary is no longer serving only as a memory aid for the analyst. It now functions as a control instrument for comparing claims across a staged corpus that may widen under several triggers. When a later document contradicts the first-pass understanding of a term, or competes to become its canonical home, the analysis needs a baseline formulation against which that later evidence can be judged. A merely skeletal label is too weak for that task. A clear independent definition is strong enough to stabilize comparison while still remaining shorter and more neutral than a full canonical exposition. [5][6][7][8][9]
+
+### 4.3 Analytical consequence
+
+The first glossary entries for issue #134 may and should now be treated as clear, independent definitions: concise enough to avoid replacing canonical documents, but self-sufficient enough to communicate what the term is without immediate dependency on deferred explanation. This is a stronger first-pass glossary rule than minimal direct labeling, yet it remains compatible with later revision if expanded evidence reveals a better formulation. [5][6][8][9]
+
+## 5. Conclusion
+
+The staged evidentiary policy for issue #134 now has a more precise form. Expansion beyond the first-pass corpus should be governed by several explicit triggers rather than by one undifferentiated appeal to insufficiency. `docs/architecture.md` and `docs/lore.md` belong in the initial pass because they already carry first-order explanatory authority for the concepts under review. And the glossary's first entries may now be written as clear, independent definitions rather than only as minimal direct labels, because the glossary must stabilize comparison across a staged corpus whose widening is conditional and inspectable. These refinements do not yet settle final canonicity outcomes. They clarify the evidentiary discipline required before such outcomes can be trusted. [1][2][3][4][5][6][7][8][9]
+
+## References
+
+[1] Finite APE Machine repository. "Spec - Finite APE Machine." `docs/spec/index.md`.
+
+[2] Finite APE Machine repository. "Inquiry as Epistemic Foundation of APE." `docs/research/inquiry/index.md`.
+
+[3] Finite APE Machine repository. "Architecture." `docs/architecture.md`.
+
+[4] Finite APE Machine repository. "The Apes - Lore." `docs/lore.md`.
+
+[5] Finite APE Machine repository. "Glossary direct-definition and audit navigation requirements for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/glossary-and-audit-navigation-requirements.md`.
+
+[6] Finite APE Machine repository. "Staged corpus entry and what-it-is-only glossary policy for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/staged-corpus-entry-and-minimal-glossary-policy.md`.
+
+[7] Finite APE Machine repository. "Obsolescence and canonicity criteria for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/obsolescence-and-canonicity-criteria.md`.
+
+[8] Finite APE Machine repository. "Glossary necessity and reader-priority clarification for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/glossary-need-and-reader-priority.md`.
+
+[9] Primary-source analysis-session clarifications dated 2026-04-22 for issue #134: expansion beyond the first pass may be triggered by definitional gap, explicit outward reference, material contradiction, or canonicity conflict; `docs/architecture.md` and `docs/lore.md` count as part of the initial evidentiary pass; first glossary entries may and should be clear, independent definitions.

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/first-pass-findings-on-current-document-strata.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/first-pass-findings-on-current-document-strata.md
@@ -1,0 +1,102 @@
+---
+id: first-pass-findings-on-current-document-strata
+title: "First-pass findings on current documentation strata for issue #134"
+date: 2026-04-22
+status: active
+tags: [findings, first-pass, canonicality, obsolescence, documentation]
+author: socrates
+---
+
+# First-Pass Findings on Current Documentation Strata for Issue #134
+
+## Abstract
+
+The first evidentiary pass over the initial corpus reveals that the repository's documentation is not merely dispersed; it is stratified into clusters with different degrees of current authority. The `docs/research/inquiry/` corpus functions as the strongest current home for the philosophical meaning of inquiry. A second cluster composed of `docs/spec/agent-lifecycle.md`, `docs/spec/cooperative-multitasking-model.md`, `docs/spec/signal-based-coordination.md`, `docs/architecture.md`, and `docs/lore.md` largely aligns around the current five-state, four-sub-agent model, though it still contains path drift and legacy references. A third cluster, especially `docs/spec/finite-ape-machine.md`, `docs/spec/orchestrator-spec.md`, `docs/spec/memory-as-code-spec.md`, and parts of `docs/spec/inquiry-cli-spec.md`, preserves an older or more expansive architecture with additional agents, legacy state names, and planned components not reflected in the current active model. Meanwhile, `docs/research/ape_builds_ape/` and `docs/research/swebok/` appear to function primarily as supporting research strata rather than as canonical homes for the core glossary terms now under review. These findings do not yet complete the status mapping, but they materially narrow the field of plausible canonical homes. [1][2][3][4][5][6][7][8][9][10][11]
+
+## 1. Scope of the First Pass
+
+The present findings are limited to the first-pass corpus defined earlier for issue #134: `docs/research/ape_builds_ape/`, `docs/research/inquiry/`, `docs/research/swebok/`, `docs/spec/`, `docs/architecture.md`, and `docs/lore.md`. The purpose of this pass is not yet to finalize canonical/historical/obsolete status for every document, but to identify where the repository currently locates its strongest definitions, where the documentation aligns with the current active model, and where explicit signals of documentary drift appear. [1][2][3][4][8][9]
+
+## 2. Inquiry Already Has a Strong Philosophical Home
+
+Among all materials read so far, `docs/research/inquiry/` is the clearest and most coherent candidate for the philosophical home of Inquiry. Its index explicitly frames inquiry as the epistemic foundation of APE. `peirce-abduction.md` defines the three modes of inference and directly maps them to ANALYZE, PLAN, and EXECUTE. `dewey-inquiry.md` defines inquiry as the controlled transformation of an indeterminate situation into a determinate one and distinguishes inquiry from documentation. `inquiry-cycle-ape-mapping.md` explicitly presents the cycle-level isomorphism between Peirce's inquiry modes and APE states. Taken together, these documents do not merely mention inquiry; they jointly develop it as a conceptual framework. [2][12][13][14]
+
+This matters for issue #134 because it weakens any assumption that a new top-level `inquiry.md` must be written as though no authoritative material already exists. The repository already contains a substantial inquiry corpus. The real question is whether that corpus should remain where it is, be elevated, be summarized elsewhere, or be cross-referenced from a more user-facing document. [2][12][13][14]
+
+## 3. A Current-Model Cluster Exists, but It Is Not Cleanly Consolidated
+
+Several documents outside `docs/research/inquiry/` align strongly with the current active model. `docs/spec/agent-lifecycle.md` presents a five-state cycle with SOCRATES, DESCARTES, BASHŌ, and DARWIN as the confirmed agents, while explicitly stating that APE is not an ape but the scheduler. `docs/spec/cooperative-multitasking-model.md` reinforces the same scheduler/task distinction and frames APE as the finite machine, not one peer agent among others. `docs/spec/signal-based-coordination.md` likewise describes the five-state cycle and the mechanical signal-driven transition model. `docs/architecture.md` explains the system as a finite-state orchestration model with one orchestrator file and current target deployment. `docs/lore.md` aligns the active model with four operative sub-agents while relegating other named agents to extended lore or future/reference status. [5][6][7][8][9]
+
+This cluster is important because it appears to contain the repository's strongest current articulation of APE as an orchestrating system, Finite APE Machine as an engineered scheduler/event-loop architecture, and Thinking Tools as methods embodied by active or historical agents. However, the cluster is not yet documentary clean. Several of these documents still reference `docs/issues/` rather than `docs/cleanrooms/`, even though the current codebase and agent assets have already moved toward `docs/cleanrooms/`. That means a document can be current in model but stale in implementation detail. [5][6][7][8][9][10]
+
+## 4. A Legacy-or-Expansive Cluster Persists Inside `docs/spec/`
+
+The first pass also reveals a different cluster that preserves a larger and older architecture. `docs/spec/finite-ape-machine.md` still describes MARCOPOLO, SOCRATES, VITRUVIUS, SUNZI, GATSBY, ADA, DIJKSTRA, BORGES, HERMES, and DARWIN as active architectural actors in a much richer multi-agent system than the currently confirmed five-state/four-sub-agent model. `docs/spec/orchestrator-spec.md` is even more explicit: it treats the orchestrator as sequencing MARCOPOLO, VITRUVIUS, SUNZI, GATSBY, ADA, and DIJKSTRA across ANALYZE, PLAN, EXECUTE, REVIEW, and DARWIN phases, with HERMES and BORGES as operational components. `docs/spec/memory-as-code-spec.md` likewise presupposes BORGES and HERMES as active machinery and assigns write zones to agents such as SUNZI and ADA. `docs/spec/inquiry-cli-spec.md` still describes broad planned command surfaces and reviewer artifacts not reflected in the current operational CLI. [4][11][15][16][17]
+
+These documents may still be valuable. They may preserve original architecture, aspirational design, or historical rationale. But they cannot be treated without qualification as the cleanest current source for user-facing definitions of the core terms under issue #134, because they repeatedly present a system that exceeds or diverges from the active registry documented elsewhere in the repository. The precise status of each such document remains to be mapped, but the first pass already shows that they carry stronger historical or mixed-status signals than the current-model cluster. [4][5][6][11][15][16][17]
+
+## 5. Supporting Research Strata Are Distinct from Canonical Taxonomy Homes
+
+The `docs/research/ape_builds_ape/` corpus appears to function mainly as a validation and research layer rather than as a home for base terminology. Its documents discuss the paper, bootstrap validation, experiment methodology, metrics, and review practice. They are highly relevant for empirical claims about the project, but they are not currently the best candidate home for defining Inquiry, APE, Finite APE Machine, FSM, RTOS, or Thinking Tools. [1][18][19][20][21]
+
+The `docs/research/swebok/` corpus similarly reads as an external reference layer. Its index explicitly frames the directory as SWEBOK/IEEE reference documentation. That makes it relevant as supporting evidence for process, models, methods, or software engineering vocabulary, but not as the project's canonical home for self-definition. [3]
+
+## 6. Path Drift Is a Concrete Obsolescence Signal
+
+One concrete signal of documentation drift now appears repeatedly enough to matter analytically: the mismatch between `docs/issues/` and `docs/cleanrooms/`. The current runtime, tests, changelog, and deployed agent assets have already moved toward `docs/cleanrooms/`, yet multiple first-pass documents still explain artifacts under `docs/issues/`. This does not automatically make those documents obsolete in full. It does, however, provide evidence that at least some portions of them risk inducing false understanding in present readers, especially those trying to infer where current analysis and planning artifacts actually live. [5][8][9][10][22]
+
+## 7. Provisional Implications for the Core Terms
+
+The first pass supports several provisional implications. Inquiry is already strongly grounded in `docs/research/inquiry/` as a philosophical and epistemic process. APE is most coherently articulated in the current-model cluster as the orchestrating methodological system and scheduler rather than as one peer agent among others. Finite APE Machine is most strongly supported where the repository describes the system as a finite-state, signal-driven, event-loop architecture rather than where it merely narrates broad methodology. Thinking Tools are currently spread between `docs/lore.md` and current-model specifications, with lore carrying the strongest explicit naming of Socratic method, Cartesian method, techne, and natural selection, but with some risk that allegorical presentation may blur current versus referential status for readers. [2][5][6][7][8][9][12][13][14]
+
+These implications remain provisional because the status mapping has not yet been fully justified document by document. But the field of plausible canonical homes is already much narrower than it was before the first pass. [1][2][3][4][5][6][7][8][9][10][11]
+
+## 8. Conclusion
+
+The initial corpus does not support a flat view of the repository's documentation. It supports a stratified one. The inquiry research corpus is the strongest current candidate for philosophical definitions. A current-model technical cluster exists across lifecycle, multitasking, signals, architecture, and lore, but it is still marred by stale paths and residual drift. A legacy-or-expansive cluster inside `docs/spec/` preserves older multi-agent and planned-system formulations that are unlikely to serve as unqualified current canonical homes for user-facing definitions. Finally, the research corpora on bootstrap validation and SWEBOK function primarily as supporting evidence layers, not as core taxonomy homes. These findings materially advance issue #134 because they transform the question from “where should the concepts go?” into the more precise question “which existing strata already own them, and which documents are now historical, mixed, or misleading?” [1][2][3][4][5][6][7][8][9][10][11]
+
+## References
+
+[1] Finite APE Machine repository. "APE Builds APE — Research Documents." `docs/research/ape_builds_ape/index.md`.
+
+[2] Finite APE Machine repository. "Inquiry as Epistemic Foundation of APE." `docs/research/inquiry/index.md`.
+
+[3] Finite APE Machine repository. "SWEBOK Research — Index." `docs/research/swebok/index.md`.
+
+[4] Finite APE Machine repository. "Spec — Finite APE Machine." `docs/spec/index.md`.
+
+[5] Finite APE Machine repository. "Agent lifecycle — five-state model and confirmed agent registry." `docs/spec/agent-lifecycle.md`.
+
+[6] Finite APE Machine repository. "Cooperative multitasking model — two-level FSM architecture." `docs/spec/cooperative-multitasking-model.md`.
+
+[7] Finite APE Machine repository. "Signal-based coordination — RTOS event model for agent communication." `docs/spec/signal-based-coordination.md`.
+
+[8] Finite APE Machine repository. "Architecture." `docs/architecture.md`.
+
+[9] Finite APE Machine repository. "The Apes — Lore." `docs/lore.md`.
+
+[10] Finite APE Machine repository. `code/cli/CHANGELOG.md`; `code/cli/assets/agents/inquiry.agent.md`; `code/cli/test/init_command_test.dart`.
+
+[11] Finite APE Machine repository. "Finite APE Machine." `docs/spec/finite-ape-machine.md`; "Orchestrator — Technical Specification." `docs/spec/orchestrator-spec.md`; "Memory as Code." `docs/spec/memory-as-code-spec.md`; "Inquiry CLI/TUI — Technical Specification." `docs/spec/inquiry-cli-spec.md`.
+
+[12] Finite APE Machine repository. "Peirce's Theory of Abduction and the Three Modes of Inference." `docs/research/inquiry/peirce-abduction.md`.
+
+[13] Finite APE Machine repository. "Dewey's Definition of Inquiry as Controlled Transformation." `docs/research/inquiry/dewey-inquiry.md`.
+
+[14] Finite APE Machine repository. "Mapping Peirce's Inquiry Cycle to APE's FSM States." `docs/research/inquiry/inquiry-cycle-ape-mapping.md`.
+
+[15] Finite APE Machine repository. "Orchestrator — Technical Specification." `docs/spec/orchestrator-spec.md`.
+
+[16] Finite APE Machine repository. "Memory as Code." `docs/spec/memory-as-code-spec.md`.
+
+[17] Finite APE Machine repository. "Inquiry CLI/TUI — Technical Specification." `docs/spec/inquiry-cli-spec.md`.
+
+[18] Finite APE Machine repository. "Finite APE Machine: Cooperative FSM Orchestration for AI-Assisted Software Engineering." `docs/research/ape_builds_ape/ape-paper.md`.
+
+[19] Finite APE Machine repository. "Bootstrap Validation: APE Builds APE." `docs/research/ape_builds_ape/bootstrap-validation.md`.
+
+[20] Finite APE Machine repository. "Experiment Methodology." `docs/research/ape_builds_ape/experiment-methodology.md`.
+
+[21] Finite APE Machine repository. "Metrics Schema." `docs/research/ape_builds_ape/metrics-schema.md`; "Review Log — APE Paper." `docs/research/ape_builds_ape/review-log.md`.
+
+[22] Finite APE Machine repository. `docs/spec/cli-as-api.md`; `docs/spec/target-specific-agents.md`.

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/glossary-and-audit-navigation-requirements.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/glossary-and-audit-navigation-requirements.md
@@ -1,0 +1,88 @@
+---
+id: glossary-and-audit-navigation-requirements
+title: "Glossary direct-definition and audit navigation requirements for issue #134"
+date: 2026-04-22
+status: active
+tags: [glossary, navigation-index, audit, evidence, documentation]
+author: socrates
+---
+
+# Glossary Direct-Definition and Audit Navigation Requirements for Issue #134
+
+## Abstract
+
+Issue #134 now requires a narrower and more operational analytical standard than glossary necessity alone. Prior analysis already established that an explicit glossary is necessary, that the dominant reader is the one seeking both philosophical and technological foundations, and that candidate documents must be read individually because the misleading ones cannot be pre-identified in advance. The present paper adds three further claims. First, the glossary should begin as a direct-definition instrument rather than as a mere hub of deferred references, because its analytical role is to stabilize vocabulary across heterogeneous documentation layers. Second, the glossary may begin with the already named terms and expand iteratively, because the starting lexical core is already known even if the total relevant vocabulary is not yet closed. Third, a general navigation index and an explicit reading order are now evidentiary requirements rather than conveniences, because repository evidence is distributed across local indexes and standalone explanatory surfaces that must be traversed together. [1][2][3][4][5][6][7][8]
+
+## 1. Decision Frame
+
+### 1.1 Prior analysis already made glossary control and complete reading unavoidable
+
+The prior analysis established three premises that materially constrain the present question. First, the relevant terminology is distributed across research, specification, architecture, and lore rather than concentrated in one authoritative explanatory surface. Second, canonicity decisions should be evaluated from the standpoint of the reader trying to understand both philosophical and technological foundations. Third, document-by-document reading is mandatory because the analysis cannot yet identify in advance which texts are most likely to induce false understanding. Once these premises are accepted, the remaining analytical question is not whether a glossary or a broader audit is necessary, but what form of glossary and what navigation discipline are required for the audit to be reliable. [1][2][3][4][5][6][7]
+
+### 1.2 The current session narrows the admissible form of the glossary and the audit
+
+The current analysis session adds four scope-defining clarifications. The glossary should define terms directly rather than primarily defer elsewhere. It may begin with the terms already named and expand later. All relevant documents must be read in order. And a general index is needed to help navigate that reading effort. These clarifications do not yet answer which documents are canonical or what the final corpus boundary should be. They do, however, determine what the evidence-gathering apparatus must do. [8]
+
+## 2. Why the Glossary Should Begin as a Direct-Definition Instrument and Expand Iteratively
+
+### 2.1 Direct definition is required because the glossary's role is lexical control, not mere redirection
+
+The prior glossary analysis justified a glossary because core terms are distributed across distinct documentary functions and because those terms are related but not interchangeable. That argument loses force if the glossary merely redirects readers elsewhere without defining the terms it governs. A glossary that primarily defers would preserve the repository's dispersed vocabulary while adding one more navigation stop. It would not provide the lexical baseline needed to judge whether two documents define the same concept, adjacent concepts, or conceptually different layers such as epistemic process, orchestrating methodology, system architecture, and thinking tools. For issue #134, the glossary's first analytical duty is therefore to state the terms directly, even if fuller treatment remains elsewhere. [1][2][3][4][5][6][7][8]
+
+### 2.2 Iterative expansion is justified because the initial lexical core is already evidentially known
+
+The current session clarifies that the glossary need not begin as an exhaustive terminological census. It may start with the already named terms and grow as later reading discloses additional terms that materially affect canonicity or false-understanding risk. This is analytically defensible because the starting problem is already framed around a known conceptual cluster: Inquiry, APE, Finite APE Machine, Thinking Tools, and neighboring terms needed to understand their boundaries. The fact that the total vocabulary remains open does not negate the evidentiary reality that some terms are already central enough to require immediate direct definition. An iterative glossary is therefore not a relaxation of rigor. It is a way to preserve rigor while avoiding the false requirement that the entire lexicon be closed before the first stable definitions are written. [5][7][8]
+
+### 2.3 Analytical consequence
+
+The admissible first-version glossary is neither a pure pointer list nor a final encyclopedia. It is a controlled definitional instrument: direct enough to stabilize vocabulary for the audit now, and open enough to incorporate additional terms as later evidence requires. That combined standard follows from the repository's distributed documentation structure and from the session's clarification that the already named terms are sufficient to begin, but not sufficient to finish, the lexical work. [1][2][3][4][7][8]
+
+## 3. Why a General Navigation Index Is Now an Analytical Requirement
+
+### 3.1 Repository evidence is organized into local navigation surfaces, not one cross-layer route
+
+The repository already contains local navigation mechanisms, but they are segmented by documentary function. The specification layer has its own index. The inquiry research layer has its own index. Meanwhile, architecture and lore operate as major explanatory documents outside those local indexes. Prior analysis has already shown that issue #134 spans these layers together rather than allowing them to be treated in isolation. This means the repository offers several legitimate entry points, but not one general navigation surface that makes the cross-layer audit legible as a whole. [1][2][3][4][7]
+
+### 3.2 A general index is required to make the mandated reading corpus auditable
+
+Once the analysis accepts that all relevant documents must be read and that the relevant reader traverses philosophical and technological foundations together, navigation ceases to be a convenience problem. It becomes an evidence problem. Without a general index, the phrase "all relevant documents" remains operationally under-specified because the corpus remains distributed across multiple local indexes and standalone documents. A general index is therefore required not merely to help readers browse, but to make the audit's working corpus explicit, inspectable, and contestable. It is the device that lets analysis say which surfaces belong to the present evidentiary pass and which do not yet belong to it. [1][2][3][4][7][8]
+
+### 3.3 Analytical consequence
+
+The need for a general index follows from the same premises that made the glossary necessary. If vocabulary is distributed and if misleading documents cannot be identified before reading them, then the reading corpus itself must be exposed through a single navigation surface. Otherwise, later judgments about canonicity, duplication, or obsolescence will rest on an audit whose completeness cannot be checked. [5][6][7][8]
+
+## 4. Why Reading "All" Documents "in Order" Is an Evidentiary Commitment Rather Than a Convenience
+
+### 4.1 "All" is now a completeness claim, not an informal gesture
+
+The previous glossary analysis already ruled out shortcut reading by showing that risky documents cannot yet be pre-selected in advance. The current session sharpens that requirement by stating that all relevant documents must be read. Under these constraints, "all" can no longer function as a loose synonym for "many" or "the ones that look central." It is a completeness claim about the evidentiary pass. The analytical burden is therefore to specify a corpus boundary that can be defended, challenged, and revised if later evidence exposes an omission. [7][8]
+
+### 4.2 "In order" is required because the audit must be reproducible and interpretable
+
+The phrase "in order" likewise does more than promise tidiness. In a documentation audit, sequence affects interpretation: earlier readings establish provisional term boundaries, later readings test or complicate them, and apparent duplication can only be judged against what has already been encountered. If the sequence is left implicit, the audit becomes difficult to reproduce and its intermediate judgments become hard to evaluate. An explicit order does not yet decide which ordering principle is correct, but it does mark sequence as part of the evidence protocol rather than as a private convenience of the analyst. [5][6][7][8]
+
+### 4.3 Analytical consequence
+
+Reading all relevant documents in order is therefore an evidentiary commitment in three senses. It commits the analysis to a defined corpus, to a declared traversal sequence, and to a standard of review under which another reader could inspect whether the audit was complete enough and sequenced clearly enough to support later judgments. That is a stronger claim than mere diligence. It is the minimum condition for turning a broad documentation survey into an accountable analytical record. [6][7][8]
+
+## 5. Conclusion
+
+Issue #134 now requires a specific policy for both lexical control and evidence navigation. The first-version glossary should define terms directly because its purpose is to stabilize vocabulary across documentary layers, not merely to forward readers elsewhere. It may expand iteratively because the initial conceptual core is already known even though the total relevant vocabulary remains open. A general navigation index is now analytically required because the audit must traverse local indexes and standalone explanatory surfaces as one inspectable corpus. And reading all relevant documents in order is an evidentiary commitment because completeness and sequence must both be explicit if later judgments about canonicity, duplication, or obsolescence are to be trustworthy. [1][2][3][4][5][6][7][8]
+
+## References
+
+[1] Finite APE Machine repository. "Spec - Finite APE Machine." `docs/spec/index.md`.
+
+[2] Finite APE Machine repository. "Inquiry as Epistemic Foundation of APE." `docs/research/inquiry/index.md`.
+
+[3] Finite APE Machine repository. "Architecture." `docs/architecture.md`.
+
+[4] Finite APE Machine repository. "The Apes - Lore." `docs/lore.md`.
+
+[5] Finite APE Machine repository. "Taxonomy and scope clarification for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/taxonomy-and-scope-clarification.md`.
+
+[6] Finite APE Machine repository. "Obsolescence and canonicity criteria for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/obsolescence-and-canonicity-criteria.md`.
+
+[7] Finite APE Machine repository. "Glossary necessity and reader-priority clarification for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/glossary-need-and-reader-priority.md`.
+
+[8] Primary-source analysis-session clarifications dated 2026-04-22 for issue #134: the glossary should define terms directly rather than primarily defer; the glossary may begin with the already named terms and expand later; all relevant documents must be read in order; a general index is needed to help navigate them.

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/glossary-baseline.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/glossary-baseline.md
@@ -1,0 +1,41 @@
+---
+id: glossary-baseline
+title: "Baseline glossary for issue #134"
+date: 2026-04-22
+status: active
+tags: [glossary, definitions, terminology, inquiry, ape]
+author: socrates
+---
+
+# Baseline Glossary for Issue #134
+
+## Abstract
+
+This glossary is the first-pass lexical control instrument for issue #134. It is not a full encyclopedia and does not yet settle every downstream documentation decision. Its purpose is narrower: provide clear, independent definitions for the core terms whose boundaries must remain stable while documentation canonicity is reorganized. The entries below are intentionally concise and neutral. They answer what the term is in current project vocabulary without trying to absorb all historical, comparative, or implementation detail. [1][2][3][4][5]
+
+## Terms
+
+| Term | Baseline definition | Primary evidence surfaces |
+|---|---|---|
+| Inquiry | The structured cycle by which a software task is clarified, planned, and executed as an instance of inquiry. | `docs/research/inquiry/`; `taxonomy-and-scope-clarification.md` |
+| APE | The orchestrating methodology and scheduler that assigns specialized agent behavior to the phases of the Inquiry cycle. | `docs/architecture.md`; `docs/spec/agent-lifecycle.md`; `docs/lore.md` |
+| Finite APE Machine | The engineered realization of APE as a finite-state, signal-driven control system for running an Inquiry cycle. | `docs/spec/cooperative-multitasking-model.md`; `docs/spec/signal-based-coordination.md`; `docs/architecture.md` |
+| Thinking Tools | The reusable reasoning methods or working disciplines employed within phases or embodied by agents. | `docs/lore.md`; `taxonomy-and-scope-clarification.md` |
+| FSM | A finite state machine: a model in which the system occupies one state at a time and changes state through declared transitions. | `docs/spec/cooperative-multitasking-model.md`; `docs/architecture.md` |
+| RTOS | Real-time operating system; in current project vocabulary, an analogical frame for signal-based coordination, scheduling, and event handling rather than a claim that Inquiry is literally an OS kernel. | `docs/spec/signal-based-coordination.md`; `docs/architecture.md` |
+
+## Notes on Use
+
+These definitions are first-pass controls, not final doctrinal prose. They should be used to evaluate canonicity, duplication, and drift across the documentation set. When a later document appears to define one of these terms differently, the disagreement should be examined explicitly rather than absorbed silently into broader narrative text. [1][2][3]
+
+## References
+
+[1] Finite APE Machine repository. "Taxonomy and scope clarification for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/taxonomy-and-scope-clarification.md`.
+
+[2] Finite APE Machine repository. "Expansion triggers, initial-pass inclusion of architecture and lore, and independent glossary definitions for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/expansion-triggers-and-independent-glossary-definitions.md`.
+
+[3] Finite APE Machine repository. "Diagnosis for issue #134: justified documentation status map and canonical-home recommendations." `docs/cleanrooms/134-organize-core-documentation/analyze/diagnosis.md`.
+
+[4] Finite APE Machine repository. "Inquiry as Epistemic Foundation of APE." `docs/research/inquiry/index.md`; "Architecture." `docs/architecture.md`; "The Apes — Lore." `docs/lore.md`.
+
+[5] Finite APE Machine repository. "Cooperative multitasking model — two-level FSM architecture." `docs/spec/cooperative-multitasking-model.md`; "Signal-based coordination — RTOS event model for agent communication." `docs/spec/signal-based-coordination.md`.

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/glossary-need-and-reader-priority.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/glossary-need-and-reader-priority.md
@@ -1,0 +1,76 @@
+---
+id: glossary-need-and-reader-priority
+title: "Glossary necessity and reader-priority clarification for issue #134"
+date: 2026-04-22
+status: active
+tags: [glossary, reader-priority, canonicity, evidence, documentation]
+author: socrates
+---
+
+# Glossary Necessity and Reader-Priority Clarification for Issue #134
+
+## Abstract
+
+Issue #134 now has an additional evidentiary constraint beyond taxonomy and canonicity alone. The analysis can no longer assume that core terms are self-evident to readers, nor that the documents most likely to induce false understanding can be identified in advance from their titles or locations. This paper establishes three claims. First, an explicit glossary is analytically necessary because the relevant vocabulary is distributed across research, specification, architecture, and lore layers while prior analysis has already shown that these terms are related but not interchangeable. Second, canonicity decisions should prioritize the reader trying to understand the project's philosophical and technological foundations, because that reader must traverse those layers together rather than in isolation. Third, document-by-document reading is now an evidentiary requirement rather than optional exploration, because the user cannot yet pre-identify which current texts are most misleading. These claims are grounded in repository evidence and in analysis-session clarifications dated 2026-04-22. [1][2][3][4][5][6][7]
+
+## 1. Why an Explicit Glossary Is Analytically Necessary
+
+### 1.1 Core terminology is distributed across distinct documentary functions
+
+The repository already separates explanatory labor across multiple documentation layers. The specification index presents technical specifications and architectural references, including project overview and foundational concepts. The inquiry research index presents the philosophical foundations of inquiry and explicitly maps them to APE. The architecture document explains the system as a finite state machine and orchestration contract. The lore document explains APE, sub-agents, and thinking tools through an allegorical but still conceptually consequential register. This means a reader encountering issue #134 does not meet a single, centralized vocabulary surface. The same conceptual family is encountered across documents with different explanatory purposes. [1][2][3][4]
+
+### 1.2 The relevant terms are already known to require boundary discipline
+
+The prior taxonomy paper established that Inquiry, APE, Finite APE Machine, and Thinking Tools form a hierarchy of related but non-identical concepts. The current analysis session adds that an explicit glossary is needed for clarity and that the first glossary scope must extend beyond the four target terms to include items such as FSM and RTOS. Once the analysis accepts both claims, the glossary ceases to be a stylistic enhancement. It becomes the minimal instrument for keeping term boundaries stable across subsequent canonicity judgments. [5][7]
+
+### 1.3 Canonicity analysis cannot proceed reliably without controlled term definitions
+
+The prior canonicity paper argued that duplication and canonical ownership are concept-dependent rather than globally fixed. That standard cannot be applied coherently if the analysis lacks a stable lexical baseline for what counts as the same concept, a neighboring concept, or an implementation-specific elaboration. Without an explicit glossary, a later judgment could mistake cross-reference for duplication, or technical operationalization for conceptual identity. The glossary is therefore analytically necessary because it controls the vocabulary on which canonicity and obsolescence judgments depend. [5][6][7]
+
+## 2. Why the Philosophical-and-Technological Foundations Reader Should Dominate Canonicity Decisions
+
+### 2.1 Issue #134 spans both foundational layers at once
+
+The repository's current structure already distinguishes philosophical foundation from technical realization. Inquiry is documented as the epistemic foundation of APE, while the specification and architecture documents present technical and system-level explanations of the finite machine. The lore document adds a third layer in which APE is described as scheduler and RTOS-like event loop while the named sub-agents embody thinking tools. Because issue #134 concerns core documentation for Inquiry, APE, Finite APE Machine, and Thinking Tools, the relevant reader is not merely seeking one isolated layer. The relevant reader is trying to understand how those layers connect. [1][2][3][4]
+
+### 2.2 This reader bears the highest interpretive cost if canonicity is assigned badly
+
+The prior canonicity paper already established that canonical homes should be chosen according to the reader or use case whose misunderstanding would be most costly. The current analysis session makes that abstract standard concrete by naming the dominant reader: someone trying to understand the philosophical and technological foundations. This reader has the highest interpretive burden because any bad canonicity decision will fracture the bridge between inquiry as epistemic process, APE as orchestrating methodology, and Finite APE Machine as engineered operationalization. A reader looking only for a narrow technical detail or only for intellectual ancestry can remain inside one documentary layer; the foundations reader cannot. [2][3][5][6][7]
+
+### 2.3 Analytical consequence
+
+Canonicity judgments for issue #134 should therefore be evaluated against a single controlling question: where would the foundations reader most reliably expect to find the first authoritative explanation that connects philosophical grounding and technical realization without contradiction or unnecessary duplication? This does not yet decide any canonical home. It clarifies whose interpretive success must govern the evidence standard. [1][2][3][6][7]
+
+## 3. Why Document-by-Document Reading Is Now an Evidentiary Requirement
+
+### 3.1 The governing risk is false understanding, not mere archival untidiness
+
+The prior canonicity paper defined obsolescence narrowly: a document is obsolete if it is no longer relevant or if it creates a meaningful risk of false understanding for present readers. That criterion cannot be applied from filename, directory, age, or issue title alone. False understanding depends on what a document actually claims, how it frames concept boundaries, and whether it silently competes with another document for canonical ownership. [6]
+
+### 3.2 The user cannot pre-identify the risky documents
+
+The current analysis session now removes the last plausible shortcut. The user explicitly states that they cannot yet identify which current documents risk false understanding and that those documents must be read individually. Once that clarification is accepted, selective reading based only on prior suspicion becomes evidentially inadequate. The analysis can no longer treat close reading as optional exploration performed only if time permits. [7]
+
+### 3.3 Individual reading is the minimum reliable evidence-gathering procedure
+
+Document-by-document reading follows directly from the combined criteria already established. If canonicity depends on concept ownership, if obsolescence depends on false-understanding risk, and if risky documents cannot be pre-selected in advance, then each candidate document must be inspected on its own terms before it can be classified as canonical, historical, duplicated, or obsolete. Any weaker procedure would rely on proxy signals that earlier analysis has already shown to be insufficient. Document-by-document reading is therefore not exploratory excess; it is the minimum evidentiary procedure compatible with the issue's current standard of rigor. [5][6][7]
+
+## 4. Conclusion
+
+Issue #134 now requires three additional analytical constraints. An explicit glossary is necessary because core terms are distributed across multiple documentary layers yet must remain lexically stable if canonicity judgments are to be coherent. The dominant reader for those judgments is the one trying to understand both philosophical and technological foundations, because that reader must integrate the repository's distinct explanatory layers. And because the user cannot now pre-identify which documents are most misleading, document-by-document reading is a mandatory evidentiary step rather than optional exploration. These clarifications narrow the analysis by specifying both the vocabulary control it requires and the readership whose reliable understanding must anchor subsequent judgments. [1][2][3][4][5][6][7]
+
+## References
+
+[1] Finite APE Machine repository. "Spec - Finite APE Machine." `docs/spec/index.md`.
+
+[2] Finite APE Machine repository. "Inquiry as Epistemic Foundation of APE." `docs/research/inquiry/index.md`.
+
+[3] Finite APE Machine repository. "Architecture." `docs/architecture.md`.
+
+[4] Finite APE Machine repository. "The Apes - Lore." `docs/lore.md`.
+
+[5] Finite APE Machine repository. "Taxonomy and scope clarification for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/taxonomy-and-scope-clarification.md`.
+
+[6] Finite APE Machine repository. "Obsolescence and canonicity criteria for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/obsolescence-and-canonicity-criteria.md`.
+
+[7] Primary-source analysis-session clarifications dated 2026-04-22 for issue #134: explicit glossary required; dominant reader is the reader seeking philosophical and technological foundations; risky current documents cannot yet be pre-identified and therefore must be read individually.

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/index.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/index.md
@@ -1,0 +1,34 @@
+# Analyze Phase — Index
+
+**Issue:** #134 — Organize core documentation: inquiry.md, ape.md, finite_ape_machine.md, thinking_tools.md
+**Branch:** 134-organize-core-documentation
+**Phase:** ANALYZE
+**Status:** In progress
+
+---
+
+## Documents
+
+| # | File | Description |
+|---|------|-------------|
+| 1 | [taxonomy-and-scope-clarification.md](taxonomy-and-scope-clarification.md) | English analysis paper clarifying issue framing, terminology boundaries, and evidence policy |
+| 2 | [obsolescence-and-canonicity-criteria.md](obsolescence-and-canonicity-criteria.md) | English analysis paper defining criteria for obsolescence, canonical homes, and non-assumption of document primacy |
+| 3 | [glossary-need-and-reader-priority.md](glossary-need-and-reader-priority.md) | English analysis paper establishing glossary necessity, dominant reader priority, and the requirement for document-by-document evidence |
+| 4 | [glossary-and-audit-navigation-requirements.md](glossary-and-audit-navigation-requirements.md) | English analysis paper establishing direct-definition glossary policy, iterative expansion, and the need for a general audit navigation index and ordered reading |
+| 5 | [corpus-boundary-and-ordering-policy.md](corpus-boundary-and-ordering-policy.md) | English analysis paper establishing whole-workspace corpus boundary, directory-order traversal, and minimal direct-definition glossary policy |
+| 6 | [staged-corpus-entry-and-minimal-glossary-policy.md](staged-corpus-entry-and-minimal-glossary-policy.md) | English analysis paper refining first-pass entry into staged reading through research/spec, conditional expansion, and what-it-is-only glossary definitions |
+| 7 | [expansion-triggers-and-independent-glossary-definitions.md](expansion-triggers-and-independent-glossary-definitions.md) | English analysis paper formalizing explicit corpus-expansion triggers, adding architecture and lore to the initial pass, and strengthening glossary entries into clear independent definitions |
+| 8 | [ordered-initial-corpus-index.md](ordered-initial-corpus-index.md) | English analysis paper defining the ordered first-pass audit corpus, expansion triggers, and glossary constraints for issue #134 |
+| 9 | [first-pass-findings-on-current-document-strata.md](first-pass-findings-on-current-document-strata.md) | English analysis paper summarizing first-pass evidence on current, legacy, and supporting documentation strata relevant to issue #134 |
+| 10 | [expanded-entry-surface-findings.md](expanded-entry-surface-findings.md) | English analysis paper synthesizing README, roadmap, site, and VS Code extension evidence after corpus expansion |
+| 11 | [diagnosis.md](diagnosis.md) | English diagnosis paper delivering the justified documentation-status map and canonical-home recommendations for issue #134 |
+| 12 | [glossary-baseline.md](glossary-baseline.md) | English first-pass glossary establishing neutral independent definitions for the core terms under issue #134 |
+
+## Legacy Drafts
+
+These files predate the current English paper-style protocol for this analysis. They are retained as scratch material but are not part of the canonical evidence set for issue #134.
+
+| File | Status | Description |
+|------|--------|-------------|
+| [ANALISIS_ESTADO.md](ANALISIS_ESTADO.md) | superseded draft | Spanish working note created before the current documentation protocol was fixed |
+| [PROPUESTA_DOCS.md](PROPUESTA_DOCS.md) | superseded draft | Spanish proposal draft created before the current documentation protocol was fixed |

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/obsolescence-and-canonicity-criteria.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/obsolescence-and-canonicity-criteria.md
@@ -1,0 +1,96 @@
+---
+id: obsolescence-and-canonicity-criteria
+title: "Obsolescence and canonicity criteria for issue #134"
+date: 2026-04-22
+status: active
+tags: [obsolescence, canonical-home, documentation, taxonomy, scope]
+author: socrates
+---
+
+# Obsolescence and Canonicity Criteria for Issue #134
+
+## Abstract
+
+Issue #134 cannot be resolved by assuming that the four proposed target documents are already the correct documentary center of gravity. Before any reorganization judgment can be trusted, the analysis must establish criteria for three distinctions: obsolete versus historical versus still-current but duplicated material; canonical home versus cross-reference; and proposed target documents versus documents that may prove more primary once repository evidence is examined. This paper argues that obsolescence should be defined narrowly, that canonical homes are concept-dependent rather than globally fixed, and that document primacy must be discovered through evidence about concept ownership and reader reliability rather than inferred from the issue title alone. The argument is grounded in repository evidence about existing documentation layers and in analysis-session clarifications dated 2026-04-22. [1][2][3][4][5][6]
+
+## 1. Decision Frame
+
+### 1.1 The present problem concerns reliability under archival drift
+
+The prior analysis already established that issue #134 is best framed as a documentation-taxonomy problem under archival drift rather than as an internal dispute about terminology. What must now be added is a criterion for deciding when a document ceases to be a trustworthy guide for readers. In a repository whose documentation is already distributed across specification, research, architectural, and lore layers, the main risk is not mere multiplicity. The main risk is that readers encounter the wrong document first and are therefore led toward a false model of the system. [1][2][3][4][5]
+
+### 1.2 Three judgments must remain analytically separate
+
+Three judgments should not be collapsed into one. First, whether a document is current, historical, or obsolete. Second, whether a concept has a single canonical home or is merely mentioned in a given document as supporting context. Third, whether the four proposed documents of issue #134 are in fact the most important documentary targets, or only initial hypotheses that analysis must test. Conflating these judgments would produce premature consolidation and would risk replacing one form of archival drift with another. [5][6]
+
+## 2. Criteria for Documentary Status
+
+### 2.1 Obsolete
+
+A document should be considered obsolete only under one of two conditions: either it is no longer relevant to the current repository and its active conceptual structure, or it poses a meaningful risk of inducing false understanding in present readers. This criterion is intentionally narrow. Age alone is not obsolescence. Redundancy alone is not obsolescence. A document becomes obsolete when its continued ordinary visibility is more likely to distort understanding than to support it. This standard follows the analysis-session clarification that obsolescence is tied to irrelevance or to the risk of false understanding, not merely to supersession in time. [6]
+
+This definition matters because the repository already preserves several documentation functions. A research text may remain useful as intellectual grounding even when it is not the best user-facing explainer. A lore document may remain current for symbolic identity even when it is not the right place for technical specification. Obsolescence should therefore be reserved for documents that no longer serve a legitimate explanatory or historical role, or that actively misdirect readers about present reality. [1][2][3][4]
+
+### 2.2 Historical
+
+Historical documents are not obsolete. A document is historical when it remains relevant as evidence of prior reasoning, architectural evolution, or conceptual development, but should not be treated as the primary source for current understanding without explicit status signaling. The prior analysis already concluded that later work must distinguish canonical, historical, and obsolete materials. That distinction implies a stable middle category: documents that retain interpretive value because they explain how the system arrived at its current shape, even if they should no longer function as the first explanation a new reader encounters. [5]
+
+The practical significance of the historical category is that it preserves traceability without allowing archival materials to masquerade as current doctrine. A historical document may still be necessary when the question is why a concept evolved, which tradeoff was once accepted, or which meaning a term previously carried. It becomes problematic only when repository organization fails to signal that temporal and interpretive status clearly enough for readers. [5][6]
+
+### 2.3 Still-current but duplicated
+
+Some documents may remain materially correct and therefore still current, while nevertheless duplicating concepts whose authoritative explanation belongs elsewhere. This is a distinct category from both obsolete and historical material. A duplicated document does not necessarily mislead because its claims are false. It misleads because it competes with another document for conceptual ownership, thereby making it unclear where readers should go for the authoritative formulation. [1][2][3][4][6]
+
+The analysis-session clarification states the governing rule succinctly: one concept in one place, while other documents should reference rather than duplicate. Under that rule, duplication is a canonicity problem rather than an obsolescence problem. A duplicated document may remain current if it is accurate, but it should not continue to restate a concept as though it were co-equal with the canonical source. Its proper role is cross-reference, contextual summary, or scoped application. [6]
+
+## 3. Criteria for Canonical Homes and Cross-References
+
+### 3.1 Canonical home
+
+A canonical home is the single document that owns the authoritative explanation of a concept. It is the place where the concept is defined at full scope, where changes to that concept should be maintained first, and where readers should be directed when they need the most reliable account. Repository evidence already suggests that canonical homes are differentiated by documentary function. The spec index defines `docs/spec/` as the home of technical specifications and architectural references. The inquiry research index defines `docs/research/inquiry/` as the home of the philosophical foundations of inquiry. The architecture document explains APE as an orchestrated finite-state system. The lore document explains symbolic identities, allegories, and thinking-tool personas. These are not interchangeable explanatory layers. [1][2][3][4]
+
+From this evidence, the canonical-home policy cannot be universal in the sense of assigning one top-level directory as the home of every important idea. It must instead be concept-dependent. A concept should live where its full and most stable explanatory frame belongs. Philosophical grounding belongs where philosophical grounding is maintained. Technical system behavior belongs where technical architecture is maintained. Allegorical identity belongs where allegorical identity is maintained. [1][2][3][4][6]
+
+### 3.2 Cross-reference
+
+A cross-reference is justified when a concept is relevant to a document's argument but is not owned by that document. The purpose of cross-reference is not to avoid explanation altogether. Its purpose is to avoid re-defining a concept at full scope when that authority already exists elsewhere. Cross-reference therefore preserves local readability while protecting canonicity. It allows a document to situate the reader without silently becoming a rival home for the same concept. [5][6]
+
+This distinction is especially important in issue #134 because terms such as Inquiry, APE, Finite APE Machine, and Thinking Tools are related but non-identical. A document may legitimately describe how one of these concepts interacts with another while still pointing elsewhere for the canonical definition. The prior taxonomy paper established those boundary distinctions; the present criterion adds that each boundary should be maintained by reference discipline, not by uncontrolled repetition. [5]
+
+### 3.3 Reader and use-case dominance
+
+The choice of canonical home should be governed by the reader or use case whose misunderstanding would produce the highest interpretive cost. Repository evidence already shows distinct readership functions: technical readers looking for specification and architecture, conceptual readers looking for inquiry foundations, and readers seeking the narrative identity of the agents and their thinking tools. Because these functions differ, canonicity should be assigned according to the dominant explanatory burden of the concept in question rather than according to a blanket preference for one document type. [1][2][3][4]
+
+This criterion does not yet answer which reader should dominate in every contested case; that remains an evidentiary question for further analysis. It does, however, establish the governing standard: the canonical home of a concept should minimize the probability that its highest-priority reader will form a false or fragmented understanding. [6]
+
+## 4. Why the Primacy of the Four Proposed Documents Must Not Be Assumed
+
+### 4.1 The issue title identifies candidates, not verdicts
+
+Issue #134 names four proposed documents: `inquiry.md`, `ape.md`, `finite_ape_machine.md`, and `thinking_tools.md`. These should be treated as analytical candidates, not as conclusions already justified. The prior analysis explicitly warned against reducing the issue to terminology alone and clarified that the central task is to determine which concepts are primary, where each concept's canonical explanation belongs, and what marks texts as canonical, historical, or obsolete. That framing leaves open the possibility that some proposed documents are necessary, some are redundant, and some already have more suitable canonical homes elsewhere in the repository. [5][6]
+
+### 4.2 Repository evidence already presents competing primary loci
+
+The repository already exposes potential primary loci that may compete with or subsume some of the proposed target documents. The spec index lists `finite-ape-machine.md` as a project overview and foundational concepts document within the specification layer. The inquiry research index already serves as an organized home for the epistemic foundation of inquiry. The architecture document already presents a system-level explanation of orchestration through the FSM. The lore document already assigns the symbolic and methodological roles of the agents and their thinking tools. This means analysis cannot simply infer that four new or reorganized top-level documents are the most important outputs. It must test whether some concepts are already primarily housed, and whether the real problem is duplication, discoverability, status signaling, or misplaced authority. [1][2][3][4]
+
+### 4.3 Proper analytical consequence
+
+The correct analytical posture is therefore comparative rather than presumptive. For each candidate concept, the question is not "which of the four proposed documents should contain it?" but rather "where is the concept's most reliable canonical home, and what secondary documents should point to it?" Under this criterion, the answer may indeed support one or more of the proposed target documents. It may also show that one of them should remain only as a pointer, that an existing document is already primary, or that an additional document not listed in the issue is the real canonical center. [1][2][3][4][5][6]
+
+## 5. Conclusion
+
+Issue #134 requires a stricter analytical vocabulary before any consolidation judgment can be trusted. Obsolete documents are those that are irrelevant or that risk inducing false understanding. Historical documents remain valuable as records of prior reasoning but should not silently govern current understanding. Still-current duplicated documents are accurate yet non-canonical and should yield authority to a single canonical home. Canonical homes are concept-dependent and should be chosen according to the reader and use case whose misunderstanding would be most costly. Finally, the four proposed documents of issue #134 must be treated as hypotheses to evaluate, not as the answer assumed in advance. [1][2][3][4][5][6]
+
+## References
+
+[1] Finite APE Machine repository. "Spec — Finite APE Machine." `docs/spec/index.md`.
+
+[2] Finite APE Machine repository. "Inquiry as Epistemic Foundation of APE." `docs/research/inquiry/index.md`.
+
+[3] Finite APE Machine repository. "Architecture." `docs/architecture.md`.
+
+[4] Finite APE Machine repository. "The Apes — Lore." `docs/lore.md`.
+
+[5] Finite APE Machine repository. "Taxonomy and scope clarification for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/taxonomy-and-scope-clarification.md`.
+
+[6] Analysis-session clarifications with the user regarding issue #134, dated 2026-04-22.

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/ordered-initial-corpus-index.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/ordered-initial-corpus-index.md
@@ -1,0 +1,89 @@
+---
+id: ordered-initial-corpus-index
+title: "Ordered initial corpus index for issue #134"
+date: 2026-04-22
+status: active
+tags: [corpus, audit, index, ordering, evidence]
+author: socrates
+---
+
+# Ordered Initial Corpus Index for Issue #134
+
+## Abstract
+
+Issue #134 now has a sufficiently explicit evidence protocol to define an ordered first-pass corpus. Prior analysis established that the problem is archival rather than primarily conceptual for the maintainer, that one canonical home should be forced per concept with references from other documents, that glossary definitions should remain neutral, and that analysis is complete only when the documentation set can be mapped with justified canonical, historical, or obsolete status. The current analysis session further narrowed the reading rule: begin with `docs/research/` and `docs/spec/`, include `docs/architecture.md` and `docs/lore.md` in the initial pass, and defer the rest of the workspace unless a definitional gap, explicit outward reference, material contradiction, or canonicity conflict requires expansion. This document records that first-pass corpus and its ordered traversal so later audit judgments remain reproducible. [1][2][3][4][5][6][7][8]
+
+## 1. Purpose
+
+The function of this index is procedural rather than taxonomic. It does not yet decide which documents are canonical. It defines the initial evidence surface from which such judgments may later be made. Because issue #134 aims at a fully justified mapping of the documentation set, the first-pass corpus must be explicit, ordered, and inspectable. Without that discipline, later claims about duplication, obsolescence, or misplacement would rest on an opaque reading path. [2][3][4][5][7][8]
+
+## 2. Ordered First-Pass Corpus
+
+The ordered first pass begins inside `docs/research/`, continues through `docs/spec/`, and then includes the two standalone documents explicitly admitted into the initial pass by analysis-session clarification.
+
+| Order | Path | Role in first pass | Initial status |
+|---|---|---|---|
+| 1 | `docs/research/ape_builds_ape/index.md` | Entry index for bootstrap-validation research artifacts | indexed |
+| 2 | `docs/research/ape_builds_ape/ape-paper.md` | Theoretical research paper candidate | unread |
+| 3 | `docs/research/ape_builds_ape/bootstrap-validation.md` | Empirical bootstrap narrative candidate | unread |
+| 4 | `docs/research/ape_builds_ape/experiment-methodology.md` | Research methodology candidate | unread |
+| 5 | `docs/research/ape_builds_ape/metrics-schema.md` | Metrics and evidence schema candidate | unread |
+| 6 | `docs/research/ape_builds_ape/review-log.md` | Meta-review artifact candidate | unread |
+| 7 | `docs/research/inquiry/index.md` | Entry index for philosophical foundation of inquiry | indexed |
+| 8 | `docs/research/inquiry/peirce-abduction.md` | Inquiry theory source candidate | unread |
+| 9 | `docs/research/inquiry/dewey-inquiry.md` | Inquiry theory source candidate | unread |
+| 10 | `docs/research/inquiry/inquiry-cycle-ape-mapping.md` | Mapping from inquiry theory to APE cycle | unread |
+| 11 | `docs/research/inquiry/bibliography.md` | Bibliographic support file | unread |
+| 12 | `docs/research/swebok/index.md` | Entry index for external software-engineering reference corpus | indexed |
+| 13 | `docs/research/swebok/swebok-overview.md` | General external reference candidate | unread |
+| 14 | `docs/research/swebok/software-requirements.md` | Domain reference candidate | unread |
+| 15 | `docs/research/swebok/software-design.md` | Domain reference candidate | unread |
+| 16 | `docs/research/swebok/software-construction.md` | Domain reference candidate | unread |
+| 17 | `docs/research/swebok/software-configuration-management.md` | Domain reference candidate | unread |
+| 18 | `docs/research/swebok/software-engineering-management.md` | Domain reference candidate | unread |
+| 19 | `docs/research/swebok/software-engineering-process.md` | Domain reference candidate | unread |
+| 20 | `docs/research/swebok/software-engineering-models-methods.md` | Domain reference candidate | unread |
+| 21 | `docs/research/swebok/software-quality.md` | Domain reference candidate | unread |
+| 22 | `docs/research/swebok/process-enactment-tools.md` | Domain reference candidate | unread |
+| 23 | `docs/spec/index.md` | Entry index for technical specification corpus | indexed |
+| 24 | `docs/spec/finite-ape-machine.md` | Foundational specification candidate | unread |
+| 25 | `docs/spec/agent-lifecycle.md` | Lifecycle specification candidate | unread |
+| 26 | `docs/spec/cooperative-multitasking-model.md` | Coordination model candidate | unread |
+| 27 | `docs/spec/signal-based-coordination.md` | Signal model candidate | unread |
+| 28 | `docs/spec/orchestrator-spec.md` | Orchestrator contract candidate | unread |
+| 29 | `docs/spec/memory-as-code-spec.md` | Documentation-architecture candidate | unread |
+| 30 | `docs/spec/inquiry-cli-spec.md` | CLI specification candidate | unread |
+| 31 | `docs/spec/cli-as-api.md` | Skills/commands boundary candidate | unread |
+| 32 | `docs/spec/target-specific-agents.md` | Target deployment candidate | unread |
+| 33 | `docs/architecture.md` | Standalone system explanation admitted into first pass | indexed |
+| 34 | `docs/lore.md` | Standalone agent/thinking-tool explanation admitted into first pass | indexed |
+
+## 3. Expansion Triggers Beyond the First Pass
+
+The first pass is not the whole workspace by default. Expansion beyond this ordered corpus is conditional. The current analysis session accepts four legitimate trigger conditions: a definitional gap, an explicit outward reference, a material contradiction, or a canonicity conflict. Any of these conditions may justify leaving the first-pass corpus to inspect `README.md`, other loose documents under `docs/`, or explanatory material elsewhere in the workspace. This staged rule refines earlier whole-workspace language without abandoning the principle that later expansion must remain evidence-driven rather than discretionary. [4][5][6][8]
+
+## 4. Glossary Constraint During the First Pass
+
+The glossary requirement remains active during this audit, but its first-version entries are constrained. Current session clarification narrows the definition policy to clear, independent statements answering only what a term is. This means the glossary should stabilize vocabulary during the first pass without prematurely absorbing extended history, argument, or navigation logic that properly belongs to canonical documents discovered through the audit. [3][4][6][8]
+
+## 5. Conclusion
+
+This ordered corpus index supplies the minimum procedural scaffold for the first evidentiary pass of issue #134. It defines which documents belong to the initial audit, in what order they should be traversed, and under what conditions the audit may legitimately expand outward. That scaffold is necessary because the stated end condition of analysis is not a loose diagnosis but a fully justified mapping of the documentation set with increased clarity. [2][3][4][5][7][8]
+
+## References
+
+[1] Finite APE Machine repository. "APE Builds APE — Research Documents." `docs/research/ape_builds_ape/index.md`.
+
+[2] Finite APE Machine repository. "Inquiry as Epistemic Foundation of APE." `docs/research/inquiry/index.md`.
+
+[3] Finite APE Machine repository. "SWEBOK Research — Index." `docs/research/swebok/index.md`.
+
+[4] Finite APE Machine repository. "Spec — Finite APE Machine." `docs/spec/index.md`.
+
+[5] Finite APE Machine repository. "Architecture." `docs/architecture.md`.
+
+[6] Finite APE Machine repository. "The Apes — Lore." `docs/lore.md`.
+
+[7] Finite APE Machine repository. "Taxonomy and scope clarification for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/taxonomy-and-scope-clarification.md`; "Obsolescence and canonicity criteria for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/obsolescence-and-canonicity-criteria.md`.
+
+[8] Primary-source analysis-session clarifications dated 2026-04-22 for issue #134: force a single canonical home with references from other documents; keep the glossary neutral; analysis is complete when a fully justified mapping and documentation clarity are achieved; begin with `docs/research/` and `docs/spec/`; include `docs/architecture.md` and `docs/lore.md` in the initial pass; expand outward when a definitional gap, explicit outward reference, material contradiction, or canonicity conflict appears; first glossary entries should be clear, independent definitions answering what a term is.

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/staged-corpus-entry-and-minimal-glossary-policy.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/staged-corpus-entry-and-minimal-glossary-policy.md
@@ -1,0 +1,92 @@
+---
+id: staged-corpus-entry-and-minimal-glossary-policy
+title: "Staged corpus entry and what-it-is-only glossary policy for issue #134"
+date: 2026-04-22
+status: active
+tags: [corpus-policy, glossary, evidence, documentation, audit]
+author: socrates
+---
+
+# Staged Corpus Entry and What-It-Is-Only Glossary Policy for Issue #134
+
+## Abstract
+
+Prior analysis established that the admissible evidentiary horizon for issue #134 cannot be confined to `docs/` alone, because explanatory material relevant to Inquiry, APE, Finite APE Machine, and Thinking Tools also appears in root and code-adjacent documentary surfaces. The present paper refines that boundary without revoking it. The whole workspace should remain the outer evidentiary corpus, but entry into that corpus should now be staged. The first pass should begin with `docs/spec/` and the relevant `docs/research/` index because those locations are the repository's explicit, indexed foundations for the technical and philosophical sides of the problem. Expansion beyond them should be conditional rather than automatic, because admissibility does not entail equal first-pass priority. Finally, the first glossary definitions should be narrower than the prior minimal direct-definition policy: in version one, they should answer only the question "what is it?" and defer comparative, historical, and navigational surplus until later evidence shows that more is needed. These claims are grounded in repository evidence, prior analysis papers in this cleanroom, and primary-source analysis-session clarifications dated 2026-04-22. [1][2][3][4][5][6][7][8][9][10]
+
+## 1. Why the Whole-Workspace Policy Must Be Refined into a Staged Entry Policy
+
+### 1.1 The prior whole-workspace claim answered admissibility, not first-pass sequence
+
+The earlier corpus-boundary paper argued correctly that issue #134 cannot begin from a `docs/`-only evidentiary assumption. The repository root `README.md`, `docs/architecture.md`, `docs/lore.md`, and documentation embedded under `code/` can all shape how a reader understands the project's core concepts. That conclusion remains analytically important because it blocks premature exclusion of documentary surfaces before canonicity has been evaluated. [3][4][5][9]
+
+However, the earlier argument does not imply that every admissible documentary surface deserves the same place in the first pass. Admissibility and entry order answer different questions. Admissibility asks which surfaces may become relevant evidence. Entry order asks where the analysis should begin when it has not yet earned the right to distribute attention across the whole workspace indiscriminately. The current session's clarification that the analysis should use common sense and start with `docs/research/` and `docs/spec/` therefore refines the earlier policy rather than contradicting it. It distinguishes outer corpus membership from disciplined initial retrieval. [9][10]
+
+### 1.2 `docs/spec/` and `docs/research/` are the repository's explicit indexed foundations for this issue
+
+The specification index describes `docs/spec/` as the location of technical specifications and architectural references, and it explicitly includes project overview and foundational concepts under its core section. The inquiry research index describes the relevant research surface as the philosophical foundation of APE and states the key thesis that every APE cycle is an instance of inquiry. Taken together, these two indexes already expose the two documentary dimensions that prior analysis identified as controlling for issue #134: technological foundation and philosophical foundation. [1][2][6][7]
+
+This matters because indexed surfaces differ from loose explanatory documents. An index is already a repository-authored statement about documentary organization, scope, and intended reading surface. When the issue concerns how core documentation should be organized, the repository's own curated indexes are stronger initial evidence than isolated explanatory texts that have not yet been situated within the broader corpus. The relevant `docs/research/` entry point for the present issue is therefore the inquiry research index, because it is the indexed research surface that directly addresses inquiry as APE's epistemic foundation. [1][2][10]
+
+### 1.3 Analytical consequence
+
+The whole workspace should remain the outer evidentiary horizon for issue #134, but first-pass entry should now be staged. The analysis should begin with the repository's curated foundation layers, namely `docs/spec/` and the relevant `docs/research/` index, before granting equal first-pass weight to root-level, loose, or code-adjacent documentary surfaces. This is a refinement in evidentiary discipline, not a retreat to a narrower corpus. [1][2][9][10]
+
+## 2. Why Expansion to the Rest of the Workspace Should Be Conditional Rather Than Automatic
+
+### 2.1 Conditional expansion follows from common-sense evidence weighting
+
+If the first pass were to expand automatically from the start to `README.md`, standalone top-level documents, and code-adjacent documentation, the analysis would flatten repository-authored differences among documentary surfaces before those differences had been evaluated. The root `README.md` is an entry surface for readers, `docs/architecture.md` is a system explanation, `docs/lore.md` is a conceptual and allegorical explanation of the agents, and code-adjacent documents operationalize parts of the same conceptual family in implementation-specific contexts. Those surfaces may all matter. But their mere existence does not justify giving them immediate parity with the repository's indexed foundation layers. [1][2][3][4][5][9]
+
+Common-sense analysis requires a narrower first move: start where the repository already declares foundational organization, then widen only when that initial pass leaves a material question underdetermined. Otherwise the audit confuses completeness of outer corpus with indiscriminate simultaneity of first-pass reading. That would increase noise at exactly the stage where the analysis is trying to establish stable evidence boundaries. [1][2][7][9][10]
+
+### 2.2 Conditional expansion preserves admissibility without making every surface primary by default
+
+Conditional expansion is justified because some evidence surfaces outside `docs/spec/` and `docs/research/` may still prove necessary. The `README.md` shapes first contact with the project. `docs/architecture.md` and `docs/lore.md` provide high-level explanatory frames not contained inside those indexed directories. Code-adjacent documentation can operationalize the same concepts in a way that reveals how the repository currently treats them in practice. For that reason, these surfaces should remain admissible. [3][4][5][9]
+
+What changes is not admissibility but trigger condition. Expansion should occur when the initial indexed pass fails to settle what a target term is, where its primary explanatory development appears to live, or whether another surface materially competes with or contradicts the indexed account. In other words, widening the corpus is warranted by evidentiary insufficiency, reference-chain dependence, or conflict detection, not by an automatic rule that every admissible surface must be consulted at the same initial stage. [1][2][8][9][10]
+
+### 2.3 Analytical consequence
+
+The refined policy preserves the prior whole-workspace boundary as a reserve of admissible evidence while treating expansion as conditional on what the first indexed pass fails to resolve. That makes the audit both stricter and more reproducible: stricter because it begins from declared documentary foundations, and more reproducible because it widens for explicit evidentiary reasons rather than by unbounded accumulation. [1][2][9][10]
+
+## 3. Why First Glossary Definitions Should Be Narrowed to "What It Is"
+
+### 3.1 The previous direct-definition policy was still broader than the current session now allows
+
+Earlier analysis already rejected a glossary made only of deferred references and argued that first-version entries should define terms directly. It also moved toward minimality by treating the glossary as an instrument for stabilizing vocabulary rather than replacing canonical documents. The current session narrows that standard further by clarifying that the first glossary definitions should answer only the question "what it is." This is a stricter rule than the prior direct-definition and disambiguation standard. [7][8][10]
+
+### 3.2 "What it is" is the smallest stable unit of definition at this stage of the audit
+
+At the current stage, the analysis is still deciding how evidence should be entered and when the corpus should widen. Under those conditions, comparative material inside the glossary risks doing too much too early. Statements about how a term differs from neighboring terms, where its primary document lives, why it matters, or how it is implemented already import a second layer of interpretation that may need revision once the staged corpus has been read more fully. A definition limited to "what it is" anchors term identity while minimizing premature commitments about relations, hierarchy, and documentary placement. [6][7][8][10]
+
+This narrowing does not abolish later expansion. It only identifies the minimum defensible first sentence of a glossary entry. In version one, the glossary should tell the reader what the thing is. It should not yet try to narrate its history, justify its importance, summarize its implementation, or absorb navigation duties that may belong elsewhere. That restraint follows directly from the current evidentiary goal: to stabilize vocabulary before the audit settles broader documentary structure. [7][8][10]
+
+### 3.3 Analytical consequence
+
+The first glossary entry for a core term should now be treated as a what-it-is statement and nothing more unless later evidence shows that the narrower form produces confusion. This refinement preserves the earlier insistence on direct definition while removing even more interpretive surplus from the glossary's first version. The glossary remains a definitional instrument, but its opening unit is now strictly identity-first. [7][8][10]
+
+## 4. Conclusion
+
+The current session requires a more disciplined policy than the earlier whole-workspace starting assumption and the earlier minimal direct-definition glossary policy. The whole workspace remains admissible as the outer evidentiary corpus, but initial entry should be staged through `docs/spec/` and the relevant `docs/research/` index because those are the repository's explicit foundation layers for the issue's technical and philosophical dimensions. Expansion to `README.md`, loose top-level documents, or code-adjacent documentation should remain possible but conditional on evidentiary need rather than automatic. And the first glossary definitions should be narrowed further so that version one answers only the question "what is it?" before adding comparative or navigational matter. These refinements do not solve canonicity by themselves. They determine the evidentiary discipline under which later canonicity judgments can be trusted. [1][2][3][4][5][6][7][8][9][10]
+
+## References
+
+[1] Finite APE Machine repository. "Spec - Finite APE Machine." `docs/spec/index.md`.
+
+[2] Finite APE Machine repository. "Inquiry as Epistemic Foundation of APE." `docs/research/inquiry/index.md`.
+
+[3] Finite APE Machine repository. "Architecture." `docs/architecture.md`.
+
+[4] Finite APE Machine repository. "The Apes - Lore." `docs/lore.md`.
+
+[5] Finite APE Machine repository. "Inquiry." `README.md`.
+
+[6] Finite APE Machine repository. "Taxonomy and scope clarification for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/taxonomy-and-scope-clarification.md`.
+
+[7] Finite APE Machine repository. "Glossary necessity and reader-priority clarification for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/glossary-need-and-reader-priority.md`.
+
+[8] Finite APE Machine repository. "Glossary direct-definition and audit navigation requirements for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/glossary-and-audit-navigation-requirements.md`.
+
+[9] Finite APE Machine repository. "Corpus boundary, directory-order traversal, and minimal-definition glossary policy for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/corpus-boundary-and-ordering-policy.md`.
+
+[10] Primary-source analysis-session clarifications dated 2026-04-22 for issue #134: use common sense; start with `docs/research/` and `docs/spec/`; expand to the rest of the workspace only when necessary; reading order follows that staged starting point; first glossary definitions should answer only "what it is."

--- a/docs/cleanrooms/134-organize-core-documentation/analyze/taxonomy-and-scope-clarification.md
+++ b/docs/cleanrooms/134-organize-core-documentation/analyze/taxonomy-and-scope-clarification.md
@@ -1,0 +1,88 @@
+---
+id: taxonomy-and-scope-clarification
+title: "Taxonomy and scope clarification for issue #134"
+date: 2026-04-22
+status: active
+tags: [taxonomy, scope, documentation, inquiry, ape]
+author: socrates
+---
+
+# Taxonomy and Scope Clarification for Issue #134
+
+## Abstract
+
+Issue #134 is not primarily driven by unresolved conceptual ambiguity among project maintainers. The present problem is archival and user-facing: core concepts and their supporting materials are distributed across heterogeneous documentation roots, while some documents may be historical or obsolete without that status being legible to readers. This paper establishes three analytical boundaries needed before any reorganization question can be evaluated: first, the distinction between archival disorder and conceptual ambiguity; second, the distinction among Inquiry, APE, Finite APE Machine, and Thinking Tools; third, the evidence policy that subsequent analysis documents should follow. These boundaries are derived from repository evidence and from analysis-session clarifications dated 2026-04-22. [1][2][3][4][5][6][7]
+
+## 1. Problem Framing: Archival Disorder Rather Than Internal Conceptual Confusion
+
+### 1.1 Existing repository structure already separates documentation functions
+
+The repository already distinguishes several documentation functions. The spec index presents `docs/spec/` as the home of technical specifications and architectural references. The inquiry research index presents `docs/research/inquiry/` as the epistemic foundation of APE. Top-level documents such as `docs/architecture.md` add system explanation at a broader descriptive layer. This means issue #134 begins from an existing taxonomy, albeit an uneven one, rather than from the absence of conceptual categories. [1][2][3]
+
+### 1.2 The clarified problem is user-facing clarity under archival drift
+
+The analysis-session clarification states that the user does not experience the four target terms as conceptually ambiguous. The difficulty lies instead in whether readers can understand their boundaries quickly, and in whether documents made obsolete by later decisions remain visible without adequate status signaling. The issue is therefore archival in two senses: placement is unclear, and historical status may be unclear. It is not, at root, a dispute about what the internal vocabulary means to the project's authors. [7]
+
+### 1.3 Analytical consequence
+
+Issue #134 should therefore be treated as a taxonomy-and-status problem. The relevant analytical questions are which concepts are primary, where each concept's canonical explanation belongs, and what marks a text as current, historical, or obsolete. An analysis that reduces the issue to terminological confusion would mis-specify the problem. [1][2][7]
+
+## 2. Terminology Boundaries
+
+### 2.1 Inquiry
+
+Within repository evidence, inquiry names the epistemic foundation of APE and the structured process that transforms an indeterminate situation into a determinate result. The inquiry research index explicitly frames inquiry as the philosophical basis of APE, and its key thesis states that every APE cycle is an instance of inquiry. The current analysis session further clarifies this boundary in direct terms: Inquiry is an APE cycle. Inquiry should therefore be treated as the cycle or process, not as the entire technical machinery that operationalizes it. [2][7]
+
+### 2.2 APE
+
+Repository documents use APE in two closely related but compatible senses: as a methodology for AI-aided development and as the orchestrating system that dispatches specialized agents across phases. The Finite APE Machine specification defines APE as a methodology and agent architecture, while the agent lifecycle and lore documents stress that APE is not one ape among others but the scheduler or event loop that coordinates them. The stable boundary is therefore that APE names the orchestrating methodological system. [5][6]
+
+### 2.3 Finite APE Machine
+
+Finite APE Machine is the most concrete, system-level term in the current taxonomy. It names Inquiry brought into operational practice through the APE cycle and expressed through finite-state, scheduler, signal, and control-loop concepts. The architecture document describes orchestration through an FSM and target-deployed agent system; the specification describes APE as a feedback control loop; the lifecycle and signal-coordination documents describe scheduler and RTOS-like event behavior. The analysis-session clarification adds that Finite APE Machine is Inquiry brought into practice through the APE cycle, additionally using FSM and RTOS theory. Finite APE Machine is therefore not merely a synonym for inquiry. It is the engineered realization of that inquiry framework. [3][5][6][7]
+
+### 2.4 Thinking Tools
+
+Thinking Tools are neither synonymous with Inquiry nor coextensive with APE or Finite APE Machine. They are the cognitive methods, reasoning disciplines, or working heuristics embodied within phases or agents. Repository evidence repeatedly describes active agents in terms of their thinking tools: Socratic questioning for SOCRATES, methodical decomposition and experiment design for DESCARTES, and execution disciplines such as TDD within the broader implementation loop. The current analysis session broadens this class explicitly to include Socratic method, Cartesian method, scientific method, TDD, and related methods. Thinking Tools should therefore be treated as a family of methods employed within the framework rather than as the framework's umbrella identity. [5][6][7]
+
+### 2.5 Boundary summary
+
+Taken together, the terms form a hierarchy rather than a set of interchangeable labels. Inquiry denotes the cycle-level epistemic process. APE denotes the orchestrating methodological system that structures that process. Finite APE Machine denotes the concrete system architecture that operationalizes APE through FSM, signal, and control-loop concepts. Thinking Tools denote the reusable methods deployed within or across phases. Collapsing these terms would reduce user-facing clarity precisely where the issue seeks to increase it. [2][3][5][6][7]
+
+## 3. Evidence Policy for Subsequent Documents
+
+### 3.1 Internal evidence should be primary for repository-local taxonomy
+
+Because issue #134 concerns the organization of this repository's own documentation, internal sources should be primary whenever the claim concerns current structure, intended terminology, canonical homes, or present architectural boundaries. The repository already maintains distinct roots for specification, inquiry research, architecture, lore, and working analysis. Those distinctions are the best evidence for claims about current documentary function. [1][2][3][4][6]
+
+### 3.2 External evidence is warranted only when repository evidence underdetermines the claim
+
+External references become necessary when a later analysis document makes claims about philosophical history, methodological ancestry, or technical theory that exceed repository self-description. Claims about Peirce, Dewey, the Socratic method, Cartesian method, control theory, or RTOS theory may require external support if they are advanced as historical or theoretical truths rather than merely as project framing. In those cases, repository documents remain evidence of project intent, but not sufficient evidence of the external claim itself. [2][3][5][6]
+
+### 3.3 Analysis-session clarifications may be cited as primary-source evidence
+
+Where the current conversation establishes scope decisions or user-defined terminology not yet codified in repository documents, those clarifications may be cited as primary-source analysis-session clarifications dated 2026-04-22. This applies here to the claims that the problem is archival rather than conceptual for the maintainer, that Inquiry is an APE cycle, that Finite APE Machine is Inquiry operationalized through the cycle with FSM and RTOS theory, and that Thinking Tools include methods such as the Socratic method, Cartesian method, scientific method, and TDD. [7]
+
+### 3.4 Negative rule
+
+Subsequent documents should avoid two evidentiary errors. First, they should not import external authorities to settle repository-local taxonomy when internal project evidence already decides the matter. Second, they should not rely only on internal project documents when advancing claims whose truth depends on external intellectual history. This mixed evidence policy follows directly from the repository's existing separation between specification, research, and architecture, and from the user's stated evidence standard for this issue. [1][2][3][7]
+
+## 4. Conclusion
+
+Issue #134 is best framed as a documentation-taxonomy problem under archival drift. The central analytical task is not to discover what the maintainers mean, but to make that meaning legible to readers and to distinguish canonical, historical, and obsolete materials. Within that framing, Inquiry denotes the cycle or process; APE denotes the orchestrating methodological system; Finite APE Machine denotes the engineered realization of that system through FSM, signal, and control-loop concepts; and Thinking Tools denote the family of methods employed within or across phases. Later analysis should preserve these boundaries if it aims to improve user-facing clarity rather than merely rearrange files. [1][2][3][5][6][7]
+
+## References
+
+[1] Finite APE Machine repository. "Spec — Finite APE Machine." `docs/spec/index.md`.
+
+[2] Finite APE Machine repository. "Inquiry as Epistemic Foundation of APE." `docs/research/inquiry/index.md`.
+
+[3] Finite APE Machine repository. "Architecture." `docs/architecture.md`.
+
+[4] Finite APE Machine repository. "Memory as Code." `docs/spec/memory-as-code-spec.md`.
+
+[5] Finite APE Machine repository. "Finite APE Machine." `docs/spec/finite-ape-machine.md`.
+
+[6] Finite APE Machine repository. "Agent Lifecycle and States." `docs/spec/agent-lifecycle.md`; "The Apes — Lore." `docs/lore.md`.
+
+[7] Analysis-session clarifications with the user regarding issue #134, dated 2026-04-22.

--- a/docs/cleanrooms/134-organize-core-documentation/plan.md
+++ b/docs/cleanrooms/134-organize-core-documentation/plan.md
@@ -1,0 +1,183 @@
+---
+id: plan
+title: "Plan for issue #134: reorganize documentation authority inside docs/"
+date: 2026-04-22
+status: active
+tags: [documentation, canonicality, architecture, finite-ape-machine, thinking-tools]
+author: descartes
+---
+
+# Plan for Issue #134: Reorganize Documentation Authority Inside docs/
+
+**Hypothesis:** If we reorganize only the `docs/` tree around the canonical-home map established in the diagnosis, then a foundations-oriented reader will be able to find one authoritative home per core concept without being misled by mixed, duplicated, or historical surfaces.
+
+**Diagnosis verified:** The analysis corpus now supports an asymmetrical solution. Inquiry already has a canonical home in `docs/research/inquiry/`. APE should be owned by `docs/architecture.md`. `docs/spec/finite-ape-machine.md` must be rewritten before it can safely serve as a canonical current overview. Thinking Tools requires a dedicated document. Current-supporting docs need path cleanup and sharper cross-references; historical or mixed docs need explicit status signaling. Per the current user instruction, execution scope is limited to `docs/` and its contents. Root `README.md`, site files, and `code/vscode/docs/` remain outside this execution scope even when the diagnosis classified them. [1][2][3]
+
+---
+
+## Phase 1 — Canonical navigation inside docs/
+
+**Objective:** Make the documentation tree itself express the canonical-home map before rewriting content in depth.
+
+**Dependencies:** Diagnosis complete.
+
+### Changes
+
+- [x] Update `docs/spec/index.md` so it no longer presents all specification documents as co-equal current authorities.
+- [x] Make `docs/spec/index.md` explicitly route readers to:
+  - Inquiry → `docs/research/inquiry/`
+  - APE → `docs/architecture.md`
+  - Finite APE Machine → `docs/spec/finite-ape-machine.md`
+  - Thinking Tools → new `docs/thinking-tools.md`
+- [x] Add concise status signaling in `docs/spec/index.md` for current-supporting versus historical-or-planned specs.
+- [x] If needed for readability, add one short cross-reference in `docs/research/inquiry/index.md` clarifying that it is the canonical philosophical home of Inquiry.
+
+### Test
+
+- Read `docs/spec/index.md` top-to-bottom and confirm that each of the four core concepts has exactly one named destination.
+- Confirm that no second document is presented in the same index as a co-equal home for the same concept.
+
+### Risks
+
+- Over-correcting the index into a changelog of statuses instead of a navigation surface.
+- Accidentally demoting a supporting technical spec that should remain easy to discover.
+
+---
+
+## Phase 2 — Reclaim `docs/spec/finite-ape-machine.md`
+
+**Objective:** Rewrite the same-named flagship spec so it reflects the current model rather than the older expansive roster.
+
+**Dependencies:** Phase 1 complete, because the rewritten file must land inside an already clarified navigation structure.
+
+### Changes
+
+- [x] Rewrite `docs/spec/finite-ape-machine.md` around the current architecture:
+  - finite-state orchestration
+  - scheduler role of APE
+  - Inquiry as the cycle-level process
+  - signal/event coordination
+  - END and opt-in EVOLUTION in the current cycle model
+- [x] Remove or relocate claims that present MARCOPOLO, VITRUVIUS, SUNZI, GATSBY, ADA, DIJKSTRA, BORGES, and HERMES as active architectural peers in the current implementation.
+- [x] Preserve historically valuable material only if it is clearly labeled as historical context or appendix material.
+- [x] Add cross-references from the rewritten spec to `docs/research/inquiry/`, `docs/architecture.md`, `docs/spec/cooperative-multitasking-model.md`, and `docs/spec/signal-based-coordination.md`.
+
+### Test
+
+- Compare the rewritten `docs/spec/finite-ape-machine.md` against `docs/architecture.md`, `docs/spec/cooperative-multitasking-model.md`, and `docs/spec/signal-based-coordination.md` and confirm that the current-state model matches across all four surfaces.
+- Grep the rewritten file for legacy-agent names and verify they appear only in explicitly historical context, if at all.
+
+### Risks
+
+- Losing valuable historical rationale while removing legacy architecture.
+- Rewriting too narrowly and duplicating `docs/architecture.md` instead of giving `finite-ape-machine.md` its own technical-overview role.
+
+---
+
+## Phase 3 — Create Thinking Tools canonical home and reposition lore
+
+**Objective:** Give Thinking Tools a clean canonical document while preserving `docs/lore.md` as nomenclature and historical companion.
+
+**Dependencies:** Phase 1 complete.
+
+### Changes
+
+- [x] Create new `docs/thinking-tools.md` as the canonical current explanation of Thinking Tools.
+- [x] Define the category directly and map current tools to phases and agents without collapsing the document into lore.
+- [x] Use repo-native hyphenated naming (`thinking-tools.md`) even though the issue title used underscore spelling.
+- [x] Update `docs/lore.md` so it explicitly states its role as nomenclature, allegory, and historical context rather than the sole canonical home of Thinking Tools.
+- [x] Add forward references between `docs/thinking-tools.md`, `docs/lore.md`, and `docs/architecture.md`.
+
+### Test
+
+- Read `docs/thinking-tools.md` alone and confirm it explains the concept without requiring lore to rescue basic comprehension.
+- Read the first sections of `docs/lore.md` and confirm a reader is immediately directed to `docs/thinking-tools.md` for the current canonical explanation.
+
+### Risks
+
+- Creating a Thinking Tools document that merely duplicates `docs/lore.md`.
+- Over-sanitizing lore and erasing the symbolic layer that still has documentary value.
+
+---
+
+## Phase 4 — Align current-supporting docs and mark mixed surfaces clearly
+
+**Objective:** Remove high-risk drift from current-supporting docs and add explicit status signaling to mixed or historical docs that remain in `docs/`.
+
+**Dependencies:** Phases 2 and 3 complete.
+
+### Changes
+
+- [x] Update `docs/architecture.md` so it explicitly owns APE as the orchestrating methodology and uses current artifact paths under `docs/cleanrooms/` where it is describing current workflow.
+- [x] Update current-supporting docs as needed for consistency and path drift:
+  - `docs/spec/agent-lifecycle.md`
+  - `docs/spec/cooperative-multitasking-model.md`
+  - `docs/spec/signal-based-coordination.md`
+  - `docs/spec/cli-as-api.md`
+  - `docs/spec/target-specific-agents.md`
+- [x] Add clear historical-or-mixed-status notes near the top of the following docs without rewriting them into current doctrine:
+  - `docs/spec/orchestrator-spec.md`
+  - `docs/spec/memory-as-code-spec.md`
+  - `docs/spec/inquiry-cli-spec.md`
+  - `docs/roadmap.md`
+- [x] Ensure `docs/roadmap.md` is framed as strategic direction rather than the source of current operational truth.
+
+### Test
+
+- Search the updated current-supporting docs for `docs/issues/` and confirm that remaining matches are either removed or explicitly historical.
+- Read the opening note of each mixed/historical document and confirm that a new reader would not mistake it for the current authoritative model.
+
+### Risks
+
+- Treating every stale path as a reason for full rewrite when a narrower status note is enough.
+- Leaving ambiguous mixed docs without a strong enough warning to prevent false understanding.
+
+---
+
+## Phase 5 — Validation pass across docs/
+
+**Objective:** Confirm that the modified docs tree behaves as one coherent documentation system.
+
+**Dependencies:** Phases 1–4 complete.
+
+### Changes
+
+- [x] Re-read the canonical set in order:
+  - `docs/research/inquiry/index.md`
+  - `docs/architecture.md`
+  - `docs/spec/finite-ape-machine.md`
+  - `docs/thinking-tools.md`
+- [x] Re-read `docs/spec/index.md` and confirm the navigation still matches the final state of the files.
+- [x] Fix any broken relative links introduced during execution.
+- [x] Update status notes or cross-references if validation reveals a remaining ambiguity.
+
+### Test
+
+- Manual link validation in VS Code markdown preview for all modified docs.
+- Focused search for the core terms `Inquiry|APE|Finite APE Machine|Thinking Tools` inside `docs/` and confirm the first explanatory hit for each term points to the intended canonical home.
+- Focused search for `docs/issues/` inside modified current docs and confirm no accidental current-path drift remains.
+
+### Risks
+
+- Link integrity drift after moving or renaming conceptual destinations.
+- Remaining contradictory summaries in supporting docs after the core rewrite is complete.
+
+---
+
+## Out of Scope for This Execution
+
+- Root `README.md`
+- `code/site/`
+- `code/vscode/docs/ape_vscode_extension.md`
+
+These surfaces were classified during analysis and may need later follow-up, but they are outside the current user-authorized execution scope, which is limited to `docs/`.
+
+---
+
+## References
+
+[1] Finite APE Machine repository. "Diagnosis for issue #134: justified documentation status map and canonical-home recommendations." `docs/cleanrooms/134-organize-core-documentation/analyze/diagnosis.md`.
+
+[2] Finite APE Machine repository. "Expanded entry-surface findings and contradiction synthesis for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/expanded-entry-surface-findings.md`.
+
+[3] Finite APE Machine repository. "Baseline glossary for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/glossary-baseline.md`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,15 @@
+# Documentation Index
+
+Top-level navigation for the repository documentation.
+
+| Path | Role |
+|------|------|
+| [architecture.md](architecture.md) | Current system-level explanation of APE as orchestrating methodology |
+| [thinking-tools.md](thinking-tools.md) | Current canonical explainer for Thinking Tools |
+| [lore.md](lore.md) | Nomenclature, allegory, and historical context for the named agents |
+| [roadmap.md](roadmap.md) | Strategic direction and long-term theses |
+| [spec/index.md](spec/index.md) | Technical specifications and status-aware navigation |
+| [research/inquiry/index.md](research/inquiry/index.md) | Canonical philosophical home of Inquiry |
+| [research/ape_builds_ape/index.md](research/ape_builds_ape/index.md) | Empirical and bootstrap research corpus |
+| [adr/](adr/) | Architecture Decision Records |
+| [cleanrooms/](cleanrooms/) | Per-issue working documentation and analysis artifacts |

--- a/docs/lore.md
+++ b/docs/lore.md
@@ -1,21 +1,22 @@
 # The Apes — Lore
 
+> This document is the repository's nomenclature, allegory, and historical-context companion for the named agents. For the current canonical explanation of Thinking Tools, see [thinking-tools.md](thinking-tools.md). For the current system-level explanation of APE as orchestrating methodology, see [architecture.md](architecture.md).
+
+> Historical naming note: APE was the project's initial working name. Inquiry is the current system name and public identity. The individual sub-agents remain "apes" here as a lore and avatar convention, and the phrase "APE builds APE" is preserved only as historical bootstrap wording from that earlier phase.
+
 > Every ape in the Finite APE Machine carries two identities: a **name** drawn from history and literature that embodies its essence, and a **function** expressed as a CLI command that describes what it does. The name is the soul; the command is the hand.
 
 ---
 
 ## Active Model (v0.0.8+)
 
-The current APE cycle uses four sub-agents, each embodying a thinking tool from a different discipline, era, and culture:
+The current APE cycle uses four sub-agents, each embodying a thinking tool from a different discipline, era, and culture, plus an explicit END gate before EVOLUTION:
 
 ```
-IDLE ──→ ANALYZE ──→ PLAN ──→ EXECUTE ──→ EVOLUTION
- │         │          │         │            │
- APE      SOCRATES   DESCARTES  BASHŌ       DARWIN
- (triage)  (mayéutica) (método)  (techne)    (selección)
+IDLE ──→ ANALYZE ──→ PLAN ──→ EXECUTE ──→ END ──→ EVOLUTION
 ```
 
-APE is NOT an ape — it is the Finite APE Machine, the scheduler, the RTOS event loop. It has no personality and no namesake. The four sub-agents below are the thinking tools it dispatches.
+APE is NOT an ape — it is the Finite APE Machine, the scheduler, the RTOS event loop. It has no personality and no namesake. It operates directly in IDLE and at the END gate; the four sub-agents below are the thinking tools it dispatches in the other states.
 
 ---
 
@@ -29,7 +30,7 @@ APE is NOT an ape — it is the Finite APE Machine, the scheduler, the RTOS even
 
 **The ape.** SOCRATES explores problems through conversation. It asks questions, identifies ambiguities, maps the domain, challenges assumptions. It produces `diagnosis.md` — a rigorous paper with references that serves as the sole input for the planning phase. Like its namesake, it does not tell the human what the requirements are — it asks until the human discovers them.
 
-**Key artifact:** `docs/issues/<task>/analyze/diagnosis.md`
+**Key artifact:** `docs/cleanrooms/<task>/analyze/diagnosis.md`
 
 ---
 
@@ -43,7 +44,7 @@ APE is NOT an ape — it is the Finite APE Machine, the scheduler, the RTOS even
 
 **The ape.** DESCARTES takes `diagnosis.md` and designs an experiment. The plan is a hypothesis: "if we implement these phases in this order, we will solve the diagnosed problem." It decomposes complexity into a WBS with checkable phases, defines tests in pseudocode as verification criteria, and sequences by dependency. The plan must be detailed enough that EXECUTE is mechanical — following instructions, not inventing them. If EXECUTE detects a deviation, the system returns to ANALYZE — like falsifying a hypothesis in the scientific method. Like its namesake, DESCARTES does not build — it designs the experiment from which others build.
 
-**Key artifact:** `docs/issues/<task>/plan.md`
+**Key artifact:** `docs/cleanrooms/<task>/plan.md`
 
 ---
 

--- a/docs/research/inquiry/index.md
+++ b/docs/research/inquiry/index.md
@@ -4,6 +4,8 @@
 
 This research documents the philosophical foundations that underpin the APE methodology, tracing the concept of **inquiry** from Aristotle through Peirce and Dewey to its application in structured software development.
 
+This directory is the canonical philosophical home of **Inquiry** in the repository. For the current system-level explanation of APE as an orchestrating methodology, see [../../architecture.md](../../architecture.md).
+
 APE's FSM (IDLE → ANALYZE → PLAN → EXECUTE → END → EVOLUTION) is not an arbitrary process — it is a formal instantiation of the **pragmatic theory of inquiry** as developed by Charles Sanders Peirce and John Dewey.
 
 ## Documents

--- a/docs/research/inquiry/iq-rebrand-vision.md
+++ b/docs/research/inquiry/iq-rebrand-vision.md
@@ -9,6 +9,10 @@ author: ccisnedev
 
 # Inquiry CLI (`iq`) — Rebrand Vision
 
+> Status note: This document captures the rebrand vision at the moment it was formulated. It is useful as historical reasoning about why Inquiry became the public identity, but it is not the authoritative description of the current repository layout or command surface.
+>
+> In particular, examples here that mention `.ape/`, `ape` commands, or `docs/issues/<NNN-slug>/` reflect the transition context in which the rebrand was being designed. For the current repository doctrine, start with [../../index.md](../../index.md), [../../architecture.md](../../architecture.md), [../../spec/finite-ape-machine.md](../../spec/finite-ape-machine.md), and [../inquiry/index.md](index.md).
+
 ## Origin
 
 During the Socratic analysis of issue #110 (naming APE's primary subcommand noun), a deeper insight emerged: **inquiry is not a subcommand of APE — inquiry IS the identity**. APE (Analyze-Plan-Execute) is the methodology that inquiry employs, not the other way around.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,8 @@
 # Roadmap
 
-> Where APE is going next. For where APE is today, see [README.md](../README.md).
+> Status note: This roadmap is a strategic and partially historical planning document. It preserves backlog framing from earlier releases and should not be used as the authoritative description of the current operational model. For the current canonical explanation, see [architecture.md](architecture.md), [spec/finite-ape-machine.md](spec/finite-ape-machine.md), and [thinking-tools.md](thinking-tools.md).
+
+> Where APE is going next. For where APE is today, see [../README.md](../README.md).
 
 This roadmap is **descriptive, not prescriptive**: it reflects the open issues currently in the backlog and the long-running theses that motivate the project. Anything not backed by an issue is exploratory.
 
@@ -14,14 +16,14 @@ APE aims to be a **methodology that survives any AI market scenario**. Three the
 
 The end-state is an **APE that builds APE**: a self-improving framework where every cycle generates evidence (in `metrics.yaml`, in evolution issues, in mutations.md) that feeds the next cycle.
 
-## Where we are (v0.0.14)
+## Historical planning snapshot (v0.0.14)
 
 - 5-state FSM with declarative transition contract (IDLE / ANALYZE / PLAN / EXECUTE / EVOLUTION)
 - 9 working CLI commands across 3 modules (`global`, `target`, `state`)
-- Single-target deployment (Copilot) per [ADR D20](docs/spec/target-specific-agents.md)
+- Single-target deployment (Copilot) per [ADR D20](spec/target-specific-agents.md)
 - 4 active agents: SOCRATES, DESCARTES, BASHŌ, DARWIN
 - 131 tests, cross-platform (Windows + Linux), 12 GitHub releases
-- Empirical bootstrap underway: APE is being built using APE (see [bootstrap-validation](docs/research/ape_builds_ape/bootstrap-validation.md))
+- Empirical bootstrap underway: APE is being built using APE (see [bootstrap-validation](research/ape_builds_ape/bootstrap-validation.md))
 
 ## Near-term (v0.0.x → v0.1.0)
 
@@ -61,7 +63,7 @@ First-class commands for the Memory-as-Code spec:
 Replace the manual `gh issue create / gh pr create / gh pr merge` dance with a single command per FSM transition. Currently the agent calls `gh` directly; `iq task` would wrap that with prechecks (issue exists, branch matches issue number, no scope drift per #49).
 
 ### Multi-target reactivation
-The deferred half of [ADR D20](docs/spec/target-specific-agents.md). Adapters already exist for Claude Code, Crush, Codex, and Gemini — they just aren't wired into `iq target get`. Reactivation requires:
+The deferred half of [ADR D20](spec/target-specific-agents.md). Adapters already exist for Claude Code, Crush, Codex, and Gemini — they just aren't wired into `iq target get`. Reactivation requires:
 1. Stable agent prompt API (so the same APE methodology runs identically across hosts)
 2. A test matrix that runs the same APE cycle against multiple targets
 3. The metrics system from #72 to compare targets quantitatively
@@ -77,7 +79,7 @@ Theses that take the project beyond a CLI tool.
 A reference deployment running entirely on local models (Gemma, Qwen, etc.) with no cloud dependency. This is the hardest test of thesis #1: if APE makes a 7B local model competitive with a frontier cloud model on real cycles, the framework's value is proven.
 
 ### Bootstrap-validation paper
-Publish the empirical paper on APE-builds-APE. Requires the full metrics dataset from #72 and at least 30 cycles of clean data. Plan: [docs/research/ape_builds_ape/bootstrap-validation.md](docs/research/ape_builds_ape/bootstrap-validation.md).
+Publish the empirical paper on APE-builds-APE. Requires the full metrics dataset from #72 and at least 30 cycles of clean data. Plan: [research/ape_builds_ape/bootstrap-validation.md](research/ape_builds_ape/bootstrap-validation.md).
 
 ### DARWIN community-level learning
 Currently DARWIN proposes mutations only to *this* repo's APE. The long-term vision is a community-level DARWIN that aggregates evolution issues across many APE-using projects to propose changes upstream to the framework itself.
@@ -87,7 +89,7 @@ The semantic risk matrix exists in spec but not yet in CLI behavior. End-state: 
 
 ## Lore vs reality
 
-The original [docs/lore.md](docs/lore.md) sketched 9+ apes. After two months of building APE with APE, the roster collapsed to 4 active agents. This is honest accounting, not a roadmap commitment to revive deferred ones — most were absorbed by simpler agents that turned out to do the job better.
+The original [lore.md](lore.md) sketched 9+ apes. After two months of building APE with APE, the roster collapsed to 4 active agents. This is honest accounting, not a roadmap commitment to revive deferred ones — most were absorbed by simpler agents that turned out to do the job better.
 
 | Lore agent | Status | What happened |
 |---|---|---|

--- a/docs/spec/agent-lifecycle.md
+++ b/docs/spec/agent-lifecycle.md
@@ -1,6 +1,6 @@
 ---
 id: agent-lifecycle
-title: "Agent lifecycle — five-state model and confirmed agent registry"
+title: "Agent lifecycle — six-state model and confirmed agent registry"
 date: 2026-04-17
 status: active
 tags: [agents, fsm, lifecycle, registry, socrates, descartes, basho, darwin]
@@ -11,10 +11,10 @@ author: socrates
 
 ## APE Cycle States (confirmed)
 
-The Finite APE Machine operates as a five-state FSM:
+The Finite APE Machine operates as a six-state FSM:
 
 ```
-IDLE → ANALYZE → PLAN → EXECUTE → EVOLUTION
+IDLE → ANALYZE → PLAN → EXECUTE → END → EVOLUTION
 ```
 
 | APE State | Function | Operator | Thinking Tool |
@@ -23,19 +23,22 @@ IDLE → ANALYZE → PLAN → EXECUTE → EVOLUTION
 | ANALYZE | Deep understanding via Socratic method | SOCRATES (sub-agent) | Mayéutica — draw truth through questions |
 | PLAN | Experimental design, WBS, test definition | DESCARTES (sub-agent) | Method — divide, order, verify, enumerate |
 | EXECUTE | Implementation under constraints | BASHŌ (sub-agent) | Techne + 用の美 (yō no bi) — functional beauty |
+| END | Explicit closure gate before evolution or return to idle | APE + human gate | Human judgment under explicit authorization |
 | EVOLUTION | Evaluate APE process, create improvement issues | DARWIN (sub-agent) | Natural selection — observe, compare, select |
 
 ### State descriptions
 
-**IDLE** — APE's default state. The user converses freely. APE uses the triage skill to evaluate whether the problem merits a formal cycle. If so, the skill guides infrastructure preparation: verify/create the GitHub issue (`gh`), create the branch and working directory (`ape issue start NNN`), and transition to ANALYZE. APE operates directly in this state — no sub-agent.
+**IDLE** — APE's default state. The user converses freely. APE uses the triage skill to evaluate whether the problem merits a formal cycle. If so, the protocol guides infrastructure preparation: verify or create the GitHub issue, create the branch and working directory, and transition to ANALYZE. APE operates directly in this state — no sub-agent.
 
 **ANALYZE** — SOCRATES conducts Socratic analysis. Explores the problem through questions, challenges assumptions, documents findings. Produces `diagnosis.md` — a rigorous technical document (paper-style, with references) that serves as the sole input for the planning phase. The user approves the diagnosis before transitioning.
 
 **PLAN** — DESCARTES applies the scientific method: the plan is an experimental design. Decomposes complexity into phases (WBS), defines tests in pseudocode, sequences by dependencies. Produces `plan.md` as an immutable checklist. The plan must be detailed enough that EXECUTE is mechanical — following instructions, not inventing them. The user approves the plan before transitioning.
 
-**EXECUTE** — BASHŌ implements the plan phase by phase, like a haiku master working within formal constraints (the plan's restrictions = the 5-7-5 form). Each phase produces a commit. The final phase includes product retrospective: an implementation report with validation instructions for the user. If a deviation is detected, returns to ANALYZE (like falsifying a hypothesis in the scientific method). The user approves execution (commit + push + PR) before transitioning.
+**EXECUTE** — BASHŌ implements the plan phase by phase, like a haiku master working within formal constraints (the plan's restrictions = the 5-7-5 form). Each phase produces a commit. The final phase includes product retrospective: an implementation report with validation instructions for the user. If a deviation is detected, returns to ANALYZE (like falsifying a hypothesis in the scientific method). The user approves the execution report before transitioning to END.
 
-**EVOLUTION** — DARWIN reads the complete cycle (diagnosis, plan, commits, deviations) and evaluates APE's own process. Searches for existing issues in `inquiry` repo (`gh issue list --search`), comments on matches or creates new issues. Automatic, no user approval required. Opt-out via `.inquiry/config.yaml` (`evolution.enabled: false`).
+**END** — APE presents the execution summary and waits for explicit authorization to create the PR and pass into EVOLUTION or return to IDLE if evolution is disabled. This keeps delivery and merge preparation as a distinct closure gate rather than an implicit side effect of EXECUTE.
+
+**EVOLUTION** — DARWIN reads the complete cycle (diagnosis, plan, commits, deviations) and evaluates APE's own process. Searches for existing issues in the Inquiry repository (`gh issue list --search`), comments on matches or creates new issues. Automatic, no user approval required. Opt-out via `.inquiry/config.yaml` (`evolution.enabled: false`).
 
 ## Agent Registry
 
@@ -106,7 +109,9 @@ All APE state transitions are mechanical, executed via skill → CLI chain:
 | IDLE → ANALYZE | `issue_ready` | Verify rama + carpeta exist |
 | ANALYZE → PLAN | `analysis_approved` | `git commit` analysis docs |
 | PLAN → EXECUTE | `plan_approved` | `git commit` plan.md |
-| EXECUTE → EVOLUTION | `execution_approved` | `git commit`, `git push`, `gh pr create` |
+| EXECUTE → END | `execution_approved` | `git commit` execution artifacts |
+| END → EVOLUTION | `pr_ready` | `git push`, `gh pr create` |
+| END → IDLE | `pr_ready_no_evolution` | `git push`, `gh pr create` |
 | EVOLUTION → IDLE | `cycle_complete` | Close issue if applicable |
 
 **Illegal transitions:**
@@ -114,6 +119,7 @@ All APE state transitions are mechanical, executed via skill → CLI chain:
 - IDLE → EXECUTE (no plan)
 - ANALYZE → EXECUTE (skipping plan)
 - EXECUTE → PLAN (must go through ANALYZE)
+- EXECUTE → EVOLUTION (must go through END)
 
 ### Transition ownership
 
@@ -123,7 +129,7 @@ All APE state transitions are mechanical, executed via skill → CLI chain:
 ## Artifacts per State
 
 ```
-docs/issues/NNN-<slug>/
+docs/cleanrooms/NNN-<slug>/
 ├── analyze/
 │   ├── index.md              ← navigation
 │   ├── *.md                  ← working documents (exploration, discards)

--- a/docs/spec/cli-as-api.md
+++ b/docs/spec/cli-as-api.md
@@ -1,6 +1,6 @@
 ---
 id: cli-as-api
-title: "CLI as API — skills instruct, commands execute"
+title: "CLI as API — skills instruct, commands execute through Inquiry"
 date: 2026-04-17
 status: active
 tags: [architecture, cli, skills, commands, validation, human-usable]
@@ -13,27 +13,27 @@ author: socrates
 
 ```
 Skill (memory-write)        →  Tells the agent WHEN and HOW to write
-CLI (ape memory write)      →  Does the actual work with validation
+CLI (`iq` command surface)  →  Does the actual work with validation
 ```
 
-A skill is documentation. A command is execution. The skill says "when you need to create an analysis document, use `ape memory write` with these parameters." The command validates input, enforces format, and writes the file.
+A skill is documentation. A command is execution. The skill tells the agent what protocol to follow; the CLI enforces the repository's runtime contract where a command exists.
 
 ## Design Decisions
 
-### D5: Skills never bypass CLI validation
+### D5: Skills never bypass CLI validation where a command exists
 
-An AI agent does not write files directly. It reads the skill to understand what to do, then invokes the CLI command. The CLI enforces:
+An AI agent does not bypass the CLI for operations that already have an Inquiry command. The CLI enforces:
 
 - YAML frontmatter validation
 - Filename conventions
 - Index.md updates
 - Directory structure rules
 
-This means **skills are pure documentation** and commands are the enforcement layer.
+This means **skills are pure documentation** and commands are the enforcement layer. Where the command surface is still planned rather than implemented, the documentation should say so explicitly instead of pretending the command already exists.
 
-### D6: Humans can use ape.exe without AI
+### D6: Humans can use Inquiry without AI
 
-A developer without any AI tool can run `ape memory write`, `ape status`, `ape signal` and get the same results. The CLI prints instructions, validates input, and manages state. The AI is an accelerator, not a requirement.
+A developer without any AI tool can still use the implemented Inquiry CLI directly. Today that includes commands such as `iq init`, `iq doctor`, `iq target get`, `iq version`, and `iq state transition --event <e>`. The AI is an accelerator, not a requirement.
 
 This is critical for trust: the human understands exactly what the tool does because they can use it themselves.
 
@@ -46,47 +46,47 @@ APE follows existing standards:
 - **Plans**: Markdown with checklists
 - **Code docs**: Standard language conventions
 
-The `ape memory write` command enforces these standards but does not invent new ones. The agent simply automates compliance with established practices.
+The future `iq memory write` command should enforce these standards without inventing new ones. The agent simply automates compliance with established practices.
 
 ## Current State
 
-The [ape-cli-spec](../../references/ape-cli-spec.md) §1 already states: "Skills do not write files directly — they execute ape memory create, ape task create, ape git commit. The CLI enforces validation."
-
-The current implementation does not reflect this. The `memory-write` skill today is a standalone markdown instruction file with no connection to any CLI command. Closing this gap is part of the work ahead.
+The current Inquiry CLI already enforces the runtime FSM and deployment operations, but the memory-writing command surface remains partly planned rather than fully materialized. The principle is therefore current, while some of the commands that would complete it still belong to future work in [inquiry-cli-spec.md](inquiry-cli-spec.md).
 
 ## Mapping: Skill → Command
 
 | Skill | CLI Command | Writes to | APE State |
 |-------|-------------|-----------|-----------|
-| triage | `gh issue list`, `gh issue create`, `ape issue start` | Issue + branch + folder | IDLE |
-| memory-write | `ape memory write` | `docs/` (persistent) | ANALYZE |
-| memory-read | `ape memory read` | stdout (query) | ANALYZE |
-| planning | (via DESCARTES sub-agent) | `docs/issues/{task}/plan.md` | PLAN |
+| triage | `gh issue list`, `gh issue create`, issue-start protocol | Issue + branch + cleanroom folder | IDLE |
+| memory-write | `iq memory write` (planned) | `docs/` (persistent) | ANALYZE |
+| memory-read | `iq memory read` (planned) | stdout (query) | ANALYZE |
+| planning | (via DESCARTES sub-agent) | `docs/cleanrooms/{task}/plan.md` | PLAN |
 | tdd | (domain skill for BASHŌ) | Source code + tests | EXECUTE |
 | api-design | (domain skill for BASHŌ) | Source code | EXECUTE |
 | db-as-code | (domain skill for BASHŌ) | Migration files | EXECUTE |
 | evolution | `gh issue list`, `gh issue create`, `gh issue comment` | Issues in APE repo | EVOLUTION |
-| (future) signal | `ape signal <event>` | `.inquiry/state.yaml` | Any |
-| (future) status | `ape status` | stdout (derived from docs/) | Any |
+| transition | `iq state transition --event <e>` | `.inquiry/state.yaml` | Any |
+| (future) status | `iq status` | stdout (derived from docs/) | Any |
 
 ## CLI Commands: Existing and Planned
 
-### Existing (v0.0.7)
+### Existing
 
 | Command | Description |
 |---------|-------------|
-| `ape init` | Initialize APE in a repo (docs/issues/, .gitignore, .inquiry/state.yaml) |
-| `ape target get` | Deploy agent + skills to target (Copilot) |
-| `ape target clean` | Remove deployed files |
-| `ape upgrade` | Upgrade CLI binary |
-| `ape version` | Show version |
-| `ape uninstall` | Remove APE completely |
+| `iq init` | Initialize Inquiry in a repo (`.inquiry/` runtime files) |
+| `iq doctor` | Verify prerequisites and environment readiness |
+| `iq target get` | Deploy agent + skills to the active target |
+| `iq target clean` | Remove deployed files |
+| `iq state transition --event <e>` | Execute a declared FSM transition |
+| `iq upgrade` | Upgrade CLI binary |
+| `iq version` | Show version |
+| `iq uninstall` | Remove Inquiry completely |
 
-### Planned (v0.0.8+)
+### Planned
 
 | Command | Description |
 |---------|-------------|
-| `ape issue start <NNN>` | Create branch + checkout + working directory from issue |
-| `ape doctor` | Verify prerequisites: git, gh, gh auth status |
-| `ape config set <key> <value>` | Configure APE settings (.inquiry/config.yaml) |
-| `ape state transition <event>` | Execute state transition with effects (commit, push, etc.) |
+| `iq memory query` | Index-aware lookup over repository memory |
+| `iq memory validate` | Validate memory artifacts and schema expectations |
+| `iq memory write` | Create documentation artifacts with validation |
+| `iq task` | Wrap issue/PR workflow with FSM-aware prechecks |

--- a/docs/spec/cooperative-multitasking-model.md
+++ b/docs/spec/cooperative-multitasking-model.md
@@ -18,7 +18,7 @@ Direct analogy with cooperative multitasking on microcontrollers. The APE cycle 
 ### Level 1: APE Cycle (the scheduler)
 
 ```
-IDLE → ANALYZE → PLAN → EXECUTE → EVOLUTION
+IDLE → ANALYZE → PLAN → EXECUTE → END → EVOLUTION
 ```
 
 The cycle FSM has no intelligence. It tracks which phase is active and dispatches the registered sub-agent for that phase. It does not produce artifacts. APE is the Finite APE Machine — not an ape.
@@ -34,6 +34,7 @@ void ape_tick() {
     case ANALYZE:    socrates_run();       break;  // Sub-agent: SOCRATES
     case PLAN:       descartes_run();      break;  // Sub-agent: DESCARTES
     case EXECUTE:    basho_run();          break;  // Sub-agent: BASHŌ
+    case END:        ape_end();            break;  // APE direct + human gate
     case EVOLUTION:  darwin_run();         break;  // Sub-agent: DARWIN
   }
 }
@@ -41,19 +42,20 @@ void ape_tick() {
 
 ### Key Properties
 
-1. **One primary sub-agent per phase.** IDLE uses APE directly (with a skill). ANALYZE→SOCRATES. PLAN→DESCARTES. EXECUTE→BASHŌ. EVOLUTION→DARWIN.
+1. **One primary operator per phase.** IDLE uses APE directly (with a skill). ANALYZE→SOCRATES. PLAN→DESCARTES. EXECUTE→BASHŌ. END→APE + human gate. EVOLUTION→DARWIN.
 2. **Sub-agents are launched with clean context.** Each invocation receives: the user's input, the relevant artifacts (diagnosis.md, plan.md, etc.), and a phase-specific prompt. The sub-agent does not know about other phases or agents.
 3. **Illusion of continuity.** Sub-agents don't persist between ticks. APE reconstructs context from artifacts (`state.yaml`, `diagnosis.md`, `plan.md`) and passes it to the sub-agent on each invocation. The agent experiences continuity; the scheduler provides it.
 4. **Agents are unaware of each other.** No agent knows what other agents exist. Communication is through artifacts (files) routed by the scheduler (see [signal-based-coordination](signal-based-coordination.md)).
 5. **Event-driven scheduling.** Agents in IDLE or WAITING state are never invoked — only READY agents get CPU time.
 
-## The Four Sub-Agents
+## Current Phase Operators
 
 | Agent | State | Thinking Tool | Key Artifact |
 |-------|-------|---------------|-------------|
 | SOCRATES | ANALYZE | Mayéutica (Socratic method) | `diagnosis.md` — rigorous paper with references |
 | DESCARTES | PLAN | Method (divide, order, verify, enumerate) | `plan.md` — WBS with checkboxes + test pseudocode |
 | BASHŌ | EXECUTE | Techne + 用の美 (functional beauty) | Code + commits per phase |
+| APE + human gate | END | Explicit closure discipline | PR creation and merge gate |
 | DARWIN | EVOLUTION | Natural selection (observe, compare, select) | Issues in APE repo (via `gh`) |
 
 ## APE in IDLE (triage)
@@ -63,13 +65,13 @@ In IDLE, APE operates directly — no sub-agent. It uses the triage skill, which
 Triage determines:
 - Whether the problem merits a formal APE cycle
 - Whether a GitHub issue already exists (via `gh issue list --search`)
-- Infrastructure preparation: `gh issue create` (if needed) → `ape issue start NNN` (branch + checkout + folder)
+- Infrastructure preparation: `gh issue create` (if needed) → issue-start protocol (branch + checkout + cleanroom folder)
 
 The gate to exit IDLE: issue exists + branch created + working directory ready.
 
 ## Relationship to Existing Specs
 
-The [orchestrator-spec](../../references/orchestrator-spec.md) §1.2 describes this model with the microcontroller analogy table. This document **updates** that model:
+The [orchestrator-spec](orchestrator-spec.md) describes an earlier expanded model with the microcontroller analogy table. This document **updates** that model:
 
 - **EVOLUTION replaces RETROSPECTIVE/REVIEW/DARWIN** as a single state. Product retrospective lives inside EXECUTE's final phase; process introspection is EVOLUTION.
 - **Sub-agents replace the multi-agent-per-phase model.** The original vision had multiple agents per phase (e.g., ADA + DIJKSTRA in EXECUTE). The current model simplifies to one sub-agent per phase, with domain skills providing specialized knowledge.
@@ -77,10 +79,10 @@ The [orchestrator-spec](../../references/orchestrator-spec.md) §1.2 describes t
 
 ## Alignment Notes
 
-The [finite-ape-machine spec](../../references/finite-ape-machine.md) §2.1 describes three loops (inner/middle/outer). The outer loop now aligns:
+The [finite-ape-machine spec](finite-ape-machine.md) describes the current three-loop framing (inner, middle, outer). The outer loop now aligns:
 
 ```
-IDLE → ANALYZE → PLAN → EXECUTE → EVOLUTION → IDLE
+IDLE → ANALYZE → PLAN → EXECUTE → END → EVOLUTION → IDLE
 ```
 
-The [lore](../lore.md) describes 10 agents from the original vision. Four are now active (SOCRATES, DESCARTES, BASHŌ, DARWIN). The rest remain as lore/future reference.
+The [lore](../lore.md) describes the broader original roster. The current operational model uses SOCRATES, DESCARTES, BASHŌ, DARWIN, and an explicit END gate governed by APE plus the human.

--- a/docs/spec/finite-ape-machine.md
+++ b/docs/spec/finite-ape-machine.md
@@ -1,621 +1,114 @@
+---
+id: finite-ape-machine
+title: "Finite APE Machine — current technical overview"
+date: 2026-04-22
+status: active
+tags: [architecture, fsm, scheduler, inquiry, rtos]
+author: descartes
+---
+
 # Finite APE Machine
 
-**AI-Aided Development Framework**
-*"Infinite monkeys produce noise. Finite APEs produce software."*
+## Overview
 
-Version: 1.0-draft
-Date: March 28, 2026
-Author: Dev (ccisnedev@gmail.com)
+Finite APE Machine is the engineered realization of the Inquiry methodology as a finite-state, signal-aware control system for software work. Inquiry names the cycle-level process. APE names the orchestrating methodology and scheduler. Finite APE Machine names the technical system that operationalizes that methodology through explicit states, governed transitions, artifacts, and phase-specific agent behavior. [1][2][3]
 
----
+The point of the system is not to multiply agents indefinitely. It is to make responsibility, transition conditions, and outputs explicit enough that AI-assisted work becomes inspectable and reproducible instead of improvisational. [1][4]
 
-## 1. Manifesto
+## Current Cycle Model
 
-### 1.1 What is Finite APE Machine?
-
-Finite APE Machine (APE) is a methodology and agent architecture for AI-Aided Development. It brings the principles of CAD/CAE/CAM to software engineering by structuring the collaboration between a human and AI agents into a disciplined, iterative control loop.
-
-Each AI agent in the system — called an **ape** — is modeled as a **Finite State Machine (FSM)** where the prompt defines the transition function. Given a current state and an input (context, task, human gate), each ape produces a deterministic transition to a new state with a defined output. There is no ambiguity about what an ape is doing, when it has finished, or when it is blocked.
-
-The name is a deliberate counterpoint to the Infinite Monkey Theorem: infinite monkeys typing at random eventually produce Shakespeare. Finite APE Machine inverts this premise — a finite number of specialized agents with defined states and controlled transitions produce quality software not by chance, but by design.
-
-### 1.2 Why APE Exists
-
-The AI-assisted development landscape in 2026 has split into two poles:
-
-- **Vibe coding**: fast, unstructured, suitable for prototypes and throwaway projects. The human prompts, the AI generates, nobody verifies systematically.
-- **Spec-Driven Development (SDD)**: structured, formal, suitable for production systems. Specifications are the source of truth from which code, tests, and documentation are derived.
-
-APE occupies a specific position: it adopts SDD principles but operationalizes them through a control-loop architecture where the human retains cognitive sovereignty and the AI assumes operational load. It is neither the chaos of vibe coding nor the rigidity of waterfall. It is engineering.
-
-### 1.3 Core Principle: APE BUILD APE
-
-The system is self-improving. Each completed cycle feeds the evolutionary agent (DARWIN) with lessons learned, which proposes mutations to the system itself. APE builds APE. The methodology evolves through its own application.
-
----
-
-## 2. Theoretical Model
-
-### 2.1 The Control Loop
-
-APE is modeled as a feedback control loop with nested inner loops, analogous to cascade control in control theory:
+The current operational model is a six-state cycle with an optional evolutionary pass:
 
 ```
-Reference (Spec/Objective)
-    │
-    ▼
-┌─────────────────────────────────────────────────┐
-│  CONTROLLER (Orchestrator + Human Gates)        │
-│                                                 │
-│   ┌─────────┐   ┌──────┐   ┌─────────┐        │
-│   │ ANALYZE │──▶│ PLAN │──▶│ EXECUTE │        │
-│   └────┬────┘   └──┬───┘   └────┬────┘        │
-│        │           │            │               │
-│        ▼           ▼            ▼               │
-│   Human Gate  Human Gate   Human Gate           │
-│                                                 │
-└───────────────────────┬─────────────────────────┘
-                        │
-                        ▼
-                   ┌─────────┐
-                   │ SENSOR  │ (Tests + Verification)
-                   └────┬────┘
-                        │
-                        ▼
-                   Error Signal (Expected vs. Obtained)
-                        │
-                        ▼
-                   ┌─────────┐
-                   │ DARWIN  │ (Adaptive Controller)
-                   └─────────┘
+IDLE → ANALYZE → PLAN → EXECUTE → END → EVOLUTION → IDLE
 ```
 
-**Inner loop (fast):** Execute: test-red → implement → test-green. This is the TDD micro-cycle.
+If evolution is disabled in `.inquiry/config.yaml`, the cycle returns directly from END to IDLE after PR creation and merge preparation. [2][5]
 
-**Middle loop (medium):** Plan → Execute → Verify for each task. This is the runbook cycle.
+| State | Operator | Purpose | Primary artifact |
+|---|---|---|---|
+| IDLE | APE | Triage, readiness, and infrastructure preparation | `.inquiry/state.yaml` |
+| ANALYZE | SOCRATES | Clarify the problem and produce a rigorous diagnosis | `docs/cleanrooms/<issue>/analyze/diagnosis.md` |
+| PLAN | DESCARTES | Design the execution sequence and verification strategy | `docs/cleanrooms/<issue>/plan.md` |
+| EXECUTE | BASHO | Implement phase by phase under the plan's constraints | code + commits |
+| END | APE + human gate | Create and merge the PR through an explicit closure gate | PR |
+| EVOLUTION | DARWIN | Propose improvements to the framework itself | issues/comments in the Inquiry repository |
 
-**Outer loop (slow):** Analyze → Plan → Execute → Learn across tasks and projects. This is the methodology evolution cycle.
+## Architectural Principles
 
-Each loop has its own time constant and its own sensor. If the inner loop is unstable (bad tests), the outer loop cannot compensate. Tests as well-defined contracts are literally the stability of the system.
+### APE is the scheduler, not one ape among others
 
-### 2.2 AAD → AAE → AAM: The Collaboration Model
+APE is not a peer agent in the roster. It is the orchestrating methodology and dispatch layer that reads state, checks transition conditions, and invokes the appropriate phase behavior. In current repository vocabulary, this is the scheduler/event-loop role. [2][4][5]
 
-Inspired by CAD/CAE/CAM in manufacturing, APE defines three perspectives of the same process:
+### One primary sub-agent per active phase
 
-| Perspective | Acronym | APE Stages | Sovereignty |
-|-------------|---------|------------|-------------|
-| Agent-Aided Design | AAD | Analyze | Human dominates, AI assists |
-| Agent-Aided Engineering | AAE | Plan + Test Definition | Deep human-AI collaboration |
-| Agent-Aided Manufacturing | AAM | Execute + Delivery | AI dominates, human supervises |
+The current system uses one primary sub-agent per active work phase:
 
-**AAD** = Define the problem, scope, constraints. The human's domain expertise is irreplaceable.
+- SOCRATES in ANALYZE
+- DESCARTES in PLAN
+- BASHO in EXECUTE
+- DARWIN in EVOLUTION
 
-**AAE** = Architecture, task planning, simulation via tests. Tests are simulations — they verify system behavior before it exists, exactly as a finite element analysis validates a part "../../doc/references"before manufacturing.
+IDLE and END are orchestration-heavy states governed directly by APE plus explicit human authorization. Earlier multi-agent rosters remain historically relevant, but they are not the active architectural model. Their documentary home is [../lore.md](../lore.md), not this specification. [4][6]
 
-**AAM** = Implement, integrate, verify mechanically, deliver. The AI operates the TDD loop; the human reviews the PR and decides on merge.
+### Transitions are explicit and CLI-governed
 
-**DARWIN** operates *between* AAD→AAE→AAM cycles. It is the evolutionary process that improves the machinery itself.
+The machine does not rely on implicit conversational drift to change phases. Transitions are checked against a declared contract and executed through the CLI, which is responsible for validating preconditions, applying effects, and updating persisted state. This makes the finite-state structure operational rather than metaphorical. [2][5]
 
-### 2.3 The Human's Non-Delegable Functions
+### Artifacts are the coordination surface
 
-The human retains four functions that cannot be transferred to the AI:
+The system coordinates through persisted artifacts rather than agent-to-agent hidden memory. At minimum, the cycle relies on:
 
-**1. Intention**
+- `.inquiry/state.yaml` for current phase and task identity
+- `.inquiry/config.yaml` for cycle options such as evolution enablement
+- `.inquiry/mutations.md` for human observations relevant to DARWIN
+- `docs/cleanrooms/<issue>/analyze/diagnosis.md` as the contract between ANALYZE and PLAN
+- `docs/cleanrooms/<issue>/plan.md` as the contract between PLAN and EXECUTE
 
-- What problem is actually being solved.
-- What must not be touched.
-- What trade-offs are acceptable.
+This keeps the orchestration inspectable from the repository itself. [2][5][7]
 
-**2. Criteria**
+### RTOS analogy: signal-aware coordination, not literal operating-system identity
 
-- What counts as a correct solution.
-- What tests validate the change.
-- What non-functional constraints apply.
+Finite APE Machine borrows the RTOS analogy to explain scheduling, waiting, event signaling, and task dispatch. The analogy is architectural, not literal: the system behaves like a scheduler with event-driven coordination, but it is not an operating-system kernel. [3][5]
 
-**3. Orchestration**
+## Collaboration Model
 
-- Which agent to use.
-- In what mode to run it.
-- When to transition from analysis to implementation.
-- When to open parallel work.
+Finite APE Machine structures collaboration across three recurring perspectives:
 
-**4. Closure**
+| Perspective | Acronym | Dominant states | Practical meaning |
+|---|---|---|---|
+| Agent-Aided Design | AAD | ANALYZE | Human intention is clarified with AI assistance |
+| Agent-Aided Engineering | AAE | PLAN | The work is decomposed, verified, and ordered |
+| Agent-Aided Manufacturing | AAM | EXECUTE + END | The approved plan is carried into implementation and delivery |
 
-- Accept or reject the change.
-- Merge, release, rollback.
-- Assume accountability.
+DARWIN operates after delivery as the meta-learning layer that evaluates the cycle itself instead of the product alone. [1][2]
 
-### 2.4 The AI's Operational Functions
+## Relationship to Supporting Specifications
 
-The AI assumes four operational functions:
+This document is the primary technical overview of the current finite-state system. Supporting documents elaborate particular aspects of that overview:
 
-**1. Explore**
+- [agent-lifecycle.md](agent-lifecycle.md) defines the current agent registry and state responsibilities.
+- [cooperative-multitasking-model.md](cooperative-multitasking-model.md) explains the scheduler/task analogy and two-level FSM model.
+- [signal-based-coordination.md](signal-based-coordination.md) explains event and signal routing.
+- [../architecture.md](../architecture.md) explains the end-to-end system at repository scale.
+- [../research/inquiry/index.md](../research/inquiry/index.md) provides the philosophical home of Inquiry, which this machine operationalizes.
 
-- Read codebase.
-- Map impact.
-- Locate dependencies.
-- Generate hypotheses.
+## Historical Boundary
 
-**2. Structure**
+Earlier repository documents described a larger and more granular roster including MARCOPOLO, VITRUVIUS, SUNZI, GATSBY, ADA, DIJKSTRA, BORGES, and HERMES as active architectural roles. That material remains valuable as historical or referential context, but it should not be read as the current active model of the Finite APE Machine. The current model is the sharper scheduler-plus-phase-agent structure described above. [4][6]
 
-- Convert objective into plan.
-- Propose sequence.
-- Build checklists and verification.
+## References
 
-**3. Execute**
+[1] Finite APE Machine repository. "Inquiry as Epistemic Foundation of APE." `docs/research/inquiry/index.md`.
 
-- Edit files.
-- Run commands.
-- Iterate on errors.
-- Fix tests.
-- Produce diffs or PRs.
+[2] Finite APE Machine repository. "Architecture." `docs/architecture.md`.
 
-**4. Verify Mechanically**
+[3] Finite APE Machine repository. "Signal-based coordination — RTOS event model for agent communication." `docs/spec/signal-based-coordination.md`.
 
-- Build.
-- Lint.
-- Test.
-- Static analysis.
-- Automated initial review.
+[4] Finite APE Machine repository. "Agent lifecycle — six-state model and confirmed agent registry." `docs/spec/agent-lifecycle.md`.
 
----
+[5] Finite APE Machine repository. "Cooperative multitasking model — two-level FSM architecture." `docs/spec/cooperative-multitasking-model.md`.
 
-## 3. Agent Architecture
+[6] Finite APE Machine repository. "The Apes — Lore." `docs/lore.md`.
 
-### 3.1 What is an Ape?
-
-An **ape** is a specialized AI sub-agent dispatched by the APE scheduler. Each ape has:
-
-- **A prompt** that defines its behavior: given context and a task, produce structured output.
-- **A set of skills** (tools it can invoke: memory, file operations, terminal, search, etc.).
-- **A defined role** with explicit boundaries and termination conditions.
-- **Clean context** on each instantiation — apes are reutilizable but stateless between invocations. They receive their task and the context they need.
-
-Apes are invoked via `runSubagent`. The scheduler (APE) never performs analysis, planning, or implementation — sub-agents do.
-
-### 3.2 The Apes of Finite APE Machine
-
-#### ANALYZE Stage
-
-##### MARCOPOLO — Document Ingestion and Normalization
-
-**Role:** MARCOPOLO (document ingestion and normalization) receives heterogeneous documents (PDF, Word, Excel, PowerPoint, emails, images, repos) and produces structured markdown. Does not make decisions — makes the illegible legible.
-
-**Skills:** markitdown (microsoft/markitdown), codebase reading, DB schema extraction, email parsing, image OCR.
-
-**FSM:**
-```
-idle → ingesting → normalizing → delivering → idle
-```
-
-**Input:** Raw documents, files, URLs, repository references.
-**Output:** Structured .md files ready for SOCRATES consumption.
-
-##### SOCRATES — Conversational Requirements Understanding
-
-**Role:** SOCRATES (conversational requirements understanding) is the primary conversational ape of Analyze. Takes MARCOPOLO's output and processes it: asks questions, identifies ambiguities, maps the domain, challenges assumptions. Produces the scope document and constraints. Conducts the Socratic conversation with the human to refine intention.
-
-**Skills:** Memory consultation (project + framework), mermaid generation (domain diagrams, context diagrams), spec writing.
-
-**FSM:**
-```
-idle → understanding → questioning → clarifying → documenting → idle
-```
-
-**Input:** Normalized .md documents from MARCOPOLO, human conversation.
-**Output:** Scope document, constraints, domain model, risk assessment.
-
-**Human Gate:** Approves the analysis before proceeding to VITRUVIUS.
-
-##### VITRUVIUS — Decomposition and Structuring
-
-**Role:** VITRUVIUS (decomposition and structuring) takes the scope defined by SOCRATES and decomposes it into a Work Breakdown Structure (WBS) with tasks. Evaluates complexity, identifies dependencies, proposes execution order, generates Gantt chart. Decides when a task is "small enough" to pass to Plan. If a task is too large, subdivides it. If it detects technical risk, flags it.
-
-**Skills:** Mermaid generation (Gantt, WBS), estimation, dependency analysis, framework memory consultation (to estimate better based on past projects).
-
-**FSM:**
-```
-idle → decomposing → sizing → sequencing → risk_assessing → delivering → idle
-```
-
-**Input:** Scope document, constraints, domain model from SOCRATES.
-**Output:** WBS, Gantt, task list with sizing and dependencies, risk register.
-
-**Human Gate:** Approves the WBS and task decomposition. Each task that passes to Plan must be a vertical slice (db-api-ui at most one flow).
-
-#### PLAN Stage
-
-##### SUNZI — Technical Design and Runbook Generation
-
-**Role:** SUNZI (technical design and runbook generation) takes a single task from the WBS and generates a phased runbook. Defines the technical strategy: which patterns to use, which components to touch (db/api/ui), implementation order. Verifies that Analyze documentation exists and is sufficient — if not, alerts to return to Analyze.
-
-**Skills:** @contract reading (existing contracts), project memory consultation, codebase analysis.
-
-**FSM:**
-```
-idle → reading_context → designing → staging → delivering → idle
-
-Exception: reading_context → context_insufficient → escalate_to_analyze
-```
-
-**Input:** Single task from WBS, Analyze documentation.
-**Output:** runbook.md with phased implementation stages.
-
-**Alert Condition:** If documentation is insufficient, transitions to `escalate_to_analyze` and blocks.
-
-##### GATSBY — Contract Definition and Red Tests
-
-**Role:** GATSBY (contract definition and RED tests) takes each runbook stage and defines concrete tests. Writes @contract blocks. Produces executable tests in RED state. Converts intention into a verifiable contract. Does not implement — only specifies what must be true.
-
-**Skills:** Test writing (dart/ts/python depending on stack), @contract generation, memory consultation for test pattern reuse.
-
-**FSM:**
-```
-idle → reading_stage → designing_contracts → writing_tests → validating_red → delivering → idle
-```
-
-**Input:** Runbook stage from SUNZI.
-**Output:** Test files with @contract metadata, all in RED state (failing).
-
-**Human Gate:** Confirms or modifies tests before Execute proceeds.
-
-#### EXECUTE Stage
-
-##### ADA — TDD Implementation
-
-**Role:** ADA (TDD implementation) is the pure TDD implementer. Takes tests in red and turns them green. Follows the runbook stage by stage. If it encounters a tactical deviation, resolves and documents it. If it encounters a strategic deviation, escalates. Does not question the tests — fulfills them.
-
-**Skills:** Stack implementation (dart/ts/python), command execution, lint, types, @contract reading.
-
-**FSM:**
-```
-idle → reading_tests → implementing → running_tests →
-    ├── green → documenting → delivering → idle
-    ├── red → fixing → running_tests (loop)
-    └── blocked → escalating → idle
-```
-
-**Input:** Test files in RED, runbook stage.
-**Output:** Implementation code, all tests GREEN, deviation log.
-
-**Deviation Handling:**
-
-- *Tactical deviation* (change library, adjust data structure, use different pattern): Resolve and document. These are alternative means to the same end.
-- *Strategic deviation* (objective unachievable as defined, spec contradiction, architectural change needed): Escalate to human. These change the contract with the human.
-
-##### DIJKSTRA — Quality Gate Pre-PR
-
-**Role:** DIJKSTRA (quality gate pre-PR) reviews code produced by ADA before the PR. Verifies coherence between @contracts, tests, and implementation. Checks code smells, validates that documented tactical deviations are reasonable, runs static analysis. Configurable intensity: lightweight for low-risk tasks, exhaustive for high-risk.
-
-**Skills:** Static analysis, @contract reading, security scanning, project memory consultation.
-
-**FSM:**
-```
-idle → reading_changes → checking_contracts → checking_quality →
-    checking_security →
-    ├── approved → delivering → idle
-    └── issues → reporting → idle
-```
-
-**Input:** Code changes, test files, @contracts, deviation log.
-**Output:** Review report, approval or issues list.
-
-**Human Gate:** Reviews the PR with DIJKSTRA's report, decides on merge.
-
-#### META Process
-
-##### DARWIN — Evolutionary Agent
-
-**Role:** Operates after each completed APE cycle. Compares plan vs. actual execution, catalogs deviations, extracts patterns, generates issues to the Finite APE Machine repository with improvement proposals. Does not produce code — produces evolution.
-
-**Skills:** Comparative analysis, issue writing, access to all three memory layers (working, project, framework), statistical pattern analysis.
-
-**FSM:**
-```
-idle → collecting_cycle_data → comparing_plan_vs_actual →
-    identifying_patterns → generating_lessons → creating_issues → idle
-```
-
-**Input:** Complete cycle data: runbook, deviation logs, test results, timing data.
-**Output:** Lessons learned document, issues on the APE framework repository.
-
-**Invocation:** Automatically after cycle closure, or manually by the human.
-
-#### Cross-Cutting Mechanism
-
-##### HERMES — Automatic State Update Hook
-
-**Role:** HERMES (automatic state update hook) is not an ape — it is a lightweight hook that executes automatically each time an ape completes a state transition. Updates a project state file (status.md) with: current task, runbook stage progress, completed apes, pending work. The orchestrator and any ape can read this file.
-
-**Mechanism:** Hook (automatic, does not consume an agent session).
-
-**Output:** Updated status.md file.
-
-### 3.3 Agent Summary
-
-| Stage | Ape | Role | Thinking Mode |
-|-------|-----|------|---------------|
-| Analyze | MARCOPOLO | Ingest and normalize documents | Mechanical-selective |
-| Analyze | SOCRATES | Conversation, scope, constraints | Socratic-exploratory |
-| Analyze | VITRUVIUS | WBS, Gantt, sizing, dependencies | Structural-analytical |
-| Plan | SUNZI | Phased runbook, technical design | Tactical-sequential |
-| Plan | GATSBY | @contract tests in red | Contractual-verifiable |
-| Execute | ADA | TDD implementation | Operative-iterative |
-| Execute | DIJKSTRA | Quality gate pre-PR, contract verification | Critical-evaluative |
-| Meta | DARWIN | Lessons learned, system evolution | Evolutionary-comparative |
-| Cross | HERMES | Automatic state update | Automatic (not an ape) |
-
-**Total: 7 apes + 1 hook + DARWIN = 8 specialized agents + 1 automatic mechanism.**
-
----
-
-## 4. Infrastructure
-
-### 4.1 Memory Architecture
-
-Three-level hierarchical memory, inspired by human cognition and implemented as a cache hierarchy:
-
-#### Working Memory (Session)
-
-The context of the current task. Discarded on completion. Equivalent to RAM.
-
-- Scope: single ape invocation.
-- Contains: task definition, relevant @contracts, runbook stage, immediate context.
-- Lifecycle: created at ape instantiation, destroyed at completion.
-
-#### Project Memory (Repository)
-
-ADRs, project-specific lessons learned, @contract blocks, deviation history. Persistent in the repository as files. Equivalent to project hard drive.
-
-- Scope: single repository/project.
-- Contains: ADRs, @contracts, deviation logs, runbook history, status.md.
-- Lifecycle: lives with the project.
-- Access: any ape can read; ADA, DIJKSTRA, and DARWIN can write.
-
-#### Framework Memory (APE)
-
-Patterns extracted from multiple projects. The issues generated by DARWIN. Equivalent to accumulated professional experience.
-
-- Scope: across all projects using APE.
-- Contains: cross-project patterns, common failure modes, estimation baselines, methodology improvements.
-- Lifecycle: permanent, grows with each DARWIN cycle.
-- Access: any ape can read (via context provider); DARWIN writes.
-
-#### Context Provider
-
-When a sub-agent needs more context than its working memory provides:
-
-1. First consults **project memory** (cheap, local — .md files in the repo).
-2. If insufficient, consults **framework memory** (issues and PRs in the APE repo).
-3. The context provider serves relevant information without the ape needing to know where it came from.
-
-Implementation: **Memory as Code** — structured .md files treated analogously to a relational database. Issues and PRs serve as the canonical record of what has been built and why. Reading a PR tells the agent what was actually constructed; reading an issue tells it what was intended.
-
-### 4.2 @contract Blocks — Semantic Test Metadata
-
-Every test carries structured metadata that connects specifications with verification, navigable by agents, language-agnostic:
-
-```
-/// @contract
-/// spec: SPEC-042 - Cancel order within 24h window
-/// risk: financial | severity: high
-/// touches: orders.service, payments.refund
-/// rationale: Ensures refund policy compliance
-```
-
-This format works identically in Dart (`///`), Python (`"""`), and TypeScript (`/** */`). It does not depend on any language's type system or decorator support. Agents read it as structured natural language — exactly where LLMs are strongest.
-
-**Purpose:**
-
-- Each test is a self-descriptive node in the dependency graph.
-- The agent does not need an external graph — the test itself carries its relationships.
-- Enables impact analysis: when code changes, the agent can identify which @contracts are affected.
-- DIJKSTRA uses @contracts to verify semantic coherence between spec, test, and implementation.
-- DARWIN uses @contracts to trace failure patterns back to specifications.
-
-### 4.3 Risk Matrix
-
-Evolution of the binary `skipReview` flag into a calibrated risk assessment:
-
-**Assessment:** The orchestrator (or the agent in Analyze) evaluates the change scope and proposes a risk level.
-
-**Confirmation:** The human confirms or adjusts the proposed level.
-
-**Gate calibration:** Risk level determines which gates are active and how intensely each ape operates.
-
-| Risk Level | Active Gates | DIJKSTRA Intensity | Example |
-|------------|-------------|-------------------|---------|
-| Low | Tests + PR | Lightweight (contracts only) | UI label change |
-| Medium | All 4 standard gates | Standard | New API endpoint |
-| High | All gates + extended DIJKSTRA | Exhaustive (security, performance) | Payment flow change |
-| Critical | All gates + mandatory human review at each ape transition | Full audit | Auth system modification |
-
-Dimensions for risk assessment: financial impact, attack surface, technical complexity, reversibility, blast radius (how many components affected).
-
-### 4.4 Deviation Handling
-
-#### Tactical Deviations
-
-- **Definition:** Alternative means to the same end (change library, adjust data structure, use different pattern).
-- **Handling:** The ape resolves and documents in the deviation log.
-- **Requirement:** The objective must be clear — if it is not, the agent cannot evaluate whether its action contradicts the plan.
-
-#### Strategic Deviations
-
-- **Definition:** Changes that affect the contract with the human (objective unachievable, spec contradiction, architectural change needed).
-- **Handling:** The ape escalates to the human gate. A new plan is generated.
-- **Principle:** The original plan is preserved as historical record (for DARWIN). A revised version reflects reality. The diff between original and executed plan is the raw material for Learn.
-
----
-
-## 5. The Learn Mechanism (DARWIN)
-
-### 5.1 Three Levels of Learning
-
-**Level 1 — Project (Immediate):** Library X doesn't support Y → fix now, document in ADR, update code. This is operational and handled within the APE cycle.
-
-**Level 2 — Methodology (The Loop):** Why didn't we detect library X's limitation in Analyze? → Improve specs to include dependency validation, perhaps add tests that verify library capabilities before use. This transcends the current project and improves the APE process itself.
-
-**Level 3 — Framework (Meta):** After N projects, what failure patterns recur? → Third-party libraries are consistently the source of deviations → This becomes a rule in the APE framework: "every external dependency requires a validation spike in Analyze."
-
-### 5.2 DARWIN's Feedback Mechanism
-
-After each completed APE cycle, DARWIN:
-
-1. Collects cycle data: runbook, deviation logs, test results, timing, DIJKSTRA reports.
-2. Compares plan vs. actual execution.
-3. Identifies patterns (Level 2 and Level 3).
-4. Generates a lessons-learned document for the project (Level 1 and 2).
-5. Creates an issue on the Finite APE Machine repository with complete context, proposed improvements, and classification (Level 3).
-
-This creates a **distributed continuous improvement mechanism**. Every project using APE contributes (opt-in) to the framework's evolution. The repository receives issues like:
-
-*"In 47 projects using library X with pattern Y, 68% had tactical deviations in Execute. Proposal: add X+Y compatibility validation in Analyze phase."*
-
-### 5.3 The Evolutionary Principle
-
-DARWIN is the only agent whose output modifies the transition functions of other apes. It does not change states — it changes the *rules*. In control theory terms, it is the adaptive controller. In evolutionary biology terms, it is natural selection. In APE's narrative: it is evolution itself.
-
----
-
-## 6. Workflow
-
-### 6.1 Complete Flow for a Feature
-
-```
-1. SDD Spec: Define objective and scope
-2. ANALYZE
-   ├── MARCOPOLO: Ingest and normalize all relevant documents
-   ├── SOCRATES: Understand domain, ask questions, produce scope document
-   │   └── [Human Gate: approve analysis]
-   └── VITRUVIUS: Decompose into WBS, Gantt, sized tasks
-       └── [Human Gate: approve WBS and task decomposition]
-
-3. For each task in WBS:
-   ├── PLAN
-   │   ├── SUNZI: Generate phased runbook for this task
-   │   └── GATSBY: Define @contract tests in RED for each phase
-   │       └── [Human Gate: confirm or modify tests]
-   │
-   ├── EXECUTE
-   │   ├── ADA: Implement TDD, phase by phase
-   │   │   ├── Tactical deviations: resolve + document
-   │   │   └── Strategic deviations: escalate → new plan
-   │   └── DIJKSTRA: Quality gate, contract verification
-   │       └── [Human Gate: review PR + merge decision]
-   │
-   └── HERMES: Updates status automatically at each transition
-
-4. DARWIN: Analyze cycle, extract lessons, generate issues
-5. Delivery + Monitoring + Feedback to specs/tests
-```
-
-### 6.2 Gate Calibration with Risk Matrix
-
-Before entering the cycle, the orchestrator proposes a risk level based on the task scope. The human confirms or adjusts. Gates activate accordingly:
-
-- **skipReview = true** (Low risk): Gates collapse. SOCRATES produces minimal scope, GATSBY writes focused tests, ADA proceeds without intermediate approvals.
-- **Standard** (Medium risk): All 4 human gates active. Standard ape intensity.
-- **Full audit** (High/Critical risk): All gates active + DIJKSTRA in exhaustive mode + mandatory human verification at each ape transition.
-
-### 6.3 Parallel Execution Model
-
-A single orchestrator manages one feature/project. Nothing prevents the human from launching N independent orchestrators on N different repositories. They never communicate with each other.
-
-Within a single orchestrator, apes within the same stage can work in parallel when tasks are independent (e.g., ADA working on two independent vertical slices simultaneously).
-
----
-
-## 7. Technical Environment
-
-### 7.1 Supported Environments
-
-APE is designed to work in two primary environments:
-
-- **IDE (VS Code + GitHub Copilot):** Plan mode maps to Analyze+Plan. Agent mode maps to Execute. Custom agents (Runbook) bridge the gap.
-- **Terminal (Claude Code):** Plan mode, subagents, and agent teams provide the orchestration primitives. Swarm mode enables parallel execution.
-
-VS Code as multi-agent hub (since January 2026) allows running Claude, Codex, and Copilot in parallel within the same editor, each in its own session.
-
-### 7.2 Native Mode Mapping
-
-| APE Stage | VS Code / Copilot | Claude Code |
-|-----------|-------------------|-------------|
-| Analyze | Custom agent (conversational) | Interactive session with plan mode |
-| Plan | Plan mode (enhanced) | Plan mode with subagent delegation |
-| Execute | Agent mode (Runbook) | Execution with agent teams |
-| DARWIN | Custom agent (post-cycle) | Dedicated session post-cycle |
-
-### 7.3 Technology Stack
-
-APE is stack-agnostic but has been designed and tested with:
-
-- **Languages:** Dart, TypeScript, Python.
-- **Framework:** Modular API (implementations in all three languages).
-- **Document processing:** Microsoft MarkItDown (PDF, Word, Excel, PowerPoint → Markdown).
-- **Memory:** Engram or equivalent (SQLite + FTS5, MCP server).
-- **Diagrams:** Mermaid (Gantt, WBS, architecture, sequence diagrams).
-- **CI/CD:** Standard pipelines with security, lint, types, test runners.
-
----
-
-## 8. Glossary
-
-| Term | Definition |
-|------|-----------|
-| **APE** | Analyze, Plan, Execute — the core operational cycle |
-| **Ape** | A specialized AI sub-agent modeled as a Finite State Machine |
-| **Finite APE Machine** | The complete framework: methodology + agent architecture + evolutionary mechanism |
-| **DARWIN** | The evolutionary agent that operates on the meta-level, improving the system itself |
-| **HERMES** | Cross-cutting hook that automatically updates project state |
-| **@contract** | Semantic metadata block in tests connecting specs with verification |
-| **AAD** | Agent-Aided Design (Analyze phase) |
-| **AAE** | Agent-Aided Engineering (Plan + Test Definition phases) |
-| **AAM** | Agent-Aided Manufacturing (Execute + Delivery phases) |
-| **FSM** | Finite State Machine — the model for each ape's behavior |
-| **Tactical deviation** | Alternative means to the same end; resolved by the ape |
-| **Strategic deviation** | Change to the contract with the human; requires escalation |
-| **Working memory** | Session-scoped context, discarded after task completion |
-| **Project memory** | Repository-scoped persistent knowledge (ADRs, @contracts, deviations) |
-| **Framework memory** | Cross-project accumulated patterns and lessons |
-| **Risk matrix** | Calibrated assessment that determines gate activation and ape intensity |
-| **WBS** | Work Breakdown Structure — decomposition of scope into tasks |
-| **APE BUILD APE** | The self-improvement principle: the system evolves through its own application |
-
----
-
-## 9. References and State of the Art
-
-### Spec-Driven Development
-
-- [Spec-Driven Development Is Eating Software Engineering (30+ frameworks)](https://medium.com/@visrow/spec-driven-development-is-eating-software-engineering-a-map-of-30-agentic-coding-frameworks-6ac0b5e2b484)
-- [GitHub Spec Kit](https://github.blog/ai-and-ml/generative-ai/spec-driven-development-with-ai-get-started-with-a-new-open-source-toolkit/)
-- [Thoughtworks — Spec-Driven Development Unpacking](https://www.thoughtworks.com/en-us/insights/blog/agile-engineering-practices/spec-driven-development-unpacking-2025-new-engineering-practices)
-
-### Test-Driven Development with AI
-
-- [TDAD: Test-Driven Agentic Development (arXiv)](https://arxiv.org/abs/2603.17973)
-- [Why TDD Works So Well In AI-Assisted Programming](https://codemanship.wordpress.com/2026/01/09/why-does-test-driven-development-work-so-well-in-ai-assisted-programming/)
-- [AI Agents, meet TDD (Latent Space)](https://www.latent.space/p/anita-tdd)
-
-### Multi-Agent Orchestration
-
-- [The Code Agent Orchestra — Addy Osmani](https://addyosmani.com/blog/code-agent-orchestra/)
-- [Claude Code Agent Teams](https://code.claude.com/docs/en/agent-teams)
-- [VS Code Multi-Agent Development Hub](https://code.visualstudio.com/blogs/2026/02/05/multi-agent-development)
-
-### Human-AI Collaboration
-
-- [Addy Osmani — My LLM Coding Workflow 2026](https://addyo.substack.com/p/my-llm-coding-workflow-going-into)
-- [Martin Fowler — Humans and Agents in Software Engineering Loops](https://martinfowler.com/articles/exploring-gen-ai/humans-and-agents.html)
-- [The Uncomfortable Truth About Vibe Coding (Red Hat)](https://developers.redhat.com/articles/2026/02/17/uncomfortable-truth-about-vibe-coding)
-
-### Related Frameworks
-
-- [Gentleman-Programming/gentle-ai](https://github.com/Gentleman-Programming/gentle-ai)
-- [Gentleman-Programming/engram](https://github.com/Gentleman-Programming/engram)
-- [Gentleman-Programming/agent-teams-lite](https://github.com/Gentleman-Programming/agent-teams-lite)
-
----
-
-*Finite APE Machine v1.0-draft — "Infinite monkeys produce noise. Finite APEs produce software."*
+[7] Finite APE Machine repository. "Diagnosis for issue #134: justified documentation status map and canonical-home recommendations." `docs/cleanrooms/134-organize-core-documentation/analyze/diagnosis.md`.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -1,32 +1,36 @@
 # Spec — Finite APE Machine
 
-Technical specifications and architectural references.
+Technical specifications and architectural references for the current Inquiry/APE system.
 
-## Core
+## Canonical Homes
 
-| Document | Description |
-|----------|-------------|
-| [finite-ape-machine.md](finite-ape-machine.md) | Project overview and foundational concepts |
-| [agent-lifecycle.md](agent-lifecycle.md) | Agent lifecycle and states (IDLE → ANALYZE → PLAN → EXECUTE) |
+Start here when you need the first authoritative explanation of a core concept.
 
-## Architecture
+| Concept | Canonical home | Notes |
+|---------|----------------|-------|
+| Inquiry | [../research/inquiry/index.md](../research/inquiry/index.md) | Philosophical and epistemic foundation of the Inquiry cycle |
+| APE | [../architecture.md](../architecture.md) | Current system-level explanation of APE as the orchestrating methodology |
+| Finite APE Machine | [finite-ape-machine.md](finite-ape-machine.md) | Primary technical overview of the engineered finite-state system |
+| Thinking Tools | [../thinking-tools.md](../thinking-tools.md) | Current canonical explainer; [../lore.md](../lore.md) remains the historical and nomenclature companion |
 
-| Document | Description |
-|----------|-------------|
-| [cooperative-multitasking-model.md](cooperative-multitasking-model.md) | Cooperative multitasking model — how agents yield and coordinate |
-| [signal-based-coordination.md](signal-based-coordination.md) | Signal-based coordination between agents |
-| [orchestrator-spec.md](orchestrator-spec.md) | Orchestrator technical specification |
-| [memory-as-code-spec.md](memory-as-code-spec.md) | Memory as code — structured documentation architecture |
+## Current Supporting Specs
 
-## CLI
+These documents support the current model and should be read as technical elaborations rather than co-equal concept homes.
 
 | Document | Description |
 |----------|-------------|
-| [inquiry-cli-spec.md](inquiry-cli-spec.md) | Inquiry CLI/TUI technical specification |
-| [cli-as-api.md](cli-as-api.md) | CLI as API principle — commands as programmatic interface |
+| [agent-lifecycle.md](agent-lifecycle.md) | Agent lifecycle and state responsibilities in the current model |
+| [cooperative-multitasking-model.md](cooperative-multitasking-model.md) | Two-level FSM and scheduler/task coordination model |
+| [signal-based-coordination.md](signal-based-coordination.md) | Signal/event model for coordination and transitions |
+| [cli-as-api.md](cli-as-api.md) | Boundary between skills, agent behavior, and CLI enforcement |
+| [target-specific-agents.md](target-specific-agents.md) | Per-target deployment strategy and current single-target decision |
 
-## Deployment
+## Mixed, Historical, or Planned Specs
 
-| Document | Description |
-|----------|-------------|
-| [target-specific-agents.md](target-specific-agents.md) | Target-specific agent files — per-tool deployment strategy |
+These documents remain relevant, but they should not be treated as the cleanest source of current doctrine without checking their status and scope.
+
+| Document | Status | Description |
+|----------|--------|-------------|
+| [orchestrator-spec.md](orchestrator-spec.md) | Historical | Expanded orchestrator architecture from an earlier multi-agent model |
+| [memory-as-code-spec.md](memory-as-code-spec.md) | Mixed | Memory architecture with still-useful concepts and legacy operational assumptions |
+| [inquiry-cli-spec.md](inquiry-cli-spec.md) | Mixed/planned | CLI/TUI direction with both current intent and planned surfaces |

--- a/docs/spec/inquiry-cli-spec.md
+++ b/docs/spec/inquiry-cli-spec.md
@@ -1,5 +1,7 @@
 # Inquiry CLI/TUI — Technical Specification
 
+> Status note: This document is a mixed planning and design surface. It contains useful intent for the Inquiry CLI, but parts of its command inventory, workflow assumptions, and architectural language do not exactly match the currently implemented CLI. Treat it as a specification draft, not as the authoritative description of current behavior. For current supporting doctrine, see [../architecture.md](../architecture.md), [cli-as-api.md](cli-as-api.md), and [target-specific-agents.md](target-specific-agents.md).
+
 **Finite APE Machine — Command Line Interface & Terminal User Interface**
 
 Version: 0.2.0-spec

--- a/docs/spec/memory-as-code-spec.md
+++ b/docs/spec/memory-as-code-spec.md
@@ -1,5 +1,7 @@
 # Memory as Code
 
+> Status note: This document remains conceptually important but is partly historical and partly planned. It preserves an earlier agent roster and implementation assumptions, so it should not be treated as the current operational source of truth without qualification. For current surrounding doctrine, see [../architecture.md](../architecture.md), [cli-as-api.md](cli-as-api.md), and [index.md](index.md).
+
 **Finite APE Machine — Memory Architecture Specification**
 *"Documentation that doesn't compile is documentation that doesn't exist."*
 

--- a/docs/spec/orchestrator-spec.md
+++ b/docs/spec/orchestrator-spec.md
@@ -1,5 +1,7 @@
 # Orchestrator — Technical Specification
 
+> Status note: This document is retained as a historical design record for an earlier expanded orchestrator model. It should not be read as the current canonical description of APE or the Finite APE Machine. For the current model, see [../architecture.md](../architecture.md), [finite-ape-machine.md](finite-ape-machine.md), [cooperative-multitasking-model.md](cooperative-multitasking-model.md), and [signal-based-coordination.md](signal-based-coordination.md).
+
 **Finite APE Machine — Cooperative Event Loop Orchestration**
 *"The Ghost in the Shell"*
 

--- a/docs/spec/signal-based-coordination.md
+++ b/docs/spec/signal-based-coordination.md
@@ -28,10 +28,10 @@ Tasks never reference each other. They only know about events.
 
 ### Signals
 
-A signal is emitted when a meaningful step completes:
+A signal is emitted when a meaningful step completes. In the current implementation, this routing is materialized through explicit transition events rather than a public `ape signal` command:
 
 ```bash
-ape signal <event-name>
+iq state transition --event <event-name>
 ```
 
 The emitter does not know who (if anyone) listens. It just signals.
@@ -53,8 +53,14 @@ signals:
     transition: PLAN → EXECUTE
     effects: [git_commit_plan]
   execution_approved:
-    transition: EXECUTE → EVOLUTION
-    effects: [git_commit, git_push, gh_pr_create]
+    transition: EXECUTE → END
+    effects: [git_commit_execution]
+  pr_ready:
+    transition: END → EVOLUTION
+    effects: [git_push, gh_pr_create]
+  pr_ready_no_evolution:
+    transition: END → IDLE
+    effects: [git_push, gh_pr_create]
   cycle_complete:
     transition: EVOLUTION → IDLE
     effects: [close_issue_if_applicable]
@@ -77,7 +83,7 @@ The scheduler only invokes READY agents. IDLE and WAITING agents are skipped —
 ```
 IDLE:
   APE uses triage skill → user defines problem
-  User: "ape issue start 42" → creates branch + folder
+  Issue-start protocol prepares branch + cleanroom folder
   Signal: issue_ready → transition to ANALYZE
 
 ANALYZE:
@@ -99,7 +105,13 @@ EXECUTE:
   BASHŌ implements phase by phase, commit per phase
   Final phase: product retrospective + validation report
   User approves → signal: execution_approved
-  Effects: git commit, git push, gh pr create → transition to EVOLUTION
+  Effects: git commit execution artifacts → transition to END
+
+END:
+  APE presents execution summary and waits for explicit authorization
+  User authorizes PR → signal: pr_ready
+  Effects: git push, gh pr create
+  If evolution disabled → pr_ready_no_evolution → transition to IDLE
 
 EVOLUTION:
   DARWIN invoked with full cycle artifacts
@@ -123,11 +135,11 @@ Sub-agent reaches COMPLETE
 
 The human's explicit approval is itself a signal — the highest-priority interrupt.
 
-**Exception:** EVOLUTION → IDLE is automatic (no human gate). DARWIN runs and completes. This can be disabled via `.inquiry/config.yaml` (`evolution.enabled: false`).
+**Exception:** EVOLUTION → IDLE is automatic (no human gate). DARWIN runs and completes. Evolution itself can be disabled via `.inquiry/config.yaml` (`evolution.enabled: false`), in which case END returns directly to IDLE.
 
 ## Relationship to Existing Specs
 
-The [orchestrator-spec](../../references/orchestrator-spec.md) §3.5 defines a precondition table where each agent checks conditions (e.g., "RED tests exist"). This is **polling** — the agent checks every tick if its condition is met.
+The [orchestrator-spec](orchestrator-spec.md) defines a precondition table where each agent checks conditions (e.g., "RED tests exist"). This is **polling** — the agent checks every tick if its condition is met.
 
 The signal model replaces polling with events. Instead of checking preconditions every tick, agents wait for signals. This is more efficient and more faithful to the RTOS analogy.
 

--- a/docs/spec/target-specific-agents.md
+++ b/docs/spec/target-specific-agents.md
@@ -18,7 +18,7 @@ AI coding tools scope their agent/skill discovery to **their own configuration d
 | GitHub Copilot | `~/.copilot/agents/`, `~/.copilot/skills/` | `~/.claude/`, `~/.codex/`, etc. |
 | Claude Code | `~/.claude/agents/`, `~/.claude/skills/` | `~/.copilot/`, `~/.codex/`, etc. |
 
-When `ape target get` deployed the same `ape.agent.md` to both `~/.copilot/` and `~/.claude/`, Copilot displayed the agent twice (once from each path it scans). The subsumption fix (D19) — skip Copilot deploy when Claude exists — eliminated the duplicate but made the agent invisible to Copilot entirely, since it only existed in `~/.claude/`.
+When `iq target get` deployed the same `inquiry.agent.md` to both `~/.copilot/` and `~/.claude/`, Copilot displayed the agent twice (once from each path it scans). The subsumption fix (D19) — skip Copilot deploy when Claude exists — eliminated the duplicate but made the agent invisible to Copilot entirely, since it only existed in `~/.claude/`.
 
 ### Root cause
 
@@ -28,7 +28,7 @@ Each tool only reads files from its own directory. Subsumption assumed tools sha
 
 ## 2. Correction: gentle-ai Pattern
 
-The initial adapter design referenced gentle-ai (see `docs/issues/003-ape-init-v2/analyze/referencia-gentle-ai.md`), which copies skills identically across 11 targets. The assumption was that agents could receive the same treatment.
+The initial adapter design referenced gentle-ai (see `docs/cleanrooms/003-ape-init-v2/analyze/referencia-gentle-ai.md`), which copies skills identically across 11 targets. The assumption was that agents could receive the same treatment.
 
 **This was incorrect.**
 
@@ -98,7 +98,7 @@ The prompt body (instructions, state machine, behavior rules) is the **shared co
 
 - Keep all adapter files, register only `CopilotAdapter` for deploy
 - Remove `subsumedBy` from `CopilotAdapter`
-- Deploy agent + skills to `~/.copilot/` only
+- Deploy `inquiry.agent.md` + skills to `~/.copilot/` only
 - `clean()` still operates on all 5 adapters (backward compat)
 - Validate that Copilot reads the agent and honors tool declarations
 

--- a/docs/thinking-tools.md
+++ b/docs/thinking-tools.md
@@ -1,0 +1,64 @@
+---
+id: thinking-tools
+title: "Thinking Tools — current canonical explainer"
+date: 2026-04-22
+status: active
+tags: [thinking-tools, methodology, agents, reasoning, documentation]
+author: descartes
+---
+
+# Thinking Tools
+
+## Overview
+
+Thinking Tools are the reusable reasoning methods and working disciplines employed within the Inquiry cycle. They are not the cycle itself, not the orchestrating methodology, and not the finite-state system that operationalizes that methodology. They are the intellectual instruments that the system dispatches through its phases. In current repository vocabulary, Inquiry names the cycle-level process, APE names the orchestrating methodology and scheduler, Finite APE Machine names the engineered finite-state realization of that methodology, and Thinking Tools name the methods used within that structure. [1][2][3]
+
+## Current Role in the System
+
+The current model uses Thinking Tools through four active sub-agents and one orchestrating system role:
+
+| Phase | Operator | Thinking Tool | Function |
+|---|---|---|---|
+| IDLE | APE | Practical triage rather than a named tool-specific persona | Prepares infrastructure and governs transition readiness |
+| ANALYZE | SOCRATES | Mayeutics / Socratic method | Clarifies the problem through structured questioning |
+| PLAN | DESCARTES | The Method | Divides, orders, verifies, and enumerates work |
+| EXECUTE | BASHO | Techne + yō no bi | Implements under constraints with emphasis on functional elegance |
+| EVOLUTION | DARWIN | Natural selection | Compares outcomes and proposes fitter process mutations |
+
+This mapping matters because the system does not treat the named agents as arbitrary characters. Their names identify the method each phase is expected to embody. [2][3][4]
+
+## Boundary Clarifications
+
+### Inquiry is not a Thinking Tool
+
+Inquiry is the structured cycle through which a task moves from indeterminacy to validated result. Thinking Tools are used inside that cycle. They are therefore components of the cycle's intellectual discipline, not synonyms for the cycle itself. [1][5]
+
+### APE is not a Thinking Tool
+
+APE is the orchestrating methodology and scheduler that assigns specialized behavior to phases. It dispatches Thinking Tools; it is not one of them. [2][3]
+
+### Finite APE Machine is not a Thinking Tool
+
+Finite APE Machine is the engineered finite-state, signal-driven realization of the methodology. Thinking Tools are methods embodied within that engineered system. [2][6]
+
+## Current Canonical Use
+
+Use this document when the question is what Thinking Tools are in the current repository model. Use [lore.md](lore.md) when the question is how those tools are personified, historicized, or related to the larger symbolic roster. Use [architecture.md](architecture.md) when the question is how the orchestrating system deploys those tools inside the cycle. [2][3][4]
+
+## Historical Note
+
+The project's broader lore includes additional named figures such as MARCOPOLO, VITRUVIUS, SUNZI, GATSBY, ADA, DIJKSTRA, BORGES, and HERMES. Those names remain useful for historical or referential context, but they are not all part of the active current model. Their continued documentary value belongs primarily to [lore.md](lore.md), not to the canonical definition of Thinking Tools as used in the current architecture. [4]
+
+## References
+
+[1] Finite APE Machine repository. "Taxonomy and scope clarification for issue #134." `docs/cleanrooms/134-organize-core-documentation/analyze/taxonomy-and-scope-clarification.md`.
+
+[2] Finite APE Machine repository. "Architecture." `docs/architecture.md`.
+
+[3] Finite APE Machine repository. "Agent lifecycle — six-state model and confirmed agent registry." `docs/spec/agent-lifecycle.md`.
+
+[4] Finite APE Machine repository. "The Apes — Lore." `docs/lore.md`.
+
+[5] Finite APE Machine repository. "Inquiry as Epistemic Foundation of APE." `docs/research/inquiry/index.md`.
+
+[6] Finite APE Machine repository. "Cooperative multitasking model — two-level FSM architecture." `docs/spec/cooperative-multitasking-model.md`; "Signal-based coordination — RTOS event model for agent communication." `docs/spec/signal-based-coordination.md`.


### PR DESCRIPTION
Closes #134

## Summary
- reorganize canonical documentation surfaces and add the issue #134 analysis corpus
- align the live CLI FSM contract with the explicit END gate and update its tests and shipped assets
- replace skipped VS Code integration placeholders with real executable coverage for the shipped extension features

## Validation
- Windows: code/cli dart pub get && dart analyze && dart test
- Windows: code/vscode 
pm run test:unit && npm run test:integration
- Linux via WSL: code/cli dart test
- Linux via WSL: code/vscode 
pm run test:unit && npm run test:integration

## Notes
- ^[volution.enabled is currently false for this workspace, so END returns to IDLE after PR creation.
- The branch contains three topic commits: CLI FSM/runtime, VS Code integration coverage, and documentation/public-surface alignment.