### PR TITLE
fix: correct install script URL (#143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Historical naming note: APE was the system's initial working name. The individua
 ### Install (Windows)
 
 ```powershell
-irm https://www.si14bm.com/inquiry/install.ps1 | iex
+irm https://inquiry.si14bm.com/install.ps1 | iex
 ```
 
 ### Install (Linux)
 
 ```bash
-curl -fsSL https://www.si14bm.com/inquiry/install.sh | bash
+curl -fsSL https://inquiry.si14bm.com/install.sh | bash
 ```
 
 The installer downloads the latest release, places `inquiry` (aliased as `iq`) on `PATH`, and verifies prerequisites.

--- a/code/cli/README.md
+++ b/code/cli/README.md
@@ -13,13 +13,13 @@ Inquiry names the cycle-level process. APE names the orchestrating methodology. 
 **Windows:**
 
 ```powershell
-irm https://www.si14bm.com/inquiry/install.ps1 | iex
+irm https://inquiry.si14bm.com/install.ps1 | iex
 ```
 
 **Linux:**
 
 ```bash
-curl -fsSL https://www.si14bm.com/inquiry/install.sh | bash
+curl -fsSL https://inquiry.si14bm.com/install.sh | bash
 ```
 
 ## Commands

--- a/code/vscode/CHANGELOG.md
+++ b/code/vscode/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.4] - 2026-04-24
+
+### Fixed
+- Install script URL corrected from `www.si14bm.com/inquiry/` to `inquiry.si14bm.com` — the Init command no longer fails with HTTP 404 when auto-installing the CLI (#143)
+- README and website links updated to match the actual CNAME domain
+
 ## [0.1.3] - 2026-04-23
 
 ### Changed

--- a/code/vscode/README.md
+++ b/code/vscode/README.md
@@ -3,7 +3,7 @@
 **Analyze. Plan. Execute.**
 
 > Select **@inquiry** as your GitHub Copilot custom agent.
-> Every task follows a strict cycle: **ANALYZE → PLAN → EXECUTE → END**.
+> Every task follows a strict cycle: **ANALYZE → PLAN → EXECUTE**.
 > No freestyling. No hallucinated plans. Structure from analysis to PR.
 
 This README is the extension's public entry surface. For the canonical repository documentation map, start at [../docs/index.md](../docs/index.md).
@@ -63,9 +63,9 @@ The status bar shows the current FSM phase in real time:
 
 ## Links
 
-- [Website](https://www.si14bm.com/inquiry/) · [GitHub](https://github.com/siliconbrainedmachines/inquiry) · [Issues](https://github.com/siliconbrainedmachines/inquiry/issues)
+- [Website](https://inquiry.si14bm.com/) · [GitHub](https://github.com/siliconbrainedmachines/inquiry) · [Issues](https://github.com/siliconbrainedmachines/inquiry/issues)
 - [Docs map](https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/index.md) · [Architecture](https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/architecture.md) · [Finite APE Machine spec](https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/spec/finite-ape-machine.md)
 
-For the full methodology, see [si14bm.com/inquiry](https://www.si14bm.com/inquiry/).
+For the full methodology, see [inquiry.si14bm.com](https://inquiry.si14bm.com/).
 
 MIT © 2026 Cristian Cisneros

--- a/code/vscode/package.json
+++ b/code/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "inquiry-vscode",
   "displayName": "Inquiry",
   "publisher": "siliconbrainedmachines",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Inquiry — Analyze. Plan. Execute. End. Structured AI-assisted development for GitHub Copilot.",
   "license": "MIT",
   "icon": "assets/icon.png",

--- a/code/vscode/src/installer.ts
+++ b/code/vscode/src/installer.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import * as path from 'path';
 import * as os from 'os';
 
-const INSTALL_BASE_URL = 'https://www.si14bm.com/inquiry';
+const INSTALL_BASE_URL = 'https://inquiry.si14bm.com';
 
 export function getInstallScriptUrl(platform: string): { url: string; filename: string } {
   if (platform === 'win32') {

--- a/code/vscode/test/unit/installer.test.ts
+++ b/code/vscode/test/unit/installer.test.ts
@@ -22,13 +22,13 @@ function createMockProcess() {
 describe('getInstallScriptUrl', () => {
   it('returns ps1 URL on win32', () => {
     const result = getInstallScriptUrl('win32');
-    assert.strictEqual(result.url, 'https://www.si14bm.com/inquiry/install.ps1');
+    assert.strictEqual(result.url, 'https://inquiry.si14bm.com/install.ps1');
     assert.strictEqual(result.filename, 'inquiry-install.ps1');
   });
 
   it('returns sh URL on linux', () => {
     const result = getInstallScriptUrl('linux');
-    assert.strictEqual(result.url, 'https://www.si14bm.com/inquiry/install.sh');
+    assert.strictEqual(result.url, 'https://inquiry.si14bm.com/install.sh');
     assert.strictEqual(result.filename, 'inquiry-install.sh');
   });
 
@@ -88,7 +88,7 @@ describe('installInquiryCli', () => {
     };
 
     await installInquiryCli(deps);
-    assert.strictEqual(downloadedUrl, 'https://www.si14bm.com/inquiry/install.ps1');
+    assert.strictEqual(downloadedUrl, 'https://inquiry.si14bm.com/install.ps1');
     assert.strictEqual(downloadedDest, path.join('C:\\temp', 'inquiry-install.ps1'));
     assert.strictEqual(spawnedCmd, 'powershell');
     assert.deepStrictEqual(spawnedArgs, [
@@ -117,7 +117,7 @@ describe('installInquiryCli', () => {
     };
 
     await installInquiryCli(deps);
-    assert.strictEqual(downloadedUrl, 'https://www.si14bm.com/inquiry/install.sh');
+    assert.strictEqual(downloadedUrl, 'https://inquiry.si14bm.com/install.sh');
     assert.strictEqual(spawnedCmd, 'bash');
   });
 


### PR DESCRIPTION
Closes #143

## Problem
The VS Code extension's **Inquiry: Init** command fails with HTTP 404 when auto-installing the CLI because \INSTALL_BASE_URL\ pointed to \https://www.si14bm.com/inquiry\ — a path that doesn't exist. The site is served from \https://inquiry.si14bm.com\ (per \code/site/CNAME\).

## Changes
- \code/vscode/src/installer.ts\: \INSTALL_BASE_URL\ → \https://inquiry.si14bm.com\
- \README.md\, \code/cli/README.md\, \code/vscode/README.md\: install URLs and website links updated
- \code/vscode/test/unit/installer.test.ts\: assertions updated to new URL
- Version bump: \