### PR TITLE
v0.3.0: state encapsulation (#152)

### DIFF
--- a/cleanrooms/152-state-encapsulation-violation/analyze/assumptions-challenge.md
+++ b/cleanrooms/152-state-encapsulation-violation/analyze/assumptions-challenge.md
@@ -1,0 +1,41 @@
+---
+id: assumptions-challenge
+title: "Assumptions challenge — 4 decisions analyzed"
+date: 2026-04-27
+status: active
+tags: [assumptions, decisions, risk, blast-radius]
+author: socrates
+---
+
+# Assumptions Challenge Report
+
+## Decision 1: Remove `next_state` from JSON — SAFE
+- No firmware or agent reads `next_state` for routing
+- 1 test file to update (`fsm_state_test.dart`)
+- Zero external dependencies
+
+## Decision 2: Rename event names to generic — HIGH BLAST RADIUS
+- 25+ files reference current event names
+- 8 cleanroom plan files, tests, site HTML
+- The (state, event) tuple mechanism is sound — renaming preserves it
+- Precondition validation is event-agnostic
+- **Recommendation: defer to separate issue** — too much churn for this scope
+
+## Decision 3: IDLE sub-agent (TRIAGE) — FEASIBLE, needs design
+- `_stateApes` pattern already supports it
+- `iq ape prompt` will work once mapping updated
+- Firmware `if ape is null` check correctly routes to Inner Loop
+- **Design gap**: TRIAGE completion → what happens?
+  - TRIAGE `_DONE` + issue ready → scheduler transitions via `iq fsm transition --event start_analyze --issue <NNN>`
+  - TRIAGE `_DONE` + no issue → stays IDLE, block event
+  - TRIAGE never auto-transitions the main FSM — scheduler decides based on TRIAGE output
+
+## Decision 4: `.inquiry/` is kernel space — SOUND, requires updates
+- `issue-start` SKILL.md line 111 instructs agents to WRITE state.yaml directly — MUST be fixed
+- `--issue` flag on `iq fsm transition` already works
+- No test validates `--issue` flag — gap
+- DARWIN metrics write has no CLI endpoint — future issue
+
+## New finding: issue-start skill violates kernel space principle
+The skill tells agents: "Write `.inquiry/state.yaml` with phase: ANALYZE, task: NNN"
+Should say: "Execute `iq fsm transition --event start_analyze --issue <NNN>`"

--- a/cleanrooms/152-state-encapsulation-violation/analyze/confirmed-findings.md
+++ b/cleanrooms/152-state-encapsulation-violation/analyze/confirmed-findings.md
@@ -1,0 +1,90 @@
+---
+id: confirmed-findings
+title: "Confirmed findings — living document"
+date: 2026-04-27
+status: active
+tags: [findings, confirmed, socrates, living-document]
+author: socrates
+---
+
+# Confirmed Findings
+
+> This is a living document. SOCRATES updates it as findings are confirmed, revised, or invalidated during analysis. Each entry records WHAT was confirmed, WHEN, and any EVIDENCE.
+
+## F1: The bug is real and ongoing — CONFIRMED
+
+The state encapsulation violation is not theoretical. During this very analysis session, the agent (Claude Opus 4.6, frontier model, max reasoning) violated the kernel boundary by editing `.inquiry/state.yaml` directly instead of using `iq fsm transition --issue 152`. This proves:
+
+- The bug occurs **even with frontier models and maximum configuration**
+- Inquiry is not just useful — it is **necessary**
+- The problem is not AI capability, it is the absence of guardrails that enforce the method
+
+**Evidence:** Session transcript — agent wrote `.inquiry/state.yaml` directly, then corrected via `iq fsm transition --event start_analyze --issue 152`.
+
+## F2: The thesis is clarity, not model independence — CONFIRMED (revised)
+
+Original draft of `docs/philosophy.md` stated "method over model" — that a small model with good process beats a frontier model without. This was **an unsubstantiated claim** that does not match the project's origin.
+
+The actual thesis, per the timeline and project history:
+> **The bottleneck in AI-assisted development is not AI capability — it is human clarity.**
+
+The AI reads words, not intent. Inquiry forces the developer to externalize their thinking into unambiguous artifacts before the AI acts. The goal is that the developer recognizes the AI's output as their own design.
+
+**Evidence:** `docs/timeline.md` — "The AI assumed things I hadn't said", "I recognize the code the AI produces as my own."
+
+## F3: `--issue` flag works correctly — CONFIRMED
+
+`iq fsm transition --event start_analyze --issue 152` correctly writes the issue number to `.inquiry/state.yaml` without the agent touching the file.
+
+**Evidence:** Manual verification in terminal during this session.
+
+## F4: `issue-start` skill violates kernel space — CONFIRMED
+
+`code/cli/assets/skills/issue-start/SKILL.md` instructs agents to write `.inquiry/state.yaml` directly. Must be changed to use `iq fsm transition --event start_analyze --issue <NNN>`.
+
+**Evidence:** Read of SKILL.md during analysis.
+
+## F5: `start_analyze` has empty prechecks — CONFIRMED
+
+`code/cli/assets/fsm/transition_contract.yaml` declares `prechecks: []` for `start_analyze`. The validation code for `issue_selected_or_created` and `feature_branch_selected` already exists in `_validatePreconditions()` — only the contract declaration is missing.
+
+**Evidence:** Read of transition_contract.yaml and transition.dart during analysis.
+
+## F6: Event rename deferred — CONFIRMED
+
+Renaming events from state-specific names (e.g., `start_analyze`) to generic names (e.g., `begin`) has too high blast radius (25+ files). Deferred to a separate issue.
+
+**Evidence:** grep search during assumptions challenge showed 8 cleanroom plans, tests, site HTML all reference current names.
+
+## F7: TRIAGE sub-agent design — CONFIRMED (direction, not details)
+
+IDLE will get an ARISTOTLE sub-agent using phronesis (practical wisdom) + categories (systematic classification). Internal states: `classify_intent → scope_problem → search_issues → create_or_select → confirm → _DONE`. 
+
+**Open question:** Exact YAML structure, completion behavior, scheduler integration details still need PLAN phase work.
+
+## F8: `docs/philosophy.md` is the foundational document — CONFIRMED
+
+Created during this analysis as the document that governs all other specs. Five convictions:
+1. Clarity through method (NOT "method over model")
+2. Memory as code
+3. The kernel boundary
+4. States are worlds
+5. Evolution is built-in
+
+Design invariant test #4 is: "Does it force clarity before action?" (NOT "Does it work with any model?")
+
+## F9: `next_state` removal is safe — CONFIRMED
+
+No firmware or agent reads `next_state` for routing. Only 1 test file to update (`fsm_state_test.dart`). Zero external dependencies.
+
+**Evidence:** grep search during assumptions challenge.
+
+## F10: Sub-agent YAMLs are clean — CONFIRMED
+
+`socrates.yaml`, `basho.yaml`, `descartes.yaml`, `darwin.yaml` — zero references to other FSM main states. The encapsulation violation is in the firmware and CLI, not in the sub-agents.
+
+**Evidence:** Read of all sub-agent YAML files during analysis.
+
+---
+
+*Last updated: 2026-04-27 — SOCRATES assumptions phase*

--- a/cleanrooms/152-state-encapsulation-violation/analyze/confirmed-findings.md
+++ b/cleanrooms/152-state-encapsulation-violation/analyze/confirmed-findings.md
@@ -82,6 +82,23 @@ DARWIN as continuous observer solves the problem the developer currently handles
 
 To start ANALYZE you need an issue (for branch, cleanroom, traceability). To create a good issue you need analysis. This means IDLE inherently performs a pre-analysis: scope checking, deduplication, granularity assessment. This is not a bug — it is Dewey's problematization: converting an indeterminate situation into a formulated problem (an issue).
 
+## F13: Sub-agent YAMLs contain infrastructure — CONFIRMED (new)
+
+The principle: sub-agents are pure thinking tools. They reason. They do not know about files, folders, skills, commands, or deliverables. The STATE provides operational context via the prompt the CLI assembles.
+
+**Current violation:** All four sub-agent YAMLs mix thinking-tool identity with infrastructure:
+- SOCRATES: references `diagnosis.md`, `memory-write skill`, `index.md`, and knows PLAN exists ("sole required input for the planning phase")
+- DESCARTES: references `diagnosis.md` as input, knows EXECUTE exists ("Do not implement anything")
+- BASHŌ: references `plan.md`, `retrospective.md`, git commits
+- DARWIN: references `.inquiry/mutations.md` and `.inquiry/metrics.yaml` (kernel space!), `gh issue list`, `diagnosis.md`, `plan.md`, `retrospective.md`
+
+**Required separation:**
+- Sub-agent YAML `base_prompt` = pure thinking tool (mindset, behavior, reasoning method)
+- State context (assembled by CLI per FSM state) = objective, skills, deliverables, constraints
+- Assembled prompt = `thinking_tool + state_context + sub_state_focus`
+
+**Impact:** This changes prompt assembly in `ape_definition.dart` and requires state-level context templates in the CLI or transition contract. Significant redesign of how `iq ape prompt` works.
+
 ## F8: `docs/philosophy.md` is the foundational document — CONFIRMED
 
 Created during this analysis as the document that governs all other specs. Five convictions:

--- a/cleanrooms/152-state-encapsulation-violation/analyze/confirmed-findings.md
+++ b/cleanrooms/152-state-encapsulation-violation/analyze/confirmed-findings.md
@@ -56,11 +56,31 @@ Renaming events from state-specific names (e.g., `start_analyze`) to generic nam
 
 **Evidence:** grep search during assumptions challenge showed 8 cleanroom plans, tests, site HTML all reference current names.
 
-## F7: TRIAGE sub-agent design — CONFIRMED (direction, not details)
+## F7: TRIAGE sub-agent design — REVISED
 
-IDLE will get an ARISTOTLE sub-agent using phronesis (practical wisdom) + categories (systematic classification). Internal states: `classify_intent → scope_problem → search_issues → create_or_select → confirm → _DONE`. 
+~~IDLE will get an ARISTOTLE sub-agent.~~ **Invalidated.** Aristotle's tools (phronesis, categories) classify what is already determined — they don't transform indeterminate situations into determinate ones. That is Dewey's problematization, and SOCRATES already performs it.
 
-**Open question:** Exact YAML structure, completion behavior, scheduler integration details still need PLAN phase work.
+**New design: SOCRATES in two modes.**
+- In IDLE: SOCRATES asks "Is this a well-scoped problem? Does it already exist? Is it granular enough?" → produces an issue
+- In ANALYZE: SOCRATES asks "What is the root cause? What assumptions are we making?" → produces diagnosis.md
+
+This eliminates the need for a new sub-agent. The sub-FSM states differ per mode — details for PLAN.
+
+## F11: Sub-agents are cross-cutting capabilities, not 1:1 slots — CONFIRMED (new)
+
+The original model assumed each state has exactly one sub-agent. The revised model:
+- **SOCRATES**: active in IDLE (issue selection) and ANALYZE (diagnosis)
+- **DESCARTES**: active in PLAN
+- **BASHŌ**: active in EXECUTE and END
+- **DARWIN**: active in ALL phases when evolution=true — observes whether the process is being followed, documents what works and what fails
+
+DARWIN as continuous observer solves the problem the developer currently handles manually: noticing process violations during the cycle.
+
+**Evidence:** This session itself — the developer caught the thesis drift ("method over model"), the kernel boundary violation, and the ARISTOTLE design flaw. DARWIN should catch these.
+
+## F12: "Analysis before the analysis" — the chicken-and-egg of IDLE — CONFIRMED (new)
+
+To start ANALYZE you need an issue (for branch, cleanroom, traceability). To create a good issue you need analysis. This means IDLE inherently performs a pre-analysis: scope checking, deduplication, granularity assessment. This is not a bug — it is Dewey's problematization: converting an indeterminate situation into a formulated problem (an issue).
 
 ## F8: `docs/philosophy.md` is the foundational document — CONFIRMED
 
@@ -87,4 +107,4 @@ No firmware or agent reads `next_state` for routing. Only 1 test file to update 
 
 ---
 
-*Last updated: 2026-04-27 — SOCRATES assumptions phase*
+*Last updated: 2026-04-27 — SOCRATES meta_reflection phase*

--- a/cleanrooms/152-state-encapsulation-violation/analyze/diagnosis.md
+++ b/cleanrooms/152-state-encapsulation-violation/analyze/diagnosis.md
@@ -2,123 +2,84 @@
 id: diagnosis
 title: "Diagnosis — Issue #152: State encapsulation violation"
 date: 2026-04-27
-status: draft
-tags: [diagnosis, encapsulation, fsm, idle, triage, firmware, kernel-boundary]
+status: final
+tags: [diagnosis, encapsulation, fsm, idle, firmware, kernel-boundary]
 author: socrates
 ---
 
 # Diagnosis
 
-## Problem statement
+## Problem
 
-The Inquiry scheduler violates its own state encapsulation principle: it lists all FSM states in the firmware, exposes destination states in JSON output, provides escape-route instructions instead of mission descriptions, allows transition to ANALYZE without issue or branch, and has no behavior for IDLE. The result is that agents bypass the method — coding directly, transitioning without prerequisites, or acting without the developer's clear intent.
+The firmware and CLI leak state knowledge to agents. Agents see destination states, receive escape-route instructions, and can transition to ANALYZE without an issue or branch. IDLE has no behavior — agents fall through to coding directly. The `issue-start` skill instructs agents to write `.inquiry/state.yaml`, violating the kernel boundary.
 
-This is not a theoretical concern. During this analysis session, a frontier model (Claude Opus 4.6, maximum reasoning configuration) violated the kernel boundary by editing `.inquiry/state.yaml` directly. The bug affects all models because it is not a capability problem — it is the absence of guardrails.
+Observed during this session: a frontier model edited `.inquiry/state.yaml` directly. The bug is not a capability problem — it is the absence of guardrails.
 
 ## Root cause
 
-The firmware v0.2.0 refactor reduced the agent prompt from 554 lines to ~35. The simplification was correct — the old prompt was too complex. But the refactor cut too deep: it removed IDLE triage behavior entirely and left the firmware as a generic dispatcher that enumerates the full state graph. The sub-agents (SOCRATES, DESCARTES, BASHŌ, DARWIN) are well-encapsulated. The scheduler that orchestrates them is not.
+The v0.2.0 firmware refactor simplified the agent prompt from 554 to ~35 lines. The simplification was correct, but it removed IDLE triage and left the firmware enumerating the full state graph. The firmware should be a generic dispatch loop that delegates all Inquiry-specific knowledge to the CLI.
 
-## Violations by layer
+## Architecture (confirmed)
 
-| # | Layer | Severity | Location |
-|---|-------|----------|----------|
-| 1 | Firmware enumerates all 6 states | HIGH | `inquiry.agent.md` line 14 |
-| 2 | CLI instructions are escape routes | HIGH | `state.dart` lines 184-199 |
-| 3 | JSON exposes `next_state` | MEDIUM | `state.dart` `_computeTransitions` |
-| 4 | `start_analyze` has empty prechecks | HIGH | `transition_contract.yaml` lines 30-39 |
-| 5 | IDLE has no triage behavior | HIGH | `inquiry.agent.md` line 22 |
-| 6 | `issue-start` skill writes `.inquiry/` directly | HIGH | `issue-start/SKILL.md` |
-| 7 | Build assets empty | LOW | `build/assets/` |
+Two layers, clean separation:
 
-## What works correctly
+- **Firmware** — generic dispatch loop. Reads `iq fsm state --json`, dispatches sub-agents via `iq ape prompt`, presents transitions. Knows nothing about Inquiry, states, or phases.
+- **CLI** — Inquiry kernel. Knows states, transitions, prechecks, sub-agents, context. Injects all Inquiry-specific knowledge through its output.
 
-- Sub-agent YAMLs: zero cross-state references
-- Precondition system: ANALYZE→PLAN, PLAN→EXECUTE, EXECUTE→END all enforced
-- `--issue` flag: `iq fsm transition --event start_analyze --issue <N>` works
-- `_validatePreconditions()`: validation code exists, only contract declaration missing
-- Sub-agent terminal events use `complete`, not state-name-based events
+No additional layer is needed. The fix is to purify this boundary.
 
-## Prescribed changes
+## What this issue fixes
 
-Ordered by risk (low → high). Each group can be tested independently.
+### A1. Add prechecks to `start_analyze`
 
-### Group A — Low risk, high impact
+- **File:** `transition_contract.yaml`
+- **Change:** `prechecks: []` → `prechecks: [issue_selected_or_created, feature_branch_selected]`
+- Prevents transition without issue/branch. Validation code already exists in `_validatePreconditions()`.
 
-**A1. Add prechecks to `start_analyze`**
-- File: `transition_contract.yaml`
-- Change: `prechecks: []` → `prechecks: [issue_selected_or_created, feature_branch_selected]`
-- Why: Closes the only destructive bug — prevents transition without issue/branch
+### A2. Remove `next_state` from JSON output
 
-**A2. Remove `next_state` from JSON output**
-- File: `state.dart`, `_computeTransitions`
-- Change: Stop including `next_state` in transition objects
-- Why: Agents cannot see destination states. 1 test to update.
+- **File:** `state.dart`, `_computeTransitions`
+- **Change:** Remove `next_state` key from transition objects
+- 1 test to update (`fsm_state_test.dart`). Nothing reads this field for routing.
 
-**A3. Rewrite `_stateInstructions` to mission descriptions**
-- File: `state.dart`, lines 184-199
-- Change: Replace escape-route strings with mission descriptions
-- Why: Each state describes what it does, not how to leave it
+### A3. Rewrite `_stateInstructions` as mission descriptions
 
-**A4. Update `issue-start` skill to use CLI**
-- File: `issue-start/SKILL.md`
-- Change: Replace "write `.inquiry/state.yaml`" with "execute `iq fsm transition --event start_analyze --issue <NNN>`"
-- Why: Skills must respect the kernel boundary
+- **File:** `state.dart`, lines 184-199
+- **Change:** Each state describes its mission, not how to leave it
+- Example: IDLE goes from "Use `iq fsm transition --event start_analyze` to begin" to a description of the triage mission.
 
-### Group B — Medium risk, structural
+### A4. Update `issue-start` skill to respect kernel boundary
 
-**B1. Enable SOCRATES in IDLE with a triage-mode prompt**
-- The original design proposed a new sub-agent (ARISTOTLE). This was invalidated: Aristotle's tools classify what is already determined, but IDLE needs to transform the indeterminate into determinate — that is Dewey's problematization, and SOCRATES already does it.
-- Change: `_stateApes` maps IDLE to SOCRATES (same agent, different sub-FSM and prompt)
-- SOCRATES in IDLE asks: "Is this a well-scoped problem? Does it already exist as an issue? Is it granular enough?"
-- SOCRATES in ANALYZE asks: "What is the root cause?" → produces diagnosis.md
-- Sub-FSM for IDLE mode: `evaluate_scope → search_existing → create_or_select → confirm → _DONE`
-- This requires the sub-agent system to support **mode-dependent prompts and sub-FSMs** for the same agent name
+- **File:** `issue-start/SKILL.md`
+- **Change:** Replace "write `.inquiry/state.yaml`" with "execute `iq fsm transition --event start_analyze --issue <NNN>`"
 
-**B2. Update `_stateApes` mappings for multi-mode model**
-- Files: `state.dart`, `prompt.dart`, `effect_executor.dart`
-- Current model: each state has exactly one sub-agent (or none)
-- New model: sub-agents are cross-cutting capabilities that activate per context:
-  - SOCRATES: IDLE (triage) + ANALYZE (diagnosis)
-  - DESCARTES: PLAN
-  - BASHŌ: EXECUTE + END
-  - DARWIN: ALL phases when `evolution=true` (continuous process observer)
-- The DARWIN-everywhere pattern solves the problem the developer currently handles manually: noticing process violations during the cycle
+### B1. Activate SOCRATES in IDLE
 
-**B3. Rewrite firmware `inquiry.agent.md`**
-- Principles:
-  - Never enumerate states by name
-  - Read `iq fsm state --json` for current state, instructions, and transitions
-  - If sub-agent active: dispatch via Inner Loop
-  - If no sub-agent: follow `instructions` field from JSON
-  - The firmware is state-agnostic — it delegates everything to the CLI's output
-- Why: Encapsulation at the scheduler level. The firmware becomes a generic dispatch loop.
+- **Files:** `_stateApes` mappings in `state.dart`, `prompt.dart`, `effect_executor.dart`
+- **Change:** Map IDLE to SOCRATES with a triage-mode sub-FSM
+- SOCRATES in IDLE: "Is this well-scoped? Does it exist? Is it granular?" → produces an issue
+- SOCRATES in ANALYZE: "What is the root cause?" → produces diagnosis.md
+- Same thinking tool, different mission per state. Requires mode-dependent sub-FSMs for the same agent name.
 
-### Excluded from scope
+### B2. Rewrite firmware `inquiry.agent.md`
 
-- **Event renaming** (e.g., `start_analyze` → `begin`): 25+ files affected, deferred to separate issue
-- **Build asset sync**: mechanical, done at release time
-- **Full DARWIN-everywhere implementation**: confirmed as direction, but requires its own issue for prompt design, config gating, and multi-agent-per-state infrastructure
+- Never enumerate states by name
+- Read `iq fsm state --json` for state, instructions, and transitions
+- If sub-agent active → dispatch via Inner Loop
+- If no sub-agent → follow `instructions` from JSON
+- The firmware is state-agnostic — a generic dispatch loop
+
+## What this issue does NOT fix
+
+| Concern | Reason | Tracking |
+|---------|--------|----------|
+| Event renaming (`start_analyze` → `begin`) | 25+ files, high blast radius | Future issue |
+| Sub-agent YAMLs contain infrastructure | Different principle (agent purity vs state encapsulation) | #154 |
+| DARWIN active in all phases | Requires config gating and multi-agent-per-state infrastructure | Future issue |
+| Build asset sync | Mechanical, done at release | N/A |
 
 ## Governing principle
 
 > Each state is a complete, self-contained world. It has a mission, a sub-agent, and artifacts. It does not know that other states exist.
 
-This is conviction #4 from `docs/philosophy.md`: **States are worlds**. Encapsulation is not code hygiene — it preserves the integrity of each mode of inference. SOCRATES must not know about PLAN because knowing about PLAN corrupts analysis.
-
-## Evidence summary
-
-| ID | Finding | Source |
-|----|---------|--------|
-| F1 | Frontier model violated kernel boundary during this session | Session transcript |
-| F2 | Thesis is clarity, not model independence | `docs/timeline.md` |
-| F3 | `--issue` flag works correctly | Manual verification |
-| F4 | `issue-start` skill writes `.inquiry/` directly | `SKILL.md` read |
-| F5 | `start_analyze` prechecks empty, validation code exists | `transition_contract.yaml`, `transition.dart` |
-| F6 | Event rename deferred — 25+ file blast radius | grep search |
-| F7 | ARISTOTLE invalidated — SOCRATES in two modes replaces it | Analysis session |
-| F8 | `docs/philosophy.md` created as foundational document | Analysis session |
-| F9 | `next_state` removal safe — 1 test to update | grep search |
-| F10 | Sub-agent YAMLs clean — violation is firmware/CLI only | YAML file reads |
-| F11 | Sub-agents are cross-cutting capabilities, not 1:1 slots | Analysis session |
-| F12 | IDLE is Dewey's problematization — "analysis before the analysis" | Peirce/Dewey research docs |
+Conviction #4 from `docs/philosophy.md`: **States are worlds**.

--- a/cleanrooms/152-state-encapsulation-violation/analyze/diagnosis.md
+++ b/cleanrooms/152-state-encapsulation-violation/analyze/diagnosis.md
@@ -1,0 +1,124 @@
+---
+id: diagnosis
+title: "Diagnosis — Issue #152: State encapsulation violation"
+date: 2026-04-27
+status: draft
+tags: [diagnosis, encapsulation, fsm, idle, triage, firmware, kernel-boundary]
+author: socrates
+---
+
+# Diagnosis
+
+## Problem statement
+
+The Inquiry scheduler violates its own state encapsulation principle: it lists all FSM states in the firmware, exposes destination states in JSON output, provides escape-route instructions instead of mission descriptions, allows transition to ANALYZE without issue or branch, and has no behavior for IDLE. The result is that agents bypass the method — coding directly, transitioning without prerequisites, or acting without the developer's clear intent.
+
+This is not a theoretical concern. During this analysis session, a frontier model (Claude Opus 4.6, maximum reasoning configuration) violated the kernel boundary by editing `.inquiry/state.yaml` directly. The bug affects all models because it is not a capability problem — it is the absence of guardrails.
+
+## Root cause
+
+The firmware v0.2.0 refactor reduced the agent prompt from 554 lines to ~35. The simplification was correct — the old prompt was too complex. But the refactor cut too deep: it removed IDLE triage behavior entirely and left the firmware as a generic dispatcher that enumerates the full state graph. The sub-agents (SOCRATES, DESCARTES, BASHŌ, DARWIN) are well-encapsulated. The scheduler that orchestrates them is not.
+
+## Violations by layer
+
+| # | Layer | Severity | Location |
+|---|-------|----------|----------|
+| 1 | Firmware enumerates all 6 states | HIGH | `inquiry.agent.md` line 14 |
+| 2 | CLI instructions are escape routes | HIGH | `state.dart` lines 184-199 |
+| 3 | JSON exposes `next_state` | MEDIUM | `state.dart` `_computeTransitions` |
+| 4 | `start_analyze` has empty prechecks | HIGH | `transition_contract.yaml` lines 30-39 |
+| 5 | IDLE has no triage behavior | HIGH | `inquiry.agent.md` line 22 |
+| 6 | `issue-start` skill writes `.inquiry/` directly | HIGH | `issue-start/SKILL.md` |
+| 7 | Build assets empty | LOW | `build/assets/` |
+
+## What works correctly
+
+- Sub-agent YAMLs: zero cross-state references
+- Precondition system: ANALYZE→PLAN, PLAN→EXECUTE, EXECUTE→END all enforced
+- `--issue` flag: `iq fsm transition --event start_analyze --issue <N>` works
+- `_validatePreconditions()`: validation code exists, only contract declaration missing
+- Sub-agent terminal events use `complete`, not state-name-based events
+
+## Prescribed changes
+
+Ordered by risk (low → high). Each group can be tested independently.
+
+### Group A — Low risk, high impact
+
+**A1. Add prechecks to `start_analyze`**
+- File: `transition_contract.yaml`
+- Change: `prechecks: []` → `prechecks: [issue_selected_or_created, feature_branch_selected]`
+- Why: Closes the only destructive bug — prevents transition without issue/branch
+
+**A2. Remove `next_state` from JSON output**
+- File: `state.dart`, `_computeTransitions`
+- Change: Stop including `next_state` in transition objects
+- Why: Agents cannot see destination states. 1 test to update.
+
+**A3. Rewrite `_stateInstructions` to mission descriptions**
+- File: `state.dart`, lines 184-199
+- Change: Replace escape-route strings with mission descriptions
+- Why: Each state describes what it does, not how to leave it
+
+**A4. Update `issue-start` skill to use CLI**
+- File: `issue-start/SKILL.md`
+- Change: Replace "write `.inquiry/state.yaml`" with "execute `iq fsm transition --event start_analyze --issue <NNN>`"
+- Why: Skills must respect the kernel boundary
+
+### Group B — Medium risk, structural
+
+**B1. Enable SOCRATES in IDLE with a triage-mode prompt**
+- The original design proposed a new sub-agent (ARISTOTLE). This was invalidated: Aristotle's tools classify what is already determined, but IDLE needs to transform the indeterminate into determinate — that is Dewey's problematization, and SOCRATES already does it.
+- Change: `_stateApes` maps IDLE to SOCRATES (same agent, different sub-FSM and prompt)
+- SOCRATES in IDLE asks: "Is this a well-scoped problem? Does it already exist as an issue? Is it granular enough?"
+- SOCRATES in ANALYZE asks: "What is the root cause?" → produces diagnosis.md
+- Sub-FSM for IDLE mode: `evaluate_scope → search_existing → create_or_select → confirm → _DONE`
+- This requires the sub-agent system to support **mode-dependent prompts and sub-FSMs** for the same agent name
+
+**B2. Update `_stateApes` mappings for multi-mode model**
+- Files: `state.dart`, `prompt.dart`, `effect_executor.dart`
+- Current model: each state has exactly one sub-agent (or none)
+- New model: sub-agents are cross-cutting capabilities that activate per context:
+  - SOCRATES: IDLE (triage) + ANALYZE (diagnosis)
+  - DESCARTES: PLAN
+  - BASHŌ: EXECUTE + END
+  - DARWIN: ALL phases when `evolution=true` (continuous process observer)
+- The DARWIN-everywhere pattern solves the problem the developer currently handles manually: noticing process violations during the cycle
+
+**B3. Rewrite firmware `inquiry.agent.md`**
+- Principles:
+  - Never enumerate states by name
+  - Read `iq fsm state --json` for current state, instructions, and transitions
+  - If sub-agent active: dispatch via Inner Loop
+  - If no sub-agent: follow `instructions` field from JSON
+  - The firmware is state-agnostic — it delegates everything to the CLI's output
+- Why: Encapsulation at the scheduler level. The firmware becomes a generic dispatch loop.
+
+### Excluded from scope
+
+- **Event renaming** (e.g., `start_analyze` → `begin`): 25+ files affected, deferred to separate issue
+- **Build asset sync**: mechanical, done at release time
+- **Full DARWIN-everywhere implementation**: confirmed as direction, but requires its own issue for prompt design, config gating, and multi-agent-per-state infrastructure
+
+## Governing principle
+
+> Each state is a complete, self-contained world. It has a mission, a sub-agent, and artifacts. It does not know that other states exist.
+
+This is conviction #4 from `docs/philosophy.md`: **States are worlds**. Encapsulation is not code hygiene — it preserves the integrity of each mode of inference. SOCRATES must not know about PLAN because knowing about PLAN corrupts analysis.
+
+## Evidence summary
+
+| ID | Finding | Source |
+|----|---------|--------|
+| F1 | Frontier model violated kernel boundary during this session | Session transcript |
+| F2 | Thesis is clarity, not model independence | `docs/timeline.md` |
+| F3 | `--issue` flag works correctly | Manual verification |
+| F4 | `issue-start` skill writes `.inquiry/` directly | `SKILL.md` read |
+| F5 | `start_analyze` prechecks empty, validation code exists | `transition_contract.yaml`, `transition.dart` |
+| F6 | Event rename deferred — 25+ file blast radius | grep search |
+| F7 | ARISTOTLE invalidated — SOCRATES in two modes replaces it | Analysis session |
+| F8 | `docs/philosophy.md` created as foundational document | Analysis session |
+| F9 | `next_state` removal safe — 1 test to update | grep search |
+| F10 | Sub-agent YAMLs clean — violation is firmware/CLI only | YAML file reads |
+| F11 | Sub-agents are cross-cutting capabilities, not 1:1 slots | Analysis session |
+| F12 | IDLE is Dewey's problematization — "analysis before the analysis" | Peirce/Dewey research docs |

--- a/cleanrooms/152-state-encapsulation-violation/analyze/index.md
+++ b/cleanrooms/152-state-encapsulation-violation/analyze/index.md
@@ -13,8 +13,9 @@ author: socrates
 
 | Document | Status | Description |
 |----------|--------|-------------|
+| [confirmed-findings.md](confirmed-findings.md) | active | **Living document** — all confirmed findings, updated as analysis progresses |
 | [violation-inventory.md](violation-inventory.md) | active | Complete inventory of all encapsulation violations across 7 layers |
-| [assumptions-challenge.md](assumptions-challenge.md) | active | Assumptions challenge for 4 key decisions — risk and blast radius |
+| [assumptions-challenge.md](assumptions-challenge.md) | active | Assumptions challenge for 4 decisions — risk and blast radius |
 
 ## Specs produced
 
@@ -24,7 +25,13 @@ author: socrates
 
 ## Key findings
 
-- `--issue` flag on `iq fsm transition` works correctly — verified manually
-- `issue-start` SKILL.md violates kernel space principle (instructs agents to write state.yaml)
-- Event rename (Decision 2) deferred to separate issue — blast radius too high
-- TRIAGE sub-agent proposed as ARISTOTLE (phronesis + categories)
+- **F1:** The bug is real and ongoing — even a frontier model violated kernel boundary during this session
+- **F2:** Thesis corrected from "method over model" to "clarity through method" — matched to project origin
+- **F3:** `--issue` flag on `iq fsm transition` works correctly — verified manually
+- **F4:** `issue-start` SKILL.md violates kernel space principle (instructs agents to write state.yaml)
+- **F5:** `start_analyze` prechecks empty — validation code exists, contract declaration missing
+- **F6:** Event rename deferred to separate issue — blast radius too high (25+ files)
+- **F7:** TRIAGE sub-agent confirmed as ARISTOTLE (phronesis + categories) — details for PLAN
+- **F8:** `docs/philosophy.md` created as foundational document — governs all specs
+- **F9:** `next_state` removal from JSON is safe — 1 test to update
+- **F10:** Sub-agent YAMLs are clean — violation is in firmware and CLI only

--- a/cleanrooms/152-state-encapsulation-violation/analyze/index.md
+++ b/cleanrooms/152-state-encapsulation-violation/analyze/index.md
@@ -31,7 +31,9 @@ author: socrates
 - **F4:** `issue-start` SKILL.md violates kernel space principle (instructs agents to write state.yaml)
 - **F5:** `start_analyze` prechecks empty — validation code exists, contract declaration missing
 - **F6:** Event rename deferred to separate issue — blast radius too high (25+ files)
-- **F7:** TRIAGE sub-agent confirmed as ARISTOTLE (phronesis + categories) — details for PLAN
+- **F7:** ~~ARISTOTLE~~ invalidated — SOCRATES in two modes (triage + diagnosis) replaces it
 - **F8:** `docs/philosophy.md` created as foundational document — governs all specs
 - **F9:** `next_state` removal from JSON is safe — 1 test to update
 - **F10:** Sub-agent YAMLs are clean — violation is in firmware and CLI only
+- **F11:** Sub-agents are cross-cutting capabilities, not 1:1 state slots — DARWIN everywhere when evolution=true
+- **F12:** IDLE is Dewey's problematization — "analysis before the analysis" is inherent, not a bug

--- a/cleanrooms/152-state-encapsulation-violation/analyze/index.md
+++ b/cleanrooms/152-state-encapsulation-violation/analyze/index.md
@@ -1,0 +1,30 @@
+---
+id: index
+title: "Analysis index — Issue #152: State encapsulation violation"
+date: 2026-04-27
+status: active
+tags: [encapsulation, fsm, idle, triage, firmware]
+author: socrates
+---
+
+# Issue #152 — State Encapsulation Violation
+
+## Documents
+
+| Document | Status | Description |
+|----------|--------|-------------|
+| [violation-inventory.md](violation-inventory.md) | active | Complete inventory of all encapsulation violations across 7 layers |
+| [assumptions-challenge.md](assumptions-challenge.md) | active | Assumptions challenge for 4 key decisions — risk and blast radius |
+
+## Specs produced
+
+| Document | Description |
+|----------|-------------|
+| [docs/spec/state-encapsulation.md](../../../docs/spec/state-encapsulation.md) | State encapsulation principle, system analogies, issue granularity rules, TRIAGE sub-agent design |
+
+## Key findings
+
+- `--issue` flag on `iq fsm transition` works correctly — verified manually
+- `issue-start` SKILL.md violates kernel space principle (instructs agents to write state.yaml)
+- Event rename (Decision 2) deferred to separate issue — blast radius too high
+- TRIAGE sub-agent proposed as ARISTOTLE (phronesis + categories)

--- a/cleanrooms/152-state-encapsulation-violation/analyze/violation-inventory.md
+++ b/cleanrooms/152-state-encapsulation-violation/analyze/violation-inventory.md
@@ -1,0 +1,92 @@
+---
+id: violation-inventory
+title: "Complete inventory of state encapsulation violations"
+date: 2026-04-27
+status: active
+tags: [encapsulation, fsm, idle, triage, firmware, cli]
+author: socrates
+---
+
+# State Encapsulation Violation Inventory
+
+## Principle
+
+> No state knows that other states exist — not their name, not their transition event.
+
+Established for sub-agents in `docs/spec/cooperative-multitasking-model.md` property #4. Never applied to the FSM main states or CLI output.
+
+## Layer 1: Firmware enumerates all 6 states (HIGH)
+
+**File:** `code/cli/assets/agents/inquiry.agent.md` line 14
+
+```
+state: current FSM state (IDLE, ANALYZE, PLAN, EXECUTE, END, EVOLUTION)
+```
+
+IDLE doesn't need to know PLAN exists. Each state should only know about itself.
+
+## Layer 2: CLI instructions are escape routes, not missions (HIGH)
+
+**File:** `code/cli/lib/modules/fsm/commands/state.dart` lines 184-199
+
+| State | Current (escape) | Proposed (mission) |
+|-------|-----------------|-------------------|
+| IDLE | "No active cycle. Use `iq fsm transition --event start_analyze` to begin." | "Evaluate what work merits formal inquiry. Use phronesis: understand the problem, verify/create an issue, prepare infrastructure." |
+| ANALYZE | "socrates is investigating. Produce diagnosis.md, then `iq fsm transition --event complete_analysis`." | "SOCRATES explores the problem through Socratic dialogue. Challenge assumptions. Document findings. Produce diagnosis.md." |
+| PLAN | "descartes is structuring the plan. Produce plan.md, then `iq fsm transition --event approve_plan`." | "DESCARTES structures an experimental design. Divide complexity into phases. Define tests. Order by dependencies. Produce plan.md." |
+| EXECUTE | "basho is implementing. Complete the work, then `iq fsm transition --event finish_execute`." | "BASHŌ implements phase by phase under the plan's formal constraints. Each phase produces a commit." |
+| END | "basho is finalizing. Create PR with `iq fsm transition --event pr_ready`." | "Review the execution report. Authorize closure." |
+| EVOLUTION | "darwin is reviewing mutations.md. Complete with `iq fsm transition --event finish_evolution`." | "DARWIN evaluates the APE process. Observe, compare, select. Create self-improvement issues." |
+
+## Layer 3: JSON exposes next_state (MEDIUM)
+
+**File:** `code/cli/lib/modules/fsm/commands/state.dart` `_computeTransitions`
+
+```json
+"transitions": [{"event": "start_analyze", "next_state": "ANALYZE"}]
+```
+
+The agent doesn't need to know the destination. Options:
+- Remove `next_state` from JSON entirely
+- Keep it but don't expose in prompts (internal use)
+
+## Layer 4: Transition contract enumerates all states (ACCEPTABLE)
+
+**File:** `code/cli/assets/fsm/transition_contract.yaml`
+
+The contract IS the state graph — enumeration is by design. But this data must not leak into agent prompts. The `reason` fields in illegal transitions reinforce state knowledge: "IDLE cannot complete analysis before ANALYZE".
+
+## Layer 5: IDLE has no triage behavior (HIGH)
+
+**File:** `code/cli/assets/agents/inquiry.agent.md` line 22
+
+Current: `If ape is null (IDLE): present transitions[] to user and wait for choice`
+
+Expected (from legacy and specs):
+1. Classify intent (consultation vs modification)
+2. Search for existing issues (`gh issue list --search`)
+3. Guide issue creation if needed
+4. Execute `issue-start` skill
+5. Never mention ANALYZE, PLAN, or EXECUTE
+
+## Layer 6: start_analyze has no prechecks (HIGH)
+
+**File:** `code/cli/assets/fsm/transition_contract.yaml` lines 30-39
+
+```yaml
+prechecks: []  # ← EMPTY
+```
+
+Should be: `[issue_selected_or_created, feature_branch_selected]`
+
+The validation code ALREADY EXISTS in `_validatePreconditions()` in `transition.dart`. Only the contract declaration is missing.
+
+## Layer 7: Build assets empty (LOW)
+
+`code/cli/build/assets/` is empty. Expected to be populated on build. Pre-release OK.
+
+## What works correctly
+
+- Sub-agent YAMLs (socrates, basho, descartes, darwin) — zero references to other FSM states
+- Precondition system — ANALYZE→PLAN, PLAN→EXECUTE, EXECUTE→END all have proper prechecks
+- Sub-agent terminal transitions use `complete` event, not state-name-based events

--- a/cleanrooms/152-state-encapsulation-violation/plan.md
+++ b/cleanrooms/152-state-encapsulation-violation/plan.md
@@ -1,0 +1,127 @@
+# Plan — Issue #152: State encapsulation violation
+
+**Input:** [diagnosis.md](analyze/diagnosis.md)
+
+## Phase 1 — Add prechecks to `start_analyze` (A1)
+
+**Entry:** diagnosis.md approved, branch `152-state-encapsulation-violation` active
+**Risk:** Low — validation code already exists, only contract declaration missing
+
+- [ ] Edit `code/cli/assets/fsm/transition_contract.yaml`: change `prechecks: []` to `prechecks: [issue_selected_or_created, feature_branch_selected]` on the IDLE→ANALYZE transition (line ~38)
+- [ ] Run `dart test` — verify existing precheck tests pass
+- [ ] Manual test: `iq fsm transition --event start_analyze` without `--issue` → should fail with precheck error
+- [ ] Manual test: `iq fsm transition --event start_analyze --issue 152` → should succeed
+
+**Verification:** Transition to ANALYZE is impossible without issue and branch.
+
+---
+
+## Phase 2 — Remove `next_state` from JSON output (A2)
+
+**Entry:** Phase 1 complete
+**Risk:** Low — 1 test to update, nothing reads this field for routing
+
+- [ ] Edit `code/cli/lib/modules/fsm/commands/state.dart` `_computeTransitions`: remove `'next_state': transition.to!.value` from the map, return only `{'event': event.value}`
+- [ ] Edit `code/cli/lib/modules/fsm/commands/state.dart` `toText()`: update the line `buf.writeln('  --${t['event']}--> ${t['next_state']}')` to only show the event name
+- [ ] Edit `code/cli/test/fsm_state_test.dart`: update test `'each transition has event and next_state'` — rename to `'each transition has event'`, remove `expect(t, contains('next_state'))`
+- [ ] Note: `transition.dart` line 77 also outputs `next_state` in its own output — this is the transition command confirming what happened, not leaking future state to the agent. Leave it.
+- [ ] Run `dart test` — all tests pass
+
+**Verification:** `iq fsm state --json` transitions array contains only `{"event": "..."}`, no `next_state`.
+
+---
+
+## Phase 3 — Rewrite `_stateInstructions` as mission descriptions (A3)
+
+**Entry:** Phase 2 complete
+**Risk:** Low — string changes only, no logic
+
+- [ ] Edit `code/cli/lib/modules/fsm/commands/state.dart` `_stateInstructions` map. Replace all 6 values:
+
+| State | New instruction |
+|-------|----------------|
+| IDLE | `Evaluate what work merits inquiry. Understand the problem, search for existing issues, create or select an issue, prepare the branch.` |
+| ANALYZE | `Investigate the problem through structured questioning. Challenge assumptions, gather evidence, explore perspectives. Produce diagnosis.md.` |
+| PLAN | `Design an experimental plan from the diagnosis. Divide into phases, order by dependencies, define verification for each. Produce plan.md.` |
+| EXECUTE | `Implement the plan phase by phase under its formal constraints. Each phase produces tested code and a commit.` |
+| END | `Review the execution. Create the pull request.` |
+| EVOLUTION | `Evaluate the completed cycle. Observe what worked, what deviated, what can improve. Create improvement issues.` |
+
+- [ ] Run `dart test` — no tests assert on instruction text content (verified)
+
+**Verification:** `iq fsm state --json` `instructions` field contains mission description, no event names or command hints.
+
+---
+
+## Phase 4 — Update `issue-start` skill to use CLI (A4)
+
+**Entry:** Phase 1 complete (prechecks active)
+**Risk:** Low — text change in skill file
+
+- [ ] Edit `code/cli/assets/skills/issue-start/SKILL.md` Step 7: replace "Write `.inquiry/state.yaml`" block with: "Execute `iq fsm transition --event start_analyze --issue <NNN>` — this transitions the FSM and auto-activates SOCRATES."
+- [ ] Remove the raw YAML template from Step 7
+- [ ] Edit Step 8: remove `[APE: ANALYZE]` announcement — the scheduler reads state from CLI, not from skill output
+- [ ] Edit Verification section: replace "State updated: `.inquiry/state.yaml` shows `phase: ANALYZE`" with "State updated: `iq fsm state` shows `ANALYZE`"
+- [ ] Sync: copy updated skill to `code/cli/build/assets/skills/issue-start/SKILL.md`
+
+**Verification:** Skill text contains no direct writes to `.inquiry/`.
+
+---
+
+## Phase 5 — Activate SOCRATES in IDLE (B1)
+
+**Entry:** Phases 1-4 complete
+**Risk:** Medium — new sub-FSM definition, changes to 3 mapping files
+**Depends on:** Phase 3 (IDLE instruction must exist before SOCRATES gets activated there)
+
+- [ ] Create `code/cli/assets/apes/socrates-idle.yaml` — SOCRATES triage-mode definition:
+  - Same `base_prompt` reference or reduced triage-focused prompt
+  - `initial_state: evaluate_scope`
+  - States: `evaluate_scope → search_existing → create_or_select → confirm → _DONE`
+  - Each state has a triage-focused prompt (scope assessment, issue search, issue creation, confirmation)
+- [ ] Edit `code/cli/lib/modules/fsm/effect_executor.dart` `_stateApes`: add `'IDLE': 'socrates-idle'`
+- [ ] Edit `code/cli/lib/modules/fsm/commands/state.dart` `_stateApes`: add `FsmState.idle: [{'name': 'socrates-idle', 'status': 'RUNNING'}]`
+- [ ] Edit `code/cli/lib/modules/ape/commands/prompt.dart` `_stateApes`: add `FsmState.idle: ['socrates-idle']`
+- [ ] Add test: `dart test` — IDLE state now shows `socrates-idle` as active APE
+- [ ] Add test: `iq ape prompt --name socrates-idle` in IDLE state returns triage prompt
+- [ ] Manual test: enter IDLE → `iq fsm state --json` shows `ape: {name: socrates-idle, state: evaluate_scope}`
+
+**Verification:** IDLE has an active sub-agent. Entering IDLE auto-activates SOCRATES in triage mode.
+
+**Design note:** Using `socrates-idle` as a separate YAML rather than mode-switching on `socrates` keeps the current architecture intact. The conceptual principle (SOCRATES is one thinking tool in two modes) is preserved in naming. The full multi-mode infrastructure is a larger refactor tracked in #154.
+
+---
+
+## Phase 6 — Rewrite firmware (B2)
+
+**Entry:** Phase 5 complete
+**Risk:** Medium — the firmware is what the agent reads first; errors degrade all behavior
+**Depends on:** All previous phases (firmware must reflect the new CLI behavior)
+
+- [ ] Rewrite `code/cli/assets/agents/inquiry.agent.md`:
+  - Remove all state name enumerations
+  - Boot section: run `iq fsm state --json`, parse `state`, `issue`, `instructions`, `transitions`, `ape`
+  - Outer Loop: announce `[INQUIRY]`, read `instructions` field, if `ape` active → Inner Loop, if no ape → follow instructions and present transitions
+  - Inner Loop: unchanged (already generic)
+  - Rules: unchanged (kernel boundary rule already present)
+  - Remove `description` field reference to specific state names if present
+- [ ] Sync: copy to `code/cli/build/assets/agents/inquiry.agent.md`
+- [ ] Manual test: verify `iq fsm state --json` output in IDLE → firmware dispatches SOCRATES triage
+- [ ] Manual test: verify ANALYZE → firmware dispatches SOCRATES analysis
+
+**Verification:** Firmware text contains zero state names (IDLE, ANALYZE, PLAN, EXECUTE, END, EVOLUTION). Grep confirms.
+
+---
+
+## Phase 7 — Final validation
+
+**Entry:** All phases complete
+**Risk:** None — read-only verification
+
+- [ ] `dart analyze` — no warnings
+- [ ] `dart test` — all tests pass
+- [ ] `iq fsm state --json` in IDLE — no `next_state`, mission instruction, `socrates-idle` active
+- [ ] `iq fsm state --json` in ANALYZE — no `next_state`, mission instruction, `socrates` active
+- [ ] Grep firmware for state names — zero matches
+- [ ] Grep `issue-start/SKILL.md` for `state.yaml` — zero matches
+- [ ] Commit all changes

--- a/cleanrooms/152-state-encapsulation-violation/plan.md
+++ b/cleanrooms/152-state-encapsulation-violation/plan.md
@@ -125,3 +125,18 @@
 - [ ] Grep firmware for state names — zero matches
 - [ ] Grep `issue-start/SKILL.md` for `state.yaml` — zero matches
 - [ ] Commit all changes
+
+---
+
+## Phase 8 — QA: Remove `to` from APE sub-FSM transitions
+
+**Entry:** Phase 7 complete (QA smoke test found the bug)
+**Risk:** Low — single line change, no tests assert on `to` in APE transitions
+**Discovery:** Manual QA simulation revealed that `_computeApeInfo` in `state.dart` was emitting `{"event": "next", "to": "assumptions"}` for APE sub-FSM transitions — the same encapsulation violation fixed in Phase 2 for the main FSM, but missed at the APE level.
+
+- [x] Edit `code/cli/lib/modules/fsm/commands/state.dart` line 220: change `.map((t) => {'event': t.event, 'to': t.to})` to `.map((t) => {'event': t.event})`
+- [x] `dart analyze` — no warnings
+- [x] `dart test` — 300/300 pass (no tests asserted on `to` field)
+- [x] QA: full cycle simulation — IDLE, ANALYZE, PLAN, EXECUTE all confirmed: APE transitions show only `{"event": "..."}`, no `to` field
+
+**Verification:** `iq fsm state --json` in any state with active APE — sub-FSM transitions contain only `{"event": "..."}`, no destination state.

--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.0]
+### Changed
+- **State encapsulation** (#152): `iq fsm state --json` transitions no longer expose `next_state` — agents see only available events
+- **APE sub-FSM encapsulation** (#152): APE transitions no longer expose `to` destination state
+- **Mission descriptions** (#152): `instructions` field contains mission objectives, not event names or CLI hints
+- **Firmware v0.3.0** (#152): state-agnostic generic dispatch loop — zero state or sub-agent names hardcoded
+- **SOCRATES in IDLE** (#152): `socrates-idle` triage sub-agent activates automatically in IDLE state
+
+### Fixed
+- **issue-start skill** (#152): uses `iq fsm transition` instead of writing `.inquiry/state.yaml` directly
+- **start_analyze prechecks** (#152): requires `issue_selected_or_created` and `feature_branch_selected`
+
 ## [0.2.1]
 ### Added
 - **`completion_authority`**: FSM contract and `iq fsm state --json` output now include per-state `completion_authority` field (`user` | `automatic`) — the scheduler reads this to know whether to ask the user or transition immediately

--- a/code/cli/assets/agents/inquiry.agent.md
+++ b/code/cli/assets/agents/inquiry.agent.md
@@ -1,30 +1,33 @@
 ---
 name: inquiry
-description: 'Inquiry — Analyze. Plan. Execute. A strict six-state FSM scheduler for structured task delivery. Dispatches sub-agents (SOCRATES, DESCARTES, BASHŌ, DARWIN). Starts in IDLE, transitions only with explicit user authorization.'
+description: 'Inquiry — a strict FSM scheduler for structured task delivery. Dispatches sub-agents as thinking tools. Transitions only with explicit user authorization.'
 tools: [vscode, execute, read, agent, edit, search, web, browser, todo]
 ---
 
-# Inquiry Scheduler — Firmware v0.2.0
+# Inquiry Scheduler — Firmware v0.3.0
 
 You are a **scheduler**. You operate a dual FSM (main + per-APE). You never think, analyze, plan, or implement yourself — sub-agents do that. You orchestrate via CLI commands only.
 
 ## Boot
 
 Run `iq fsm state --json` to read current state. Parse the JSON:
-- `state`: current FSM state (IDLE, ANALYZE, PLAN, EXECUTE, END, EVOLUTION)
-- `issue`: active issue number (null if IDLE)
+- `state`: current FSM state
+- `issue`: active issue number (null when no cycle is active)
+- `instructions`: mission description for the current state
 - `transitions[]`: valid FSM events from this state
+- `completion_authority`: `"user"` or `"automatic"`
 - `ape`: active sub-agent `{name, state, transitions[]}` or null
 
 ## Outer Loop (Main FSM)
 
-1. Announce state: `[INQUIRY: <state>]`
-2. If `ape` is null (IDLE): present `transitions[]` to user and wait for choice
+1. Announce state: `[INQUIRY]`
+2. Read `instructions` — this describes what the current state does
 3. If `ape` is active: enter Inner Loop
-4. After APE reaches `_DONE`: read `completion_authority` from JSON output:
-   - If `"user"`: ask ONE yes/no question to confirm the state is complete, then `iq fsm transition --event <event>`.
-   - If `"automatic"`: `iq fsm transition --event <event>` immediately.
-5. After transition: re-run `iq fsm state --json` and loop
+4. If `ape` is null: follow `instructions` and present `transitions[]` to user
+5. After APE reaches `_DONE`: read `completion_authority`:
+   - If `"user"`: ask ONE yes/no question to confirm, then `iq fsm transition --event <event>`
+   - If `"automatic"`: `iq fsm transition --event <event>` immediately
+6. After transition: re-run `iq fsm state --json` and loop
 
 ## Inner Loop (Per-APE FSM)
 
@@ -32,7 +35,7 @@ Run `iq fsm state --json` to read current state. Parse the JSON:
 2. **Dispatch** that sub-agent: use the `agent` tool to invoke `@<ape.name>` with the prompt as context. Do NOT perform the sub-agent's work yourself. Do NOT render its output in chat.
 3. Wait for the sub-agent to signal completion (it will announce its sub-phase is done).
 4. When signaled: `iq ape transition --event <event>` to advance the sub-FSM.
-5. If `ape.state` becomes `_DONE`: exit Inner Loop, return to Outer Loop step 4.
+5. If `ape.state` becomes `_DONE`: exit Inner Loop, return to Outer Loop step 5.
 
 ## Rules
 
@@ -40,3 +43,4 @@ Run `iq fsm state --json` to read current state. Parse the JSON:
 - If a command fails, report the error and offer retry.
 - If you are unsure of your state, run `iq fsm state --json`.
 - One sub-phase at a time. Complete it before transitioning.
+- Do not enumerate states, transitions, or sub-agent names from memory. Read them from the CLI output.

--- a/code/cli/assets/apes/socrates-idle.yaml
+++ b/code/cli/assets/apes/socrates-idle.yaml
@@ -1,0 +1,85 @@
+name: socrates-idle
+version: "0.2.0"
+description: "Issue triage via Socratic method — Dewey's problematization"
+
+initial_state: evaluate_scope
+
+base_prompt: |
+  You are SOCRATES, applying the Socratic method to evaluate whether a problem merits formal inquiry.
+
+  ## Mindset
+
+  - EPISTEMIC HUMILITY: Do not assume the problem is clear. Even if it seems obvious, question it.
+  - PROBLEMATIZATION: Your task is Dewey's first act of inquiry — converting an indeterminate situation into a well-formulated problem.
+  - GRANULARITY: A good issue changes one thing for one reason. If the problem has independent parts, they are separate issues.
+  - DEDUPLICATION: Before creating, search. The problem may already be tracked.
+
+  ## Behavior
+
+  DO:
+  - Ask what the user wants to accomplish
+  - Challenge scope: "Is this one problem or several?"
+  - Search for existing issues: "Has this been reported before?"
+  - Help formulate a clear issue title and description
+  - Verify the issue is actionable and well-scoped
+
+  DO NOT:
+  - Analyze root causes — that is for the ANALYZE phase
+  - Propose solutions or plans
+  - Create branches, directories, or files
+  - Write to `.inquiry/` — all state mutations go through `iq` commands
+
+  ## Response Structure
+
+  1. Understand what the user is bringing (bug, feature, improvement, question)
+  2. Question scope and granularity
+  3. Search for existing related issues
+  4. Guide toward a clear, actionable issue
+  5. Confirm the issue is ready for formal inquiry
+
+states:
+  evaluate_scope:
+    description: "Understand what the user wants — is it one problem or many?"
+    transitions:
+      - event: next
+        to: search_existing
+      - event: skip
+        to: create_or_select
+    prompt: |
+      FOCUS: Scope evaluation. Understand the problem space.
+      Ask: "What are you trying to solve?", "Is this one issue or several?", "What changed or broke?"
+
+  search_existing:
+    description: "Search for existing issues that match"
+    transitions:
+      - event: next
+        to: create_or_select
+      - event: back
+        to: evaluate_scope
+    prompt: |
+      FOCUS: Deduplication. Search before creating.
+      Use: `gh issue list --search "<keywords>"` to find existing issues.
+      Ask: "Does any existing issue cover this?", "Should we extend an existing issue or create new?"
+
+  create_or_select:
+    description: "Create a new issue or select an existing one"
+    transitions:
+      - event: next
+        to: confirm
+      - event: back
+        to: search_existing
+    prompt: |
+      FOCUS: Issue formulation. Create or select.
+      If creating: help write a clear title and description. One problem, one reason.
+      If selecting: confirm the existing issue matches the user's intent.
+
+  confirm:
+    description: "Confirm the issue is ready for formal inquiry"
+    transitions:
+      - event: complete
+        to: _DONE
+      - event: back
+        to: create_or_select
+    prompt: |
+      FOCUS: Confirmation. Verify readiness.
+      Ask: "Is this issue well-scoped?", "Is the title clear?", "Are we ready to begin analysis?"

--- a/code/cli/assets/fsm/transition_contract.yaml
+++ b/code/cli/assets/fsm/transition_contract.yaml
@@ -35,7 +35,7 @@ transitions:
     to: ANALYZE
     allowed: true
     operations:
-      prechecks: []
+      prechecks: [issue_selected_or_created, feature_branch_selected]
       effects: [open_analysis_context, reset_mutations, snapshot_metrics]
       artifacts: [analysis/index.md, .inquiry/metrics_snapshot.yaml]
       commit_policy: none

--- a/code/cli/assets/skills/issue-start/SKILL.md
+++ b/code/cli/assets/skills/issue-start/SKILL.md
@@ -106,31 +106,19 @@ Create `cleanrooms/<NNN>-<slug>/analyze/index.md` with this template:
 |---|------|-------------|
 ```
 
-### Step 7: Update state.yaml
+### Step 7: Transition to ANALYZE
 
-Write `.inquiry/state.yaml` with:
-
-```yaml
-cycle:
-  phase: ANALYZE
-  task: "<NNN>"
-
-ready: []
-waiting: []
-complete: []
-```
-
-Use the same raw string write pattern as `inquiry init` does.
-
-### Step 8: Announce Transition
-
-Output the state announcement:
+Execute the CLI transition command with the issue number:
 
 ```
-[APE: ANALYZE]
+iq fsm transition --event start_analyze --issue <NNN>
 ```
 
-The scheduler is now in ANALYZE state and should invoke SOCRATES for analysis work.
+This transitions the FSM to ANALYZE and auto-activates the analysis sub-agent. Do NOT write `.inquiry/state.yaml` directly — all state mutations go through `iq` commands.
+
+### Step 8: Verify Transition
+
+Run `iq fsm state` to confirm the state is now ANALYZE with the correct issue number.
 
 ## Verification
 
@@ -138,7 +126,7 @@ After completing all steps, verify:
 
 - [ ] Branch exists: `git branch --show-current` returns `<NNN>-<slug>`
 - [ ] Directory exists: `cleanrooms/<NNN>-<slug>/analyze/index.md`
-- [ ] State updated: `.inquiry/state.yaml` shows `phase: ANALYZE`
+- [ ] State updated: `iq fsm state` shows ANALYZE with the issue number
 
 ## Notes
 

--- a/code/cli/lib/modules/ape/commands/prompt.dart
+++ b/code/cli/lib/modules/ape/commands/prompt.dart
@@ -87,7 +87,7 @@ class ApePromptCommand implements Command<ApePromptInput, ApePromptOutput> {
 
   /// Maps FSM states to their active sub-agent names.
   static const _stateApes = <FsmState, List<String>>{
-    FsmState.idle: [],
+    FsmState.idle: ['socrates-idle'],
     FsmState.analyze: ['socrates'],
     FsmState.plan: ['descartes'],
     FsmState.execute: ['basho'],

--- a/code/cli/lib/modules/fsm/commands/state.dart
+++ b/code/cli/lib/modules/fsm/commands/state.dart
@@ -217,7 +217,7 @@ class FsmStateCommand implements Command<FsmStateInput, FsmStateOutput> {
         final apeState = def.findState(subState);
         if (apeState != null) {
           result['transitions'] = apeState.transitions
-              .map((t) => {'event': t.event, 'to': t.to})
+              .map((t) => {'event': t.event})
               .toList();
         }
       }

--- a/code/cli/lib/modules/fsm/commands/state.dart
+++ b/code/cli/lib/modules/fsm/commands/state.dart
@@ -72,7 +72,7 @@ class FsmStateOutput extends Output {
     if (transitions.isNotEmpty) {
       buf.writeln('Valid transitions:');
       for (final t in transitions) {
-        buf.writeln('  --${t['event']}--> ${t['next_state']}');
+        buf.writeln('  --${t['event']}');
       }
     }
     return buf.toString().trimRight();
@@ -133,7 +133,6 @@ class FsmStateCommand implements Command<FsmStateInput, FsmStateOutput> {
       if (transition != null && transition.allowed && transition.to != null) {
         result.add({
           'event': event.value,
-          'next_state': transition.to!.value,
         });
       }
     }

--- a/code/cli/lib/modules/fsm/commands/state.dart
+++ b/code/cli/lib/modules/fsm/commands/state.dart
@@ -182,17 +182,17 @@ class FsmStateCommand implements Command<FsmStateInput, FsmStateOutput> {
 
   static const _stateInstructions = <FsmState, String>{
     FsmState.idle:
-        'IDLE: No active cycle. Use `iq fsm transition --event start_analyze` to begin.',
+        'Evaluate what work merits inquiry. Understand the problem, search for existing issues, create or select an issue, prepare the branch.',
     FsmState.analyze:
-        'ANALYZE: socrates is investigating. Produce diagnosis.md, then `iq fsm transition --event complete_analysis`.',
+        'Investigate the problem through structured questioning. Challenge assumptions, gather evidence, explore perspectives. Produce diagnosis.md.',
     FsmState.plan:
-        'PLAN: descartes is structuring the plan. Produce plan.md, then `iq fsm transition --event approve_plan`.',
+        'Design an experimental plan from the diagnosis. Divide into phases, order by dependencies, define verification for each. Produce plan.md.',
     FsmState.execute:
-        'EXECUTE: basho is implementing. Complete the work, then `iq fsm transition --event finish_execute`.',
+        'Implement the plan phase by phase under its formal constraints. Each phase produces tested code and a commit.',
     FsmState.end:
-        'END: basho is finalizing. Create PR with `iq fsm transition --event pr_ready`.',
+        'Review the execution. Create the pull request.',
     FsmState.evolution:
-        'EVOLUTION: darwin is reviewing mutations.md. Complete with `iq fsm transition --event finish_evolution`.',
+        'Evaluate the completed cycle. Observe what worked, what deviated, what can improve. Create improvement issues.',
   };
 
   String _computeInstructions(FsmState state) {

--- a/code/cli/lib/modules/fsm/commands/state.dart
+++ b/code/cli/lib/modules/fsm/commands/state.dart
@@ -168,7 +168,7 @@ class FsmStateCommand implements Command<FsmStateInput, FsmStateOutput> {
   }
 
   static const _stateApes = <FsmState, List<Map<String, String>>>{
-    FsmState.idle: [],
+    FsmState.idle: [{'name': 'socrates-idle', 'status': 'RUNNING'}],
     FsmState.analyze: [{'name': 'socrates', 'status': 'RUNNING'}],
     FsmState.plan: [{'name': 'descartes', 'status': 'RUNNING'}],
     FsmState.execute: [{'name': 'basho', 'status': 'RUNNING'}],

--- a/code/cli/lib/modules/fsm/commands/transition.dart
+++ b/code/cli/lib/modules/fsm/commands/transition.dart
@@ -143,6 +143,7 @@ class StateTransitionCommand
     final precheckResult = await _validatePreconditions(
       transition,
       input.workingDirectory,
+      inputIssue: input.issue,
     );
     if (precheckResult != null) {
       return StateTransitionOutput(
@@ -193,11 +194,13 @@ class StateTransitionCommand
 
   Future<String?> _validatePreconditions(
     FsmTransition transition,
-    String workingDirectory,
-  ) async {
+    String workingDirectory, {
+    String? inputIssue,
+  }) async {
     final prechecks = transition.operations?.prechecks ?? const <String>[];
     final branch = await branchProvider(workingDirectory);
-    final issueSelected = _isIssueSelected(workingDirectory);
+    final issueSelected = _isIssueSelected(workingDirectory) ||
+        (inputIssue != null && inputIssue.trim().isNotEmpty);
 
     if ((prechecks.contains('issue_selected') ||
             prechecks.contains('issue_selected_or_created')) &&

--- a/code/cli/lib/modules/fsm/effect_executor.dart
+++ b/code/cli/lib/modules/fsm/effect_executor.dart
@@ -32,6 +32,7 @@ class EffectExecutor {
 
   /// Maps FSM states to their active sub-agent names.
   static const _stateApes = <String, String>{
+    'IDLE': 'socrates-idle',
     'ANALYZE': 'socrates',
     'PLAN': 'descartes',
     'EXECUTE': 'basho',

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.2.1';
+const String inquiryVersion = '0.3.0';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.2.1
+version: 0.3.0
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/effect_executor_test.dart
+++ b/code/cli/test/effect_executor_test.dart
@@ -224,9 +224,14 @@ void main() {
         expect(content, contains('state: clarification'));
       });
 
-      test('writes ape null when transitioning to IDLE', () {
+      test('activates socrates-idle when transitioning to IDLE', () {
         File('${tempDir.path}/.inquiry/state.yaml')
             .writeAsStringSync('state: EVOLUTION\nissue: "145"\n');
+
+        final apesDir = Directory('${tempDir.path}/assets/apes');
+        apesDir.createSync(recursive: true);
+        File('assets/apes/socrates-idle.yaml')
+            .copySync('${apesDir.path}/socrates-idle.yaml');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.updateState('IDLE');
@@ -234,7 +239,8 @@ void main() {
         final content =
             File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
         expect(content, contains('state: IDLE'));
-        expect(content, contains('ape: null'));
+        expect(content, contains('name: socrates-idle'));
+        expect(content, contains('state: evaluate_scope'));
       });
 
       test('activates descartes when transitioning to PLAN', () {

--- a/code/cli/test/fsm_state_test.dart
+++ b/code/cli/test/fsm_state_test.dart
@@ -200,7 +200,7 @@ void main() {
     });
 
     group('instructions', () {
-      test('ANALYZE instructions reference socrates', () async {
+      test('ANALYZE instructions describe the mission', () async {
         setupWorkspace(state: 'ANALYZE', issue: '145');
 
         final command = FsmStateCommand(FsmStateInput(
@@ -208,10 +208,11 @@ void main() {
         ));
         final result = await command.execute();
 
-        expect(result.toJson()['instructions'], contains('socrates'));
+        expect(result.toJson()['instructions'], contains('Investigate'));
+        expect(result.toJson()['instructions'], contains('diagnosis.md'));
       });
 
-      test('IDLE instructions mention start_analyze', () async {
+      test('IDLE instructions describe triage mission', () async {
         setupWorkspace(state: 'IDLE');
 
         final command = FsmStateCommand(FsmStateInput(
@@ -219,7 +220,8 @@ void main() {
         ));
         final result = await command.execute();
 
-        expect(result.toJson()['instructions'], contains('start_analyze'));
+        expect(result.toJson()['instructions'], contains('Evaluate'));
+        expect(result.toJson()['instructions'], contains('inquiry'));
       });
     });
 

--- a/code/cli/test/fsm_state_test.dart
+++ b/code/cli/test/fsm_state_test.dart
@@ -116,7 +116,7 @@ void main() {
         expect(events, isNot(contains('complete_analysis')));
       });
 
-      test('each transition has event and next_state', () async {
+      test('each transition has event only', () async {
         setupWorkspace(state: 'PLAN', issue: '145');
 
         final command = FsmStateCommand(FsmStateInput(
@@ -127,7 +127,7 @@ void main() {
 
         for (final t in transitions) {
           expect(t, contains('event'));
-          expect(t, contains('next_state'));
+          expect(t.keys, isNot(contains('next_state')));
         }
       });
     });

--- a/code/cli/test/fsm_state_test.dart
+++ b/code/cli/test/fsm_state_test.dart
@@ -147,7 +147,7 @@ void main() {
         expect(apes[0]['status'], equals('RUNNING'));
       });
 
-      test('IDLE has no active APEs', () async {
+      test('IDLE has socrates-idle active', () async {
         setupWorkspace(state: 'IDLE');
 
         final command = FsmStateCommand(FsmStateInput(
@@ -156,7 +156,8 @@ void main() {
         final result = await command.execute();
         final apes = result.toJson()['apes'] as List;
 
-        expect(apes, isEmpty);
+        expect(apes, hasLength(1));
+        expect(apes.first['name'], equals('socrates-idle'));
       });
 
       test('PLAN has descartes running', () async {

--- a/code/cli/test/fsm_transition_test.dart
+++ b/code/cli/test/fsm_transition_test.dart
@@ -88,7 +88,7 @@ void main() {
       expect(output.message, contains('ERROR_PRECONDITION_ISSUE_FIRST'));
     });
 
-    test('allows IDLE exploration transition without issue context', () async {
+    test('blocks IDLE to ANALYZE without issue context', () async {
       _writeState(tempDir.path, 'IDLE');
 
       final input = StateTransitionInput(
@@ -98,7 +98,27 @@ void main() {
       );
       final command = StateTransitionCommand(
         input,
-        branchProvider: (_) async => 'main',
+        branchProvider: (_) async => '152-feature-branch',
+      );
+
+      final output = await command.execute();
+
+      expect(output.allowed, isFalse);
+      expect(output.message, contains('ERROR_PRECONDITION_ISSUE_FIRST'));
+    });
+
+    test('allows IDLE to ANALYZE with issue and feature branch', () async {
+      _writeState(tempDir.path, 'IDLE');
+
+      final input = StateTransitionInput(
+        currentState: null,
+        event: 'start_analyze',
+        issue: '152',
+        workingDirectory: tempDir.path,
+      );
+      final command = StateTransitionCommand(
+        input,
+        branchProvider: (_) async => '152-feature-branch',
       );
 
       final output = await command.execute();
@@ -176,7 +196,7 @@ void main() {
       );
       final command = StateTransitionCommand(
         input,
-        branchProvider: (_) async => 'main',
+        branchProvider: (_) async => '31-feature-branch',
       );
 
       final output = await command.execute();

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More targets coming soon.</p>
-      <span class="badge">v0.2.1</span>
+      <span class="badge">v0.3.0</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,9 @@ Top-level navigation for the repository documentation.
 
 | Path | Role |
 |------|------|
+| [philosophy.md](philosophy.md) | **Foundational document** — the five convictions, epistemic principles, and design invariants that govern all decisions |
 | [architecture.md](architecture.md) | Current system-level explanation of APE as orchestrating methodology |
+| [timeline.md](timeline.md) | Origin story: from communication problem to methodology to CLI |
 | [thinking-tools.md](thinking-tools.md) | Current canonical explainer for Thinking Tools |
 | [lore.md](lore.md) | Nomenclature, allegory, and historical context for the named agents |
 | [roadmap.md](roadmap.md) | Strategic direction and long-term theses |

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,0 +1,125 @@
+# Philosophy
+
+> This is the foundational document of the Inquiry project. Every specification, architecture decision, and implementation choice must be traceable to the principles stated here. When two specs contradict each other, this document arbitrates. When a new feature is proposed, this document is the litmus test.
+
+## The thesis
+
+**The bottleneck in AI-assisted development is not AI capability — it is human clarity.**
+
+The AI assumes things you didn't say. It misinterprets ambiguous requests. It produces plausible but wrong solutions with absolute confidence. And most of the time, the fault is yours — you expressed yourself with the ambiguity natural to human language and expected the machine to read your intent. It didn't. It read your words.
+
+Inquiry exists to solve this communication problem. It is a method for **thinking clearly before the AI acts** — so that when it acts, it produces code you recognize as your own. Not because you wrote it, but because you designed it. Every decision was made during analysis and planning. The AI implemented your design, following your conventions, under your constraints.
+
+The methodology doesn't replace the engineer — it amplifies them.
+
+## What Inquiry is
+
+Inquiry is a methodology that treats software development as an instance of **philosophical inquiry** in the pragmatist tradition.
+
+Every development cycle is an inquiry in Dewey's precise sense:
+
+> "Inquiry is the controlled or directed transformation of an indeterminate situation into one that is so determinate in its constituent distinctions and relations as to convert the elements of the original situation into a unified whole." — John Dewey, *Logic: The Theory of Inquiry* (1938)
+
+A GitHub issue is an indeterminate situation. A merged pull request is a determinate unified whole. The APE cycle is the controlled transformation between them.
+
+This is not a metaphor. It is an isomorphism:
+
+| Pragmatist inquiry | Inquiry cycle |
+|-------------------|---------------|
+| Indeterminate situation | Open issue |
+| Abduction (hypothesis) | ANALYZE — SOCRATES generates diagnosis |
+| Deduction (experimental design) | PLAN — DESCARTES derives the plan |
+| Induction (empirical test) | EXECUTE — BASHŌ implements and verifies |
+| Determinate unified whole | Merged PR |
+
+The three modes of inference — abduction, deduction, induction — are not optional stages. They are **epistemically necessary**. You cannot plan what you have not understood (abduction before deduction). You cannot verify what you have not planned (deduction before induction). You cannot understand without questioning what you assume (abduction requires Socratic humility). Peirce proved this cycle is the structure of all scientific inquiry. We apply it to software.
+
+## The five convictions
+
+### 1. Clarity through method
+
+The typical failures of AI-assisted development — hallucination, loss of context, unauthorized changes, code that doesn't match intent — are not failures of AI capability. They are failures of **human communication**. The developer says something ambiguous. The AI interprets literally. The result surprises the developer. The developer blames the AI.
+
+Inquiry breaks this cycle by forcing clarity *before* the AI acts. The analysis phase eliminates ambiguity — you cannot plan what you have not understood. The plan phase makes the solution explicit — by the time execution starts, the problem is already solved. What remains is mechanical transcription from a clear specification into code.
+
+The method liberates the mind. Instead of holding the entire problem in your head while also writing code, you externalize your thinking into structured artifacts: diagnosis documents, step-by-step plans, test specifications. The AI then executes against those artifacts, not against your vague intent. The thinking tools — Socratic questioning, Cartesian decomposition, constraint-aware implementation — are the instruments that make this externalization rigorous.
+
+### 2. Memory as code
+
+Project knowledge belongs in the repository, version-controlled, readable by any agent, owned by the developer. Not in a cloud-hosted vector database. Not in a chat history that evaporates. Not in a proprietary model's context window.
+
+`.inquiry/` is the runtime state. `cleanrooms/` are the epistemic artifacts. `docs/` is the canonical doctrine. Everything is markdown, YAML, or code. Everything is `git diff`-able. Everything survives the disappearance of any vendor.
+
+### 3. The kernel boundary
+
+`.inquiry/` is kernel space. Agents are userspace.
+
+Just as Linux processes do not write to `/proc/` — the kernel manages that state — agents do not write to `.inquiry/`. All state mutations go through `iq` commands. Skills and prompts must never instruct agents to modify `.inquiry/` files directly.
+
+This boundary exists because **trust must be verified, not assumed**. The CLI validates preconditions before every transition. The CLI enforces the contract. The agent proposes; the CLI disposes. If the agent hallucinates a state change, the CLI rejects it. The kernel is the last line of defense.
+
+### 4. States are worlds
+
+Each FSM state is a complete, self-contained world. It has a mission, a sub-agent, and artifacts. It does not know that other states exist. It does not know their names, their events, or their transitions.
+
+The scheduler sees the full graph. The state sees only itself. This is not an implementation detail — it is an **epistemic principle**. SOCRATES must not know about PLAN because knowing about PLAN corrupts analysis. If you analyze a problem while already thinking about how to plan it, you shortcut the abductive process. You confirm instead of questioning. You converge instead of exploring.
+
+Encapsulation is not about code hygiene. It is about **preserving the integrity of each mode of inference**.
+
+### 5. Evolution is built-in
+
+The system must improve itself through its own operation. DARWIN is not an afterthought — it is the reason the system can survive.
+
+Every completed cycle generates evidence: what worked, what failed, what was harder than expected. DARWIN reads this evidence and proposes mutations to Inquiry itself. The mutations that improve the process survive. The mutations that don't are discarded. This is natural selection applied to methodology.
+
+The end-state is a system where every cycle leaves the framework measurably better than before. Not by design — by selection.
+
+## The named agents as thinking tools
+
+The sub-agents are not arbitrary characters. Each name identifies a **thinking tool** — a method of reasoning drawn from a specific philosopher, culture, and era:
+
+| Agent | Thinker | Era | Culture | Tool | Essence |
+|-------|---------|-----|---------|------|---------|
+| ARISTOTLE | Aristotle (384–322 BC) | Classical | Greek | **Phronesis** — practical wisdom + **Categories** — systematic classification | To know what merits action and how to scope it |
+| SOCRATES | Socrates (470–399 BC) | Classical | Greek | **Mayéutica** — truth through questioning | To understand before solving |
+| DESCARTES | René Descartes (1596–1650) | Early Modern | French | **The Method** — divide, order, verify, enumerate | To decompose until execution is mechanical |
+| BASHŌ | Matsuo Bashō (1644–1694) | Edo period | Japanese | **Techne + 用の美** — functional beauty under constraint | To create within limits, where constraint reveals elegance |
+| DARWIN | Charles Darwin (1809–1882) | Victorian | English | **Natural selection** — observe, compare, select | To improve without a designer |
+
+This diversity is intentional. The tools span 2,400 years, four cultures, and five disciplines (philosophy, epistemology, mathematics, poetry, biology). The thesis: **the best methodology for building software already exists, scattered across human intellectual history. Inquiry assembles it.**
+
+## The name
+
+The project is called Inquiry because that is what it does. Not "AI coding assistant." Not "agent framework." Not "prompt engineering toolkit." It conducts inquiry — the disciplined transformation of doubt into knowledge, of problems into solutions, of indeterminate situations into determinate unified wholes.
+
+**Inquiry** names the cycle-level process. **APE** (Analyze-Plan-Execute) names the orchestrating methodology. **Finite APE Machine** names the engineered finite-state system that makes the methodology operational. The philosophy precedes the engineering. The engineering serves the philosophy.
+
+The banner phrase captures this lineage:
+
+> Infinite monkeys produce noise. Finite APEs produce software.
+
+The infinite monkey theorem says that random input eventually produces any text — given infinite time. Inquiry rejects randomness. A finite number of disciplined agents, following a structured method, produce working software in finite time. The constraint is the point. The method is the machine.
+
+## Implications for design decisions
+
+When evaluating any change to Inquiry, apply these tests in order:
+
+1. **Does it respect the kernel boundary?** If agents write to `.inquiry/` directly, reject it.
+2. **Does it preserve state encapsulation?** If a state learns about other states, reject it.
+3. **Does it maintain the epistemic sequence?** If analysis is skipped or planning is merged with execution, reject it.
+4. **Does it force clarity before action?** If the AI can act without the developer having articulated a clear, unambiguous intent, the method has failed.
+5. **Does it leave evidence for DARWIN?** If the cycle produces no measurable artifacts, the system cannot improve itself.
+
+These are not guidelines. They are invariants. Violating them is a bug.
+
+## References
+
+- Peirce, C.S. (1878). "Deduction, Induction, and Hypothesis." *Popular Science Monthly*, 13, 470–482.
+- Peirce, C.S. (1903). "Pragmatism as a Principle and Method of Right Thinking." *Harvard Lectures on Pragmatism*.
+- Dewey, J. (1938). *Logic: The Theory of Inquiry*. Henry Holt and Company.
+- Dewey, J. (1910). *How We Think*. D.C. Heath.
+- Aristotle. *Nicomachean Ethics*, Book VI. Phronesis as practical wisdom.
+- Aristotle. *Categories* (Κατηγορίαι). The first systematic taxonomy.
+- Descartes, R. (1637). *Discours de la méthode*. Ian Maire, Leiden.
+- Linux kernel documentation. "Submitting patches." https://www.kernel.org/doc/html/latest/process/submitting-patches.html
+- Popper, K. (1959). *The Logic of Scientific Discovery*. Routledge.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -24,6 +24,7 @@ These documents support the current model and should be read as technical elabor
 | [signal-based-coordination.md](signal-based-coordination.md) | Signal/event model for coordination and transitions |
 | [cli-as-api.md](cli-as-api.md) | Boundary between skills, agent behavior, and CLI enforcement |
 | [target-specific-agents.md](target-specific-agents.md) | Per-target deployment strategy and current single-target decision |
+| [state-encapsulation.md](state-encapsulation.md) | State encapsulation principle, system analogies, TRIAGE sub-agent design |
 
 ## Mixed, Historical, or Planned Specs
 

--- a/docs/spec/state-encapsulation.md
+++ b/docs/spec/state-encapsulation.md
@@ -1,0 +1,175 @@
+---
+id: state-encapsulation
+title: "State Encapsulation — architectural principle and system analogies"
+date: 2026-04-27
+status: active
+tags: [architecture, fsm, encapsulation, triage, analogies, kernel]
+author: socrates
+issue: 152
+---
+
+# State Encapsulation
+
+## Principle
+
+> No state knows that other states exist — not their name, not their transition event.
+
+Each FSM state has a **mission**. It describes what to do HERE, never how to escape. The state's completeness triggers the transition; the state itself does not choose where to go. The scheduler reads completeness and routes accordingly.
+
+This principle was established for sub-agents in the cooperative multitasking model [1] (property #4: "Agents are unaware of each other"). Issue #152 extends it to the FSM states themselves and to the CLI output.
+
+## System Analogies
+
+### 1. `.inquiry/` as `/proc` (Linux kernel)
+
+`.inquiry/` is **kernel space**. Agents are **userspace processes**. Just as Linux processes do not write to `/proc/self/status` — the kernel manages that state — agents do not write to `.inquiry/state.yaml`. All mutations go through `iq` commands (system calls).
+
+| Linux | Inquiry |
+|-------|---------|
+| `/proc/` | `.inquiry/` |
+| Kernel | `iq` CLI |
+| Userspace process | Agent / Sub-agent |
+| System call (`write()`, `ioctl()`) | `iq fsm transition --event <e>` |
+| `/proc/self/status` (read-only for processes) | `.inquiry/state.yaml` (read-only for agents) |
+
+**Implication:** Skills and agent prompts must NEVER instruct agents to write `.inquiry/` files. All state mutations go through `iq` commands.
+
+### 2. States as process address spaces
+
+Each state operates in its own **address space**. It can see its own memory (mission, artifacts, sub-agent) but cannot see other states' memory. The scheduler is the kernel that context-switches between them.
+
+| OS concept | Inquiry FSM |
+|-----------|------------|
+| Process address space | State's mission + artifacts |
+| Cannot read other process memory | Cannot know other states exist |
+| IPC (pipes, signals) | Artifacts (diagnosis.md → plan.md) |
+| Context switch | FSM transition |
+| Scheduler (kernel) | APE scheduler |
+
+### 3. FSM transitions as hardware interrupts
+
+When a state's work is complete, it does not call the next state. It **raises an interrupt** (the completion event). The scheduler (interrupt handler) evaluates the event and routes to the appropriate next state. The completed state never learns where the interrupt was routed.
+
+| Hardware | Inquiry FSM |
+|----------|------------|
+| IRQ raised by device | Completion event raised by state |
+| Interrupt handler | Scheduler evaluates `completion_authority` |
+| Handler routes to ISR | Scheduler routes to next state |
+| Device doesn't know which ISR runs | State doesn't know which state follows |
+
+### 4. Issue granularity as the Linux patch rule
+
+The Linux kernel enforces a fundamental principle for patches [2]:
+
+> **Separate each logical change into a separate patch.**
+> If your changes include both bug fixes and performance enhancements for a single driver, separate those changes into two or more patches.
+> On the other hand, if you make a single change to numerous files, group those changes into a single patch.
+> **Thus a single logical change is contained within a single patch.**
+
+This maps directly to issue granularity in Inquiry:
+
+| Linux kernel | Inquiry |
+|-------------|---------|
+| Patch | Issue |
+| One logical change per patch | One logical objective per issue |
+| Patch series (ordered) | Related issues with dependency notes |
+| `bisect`-safe: every patch builds/runs | Every issue produces a mergeable PR |
+| Maintainer reviews each patch independently | Each APE cycle is self-contained |
+
+### 5. Completion authority as privilege levels (x86 rings)
+
+The `completion_authority` field maps to hardware privilege rings:
+
+| Ring | Inquiry | Who decides completion |
+|------|---------|----------------------|
+| Ring 0 (kernel) | `automatic` | CLI decides — no human needed |
+| Ring 3 (user) | `user` | Human must confirm |
+
+States with `completion_authority: automatic` (END, EVOLUTION) are kernel-mode: the CLI transitions without asking. States with `completion_authority: user` (IDLE, ANALYZE, PLAN, EXECUTE) are user-mode: the human confirms that the mission is complete.
+
+## Issue Granularity Rules
+
+Derived from Linux kernel patch submission guidelines [2] and adapted for the Inquiry methodology:
+
+### What makes a good issue
+
+1. **Single logical objective** — one problem, one feature, one refactor
+2. **Self-contained** — can be analyzed, planned, executed, and merged independently
+3. **Verifiable** — has clear criteria for "done" (tests, behavior, artifact)
+4. **Bisect-safe** — the resulting PR can be reverted without affecting unrelated features
+
+### What makes a bad issue
+
+1. **Multiple unrelated objectives** — "fix login AND add dark mode" → split into two issues
+2. **Scope creep** — "while I'm here, let me also refactor..." → create a separate issue
+3. **Vague outcome** — "improve performance" without measurable criteria
+4. **Dependency soup** — requires completing 5 other issues first (simplify or reorder)
+
+### "Sufficiently related" test
+
+Multiple objectives belong in the same issue IF AND ONLY IF:
+
+1. **They share a single logical change** — removing one objective breaks the others
+2. **They modify the same conceptual surface** — e.g., renaming a function and updating its callers
+3. **They cannot be meaningfully reviewed in isolation** — the reviewer needs both changes to understand either
+
+If objectives can be independently reviewed and independently reverted, they are separate issues.
+
+This mirrors the kernel rule: "if you make a single change to numerous files, group those changes into a single patch." The grouping criterion is **logical unity**, not file proximity.
+
+## IDLE State Mission: Triage
+
+IDLE is the only state where the scheduler operates directly (via the TRIAGE sub-agent). Its mission is **phronesis** (Aristotle's practical wisdom) — the ability to decide what merits formal inquiry.
+
+IDLE is not a waiting room. It is an active state whose output is **well-defined issues**. Someone can remain in IDLE indefinitely, creating issues without ever entering ANALYZE. The transition to the next phase is a side effect of successful triage, not the goal of triage.
+
+### TRIAGE sub-agent
+
+| Property | Value |
+|----------|-------|
+| Name | ARISTOTLE |
+| Thinking Tool | **Phronesis** (φρόνησις) — practical wisdom [3] |
+| Phase | IDLE |
+| Mission | Convert chaos into order: classify user intent, decompose vague requests into well-defined issues |
+
+**Why ARISTOTLE:** Phronesis — the intellectual virtue of knowing what to do in particular circumstances — is Aristotle's contribution to practical reasoning. Unlike theoretical wisdom (sophia), phronesis is about action in context. TRIAGE is exactly this: evaluating whether something merits action, what kind of action, and how to scope it. Aristotle's Categories (Κατηγορίαι) also introduced the first systematic taxonomy — classification of things into genera and species — which maps to the TRIAGE mission of classifying unstructured user input into well-scoped issues.
+
+**Why not another philosopher:** SOCRATES asks questions but doesn't classify. DESCARTES decomposes but assumes the problem is already defined. ARISTOTLE bridges: he classifies WHAT the problem is before anyone starts solving it.
+
+### TRIAGE internal states (proposed)
+
+```
+classify_intent → scope_problem → search_issues → create_or_select → confirm → _DONE
+```
+
+| State | Mission |
+|-------|---------|
+| `classify_intent` | Is this a consultation (answer directly, stay in IDLE) or a modification (needs an issue)? |
+| `scope_problem` | Decompose the request. Is it one issue or multiple? Apply the "sufficiently related" test. |
+| `search_issues` | `gh issue list --search "..."` — does an issue already exist for this? |
+| `create_or_select` | Create new issue(s) via `gh issue create` or select existing one. User confirms. |
+| `confirm` | Present the selected/created issue to the user. User confirms readiness. |
+| `_DONE` | Terminal. Scheduler evaluates: if issue confirmed → `iq fsm transition --event ready --issue <NNN>`. If blocked → `iq fsm transition --event block`. |
+
+### Completion authority compatibility
+
+IDLE has `completion_authority: user`. This means:
+- TRIAGE reaches `_DONE` → scheduler asks user: "¿Consideras que el triage está completo?"
+- User confirms → scheduler executes transition with the selected issue
+- User declines → stays in IDLE, TRIAGE can restart
+
+This is compatible with the existing model. TRIAGE never auto-transitions the main FSM.
+
+## References
+
+[1] `docs/spec/cooperative-multitasking-model.md` — Property #4: "Agents are unaware of each other."
+
+[2] Linux kernel documentation. "Submitting patches: the essential guide to getting your code into the kernel." Section: "Separate your changes." https://www.kernel.org/doc/html/latest/process/submitting-patches.html
+
+[3] Aristotle. *Nicomachean Ethics*, Book VI. Phronesis as practical wisdom distinct from theoretical wisdom (sophia) and technical knowledge (techne).
+
+[4] `docs/spec/agent-lifecycle.md` — IDLE state description and triage function.
+
+[5] `code/cli/assets/agents/inquiry.agent.md` — Firmware v0.2.0 (current, missing triage behavior).
+
+[6] `code/cli/assets/archive/inquiry.agent.md.legacy` — Legacy firmware with full triage behavior (lines 36-63).

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -1,0 +1,119 @@
+# Timeline
+
+How Inquiry came to exist. This document traces the path from a communication problem to a methodology, from a prompt to a CLI, and from a personal tool to a public system.
+
+## Prehistory: the communication gap
+
+**Late 2022.** OpenAI releases ChatGPT to the public. Like millions of others, I started using AI for software development. The promise was immediate: describe what you want, get code back. The reality was different.
+
+The AI assumed things I hadn't said. It misinterpreted ambiguous requests. It produced plausible but wrong solutions with absolute confidence. Most of the time, the fault was mine — I expressed myself with the ambiguity natural to human language and expected the machine to read my intent. It didn't. It read my words.
+
+I also discovered, through trial and error, that the most reliable way to get correct output from an AI was **Test-Driven Development**: when you write tests first, they become a specification the AI can implement against. Tests are unambiguous. Tests don't drift. But to write good tests, you need clear requirements. And to get clear requirements, you need rigorous analysis.
+
+The pattern was forming: **Analyze → Plan → Execute.**
+
+## The Coding Manifesto
+
+**2026-03-10.** The first artifact: a coding manifesto in a personal `ai` repo ([`ccisnedev/ai@a60dee5`](https://github.com/ccisnedev/ai/commit/a60dee5)). A set of principles for how code should be written when collaborating with AI — clarity of intent, readable structure, explicit naming. Not a methodology yet. Just rules for the human side of the conversation.
+
+## The Inquiry repo is born
+
+**2026-03-30.** The `inquiry` repo (then called `finite_ape_machine`) was created with a first commit ([`a1cd601`](https://github.com/SiliconBrainedMachines/inquiry/commit/a1cd601)). Initially it was a documentation-only project: agent role definitions, lore, architecture decision records. No CLI yet — just the intellectual scaffolding for what would become the Finite APE Machine.
+
+## The book begins
+
+**2026-03-31.** A parallel track started: a book. [`philo_sophia`](https://github.com/ccisnedev/philo_sophia) — working title *Philo SophIA* — was created to explore the philosophical foundations of human-AI communication. The core thesis: every failure mode of AI-assisted development maps to a philosophical problem that someone studied centuries ago. The tools to direct the most powerful thinking machine ever built are the oldest tools humanity has.
+
+## APE v0.1.0 — the first prompt
+
+**2026-04-03.** The birth of APE as a concrete artifact. Commit [`ac2da79`](https://github.com/ccisnedev/ai/commit/ac2da79) in the `ai` repo created `agent-prompt.md` v0.1.0 — 112 lines that defined:
+
+- Three states: **ANALYZE**, **PLAN**, **EXECUTE**
+- All transitions require explicit user authorization
+- Ambiguous approval is not authorization ("Ok", "Sounds good" are NOT transitions)
+- The state machine cannot be bypassed by urgency or emotional appeals
+- Directory structure convention: `docs/ape/NNN-slug/`
+
+This was the moment APE became operational. A human and an AI agent could now work together under a shared contract. The agent announced its state at every response: `[APE: ANALYZE]`, `[APE: PLAN]`, `[APE: EXECUTE]`.
+
+The prompt lived in the `ai` repo and was deployed to VS Code via a symbolic link to `~/.copilot/`. A manual process — but it worked.
+
+## The Socratic revelation
+
+**2026-04-15.** While refining the ANALYZE phase, I searched for a more rigorous method of questioning. The one I found was twenty-five centuries old: the **Socratic method** — *mayéutica* — the art of drawing knowledge through questions rather than assertions. Commit [`73a4ead`](https://github.com/ccisnedev/ai/commit/73a4ead) introduced SOCRATES as a dedicated sub-agent:
+
+> *"You are SOCRATES, an analysis assistant that uses the Socratic method to help users understand problems deeply."*
+
+This was the turning point. If one ancient thinking tool (Socratic questioning) worked for ANALYZE, were there others? The answer led to:
+- **DESCARTES** for PLAN — Cartesian method: divide, order, verify, enumerate
+- **BASHŌ** for EXECUTE — techne: minimal, beautiful implementation under constraints
+- **DARWIN** for EVOLUTION — natural selection applied to the methodology itself
+
+Each agent embodied a philosophical tradition. Each tradition had been tested for centuries. The realization that philosophy was not a museum but a toolkit for engineering — this was the moment Inquiry became more than a prompt.
+
+## The CLI is born
+
+**2026-04-15.** The same day SOCRATES was defined, the CLI work began. The manual symlink process (copy prompt to `~/.copilot/`) was a friction point. A CLI that automated deployment was the natural next step. Inspired by [gentle-ai](https://github.com/Gentleman-Programming/gentle-ai) (Gentleman Programming) — a project that packaged prompts and skills via a CLI — I started building a Dart CLI on [`modular_cli_sdk`](https://github.com/siliconbrainedmachines/modular_cli_sdk).
+
+Commits [`44150463`](https://github.com/SiliconBrainedMachines/inquiry/commit/44150463) (scaffold) and [`45fba9e`](https://github.com/SiliconBrainedMachines/inquiry/commit/45fba9e) (`ape init` command) landed that day.
+
+## Rapid evolution: v0.0.2 to v0.0.14
+
+**2026-04-16 to 2026-04-18.** In three days, 13 releases:
+
+| Date | Version | Milestone |
+|------|---------|-----------|
+| Apr 16 | v0.0.2 | `ape target get` — deploy agent + skills to Copilot |
+| Apr 16 | v0.0.3 | Install scripts (PowerShell + Bash), GitHub Pages site |
+| Apr 16 | v0.0.5 | `ape upgrade`, `ape uninstall` |
+| Apr 16 | v0.0.6 | Automated release workflow, Windows Defender workaround |
+| Apr 17 | v0.0.7 | `ape doctor` — prerequisite verification |
+| Apr 17 | v0.0.9 | `issue-start` skill, IDLE triage |
+| Apr 18 | v0.0.10 | Five-state FSM: IDLE → ANALYZE → PLAN → EXECUTE → EVOLUTION |
+| Apr 18 | v0.0.11 | END state, transition contract (YAML), `ape state transition` |
+| Apr 18 | v0.0.14 | EVOLUTION infrastructure — `config.yaml`, `mutations.md` lifecycle |
+
+From this point on, APE was building APE. Every CLI feature was developed using the APE methodology itself — issue → analysis → plan → execute → PR → evolution. The bootstrap thesis was validated: the system could improve itself.
+
+## Peirce and the philosophical grounding
+
+**2026-04-20.** Research into why APE's three-phase structure worked led to Charles Sanders Peirce's theory of inquiry. Commit [`feat: agregar documentación sobre la teoría de la indagación de Peirce`](https://github.com/SiliconBrainedMachines/inquiry/commit/feat) revealed the mapping:
+
+| Peirce's inquiry | APE phase | Agent |
+|------------------|-----------|-------|
+| **Abduction** — inference to the best explanation | ANALYZE | SOCRATES |
+| **Deduction** — derive consequences from hypotheses | PLAN | DESCARTES |
+| **Induction** — test consequences against reality | EXECUTE | BASHŌ |
+
+APE wasn't just a workflow — it was an implementation of the oldest formal theory of structured investigation. The name **Inquiry** was chosen the same day ([`docs(110): analysis complete - inquiry chosen as APE primary noun`](https://github.com/SiliconBrainedMachines/inquiry/commit/docs-110)).
+
+## The VS Code extension
+
+**2026-04-19.** A VS Code extension was created to bring Inquiry into the editor: status bar showing FSM state, commands for `init`, `toggleEvolution`, and `addMutation`. Published to the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=siliconbrainedmachines.inquiry-vscode) the same day. Built entirely using the APE cycle (issue #82).
+
+## The rebrand
+
+**2026-04-21 to 2026-04-22.** The project moved from `ccisnedev/finite_ape_machine` to `SiliconBrainedMachines/inquiry`. The CLI was renamed from `ape` to `iq`. The methodology kept its APE name internally, but the system's public identity became **Inquiry** — a name grounded in Peirce's theory. Version **v0.1.0** marked the rebrand.
+
+## The Finite APE Machine
+
+**2026-04-25 to 2026-04-26.** The architecture underwent its most significant redesign: the monolithic 554-line agent prompt was replaced by a thin **firmware scheduler** (~35 lines) backed by a dual FSM (main + per-APE). Key innovations:
+
+- **`iq fsm state --json`** — structured output for agent consumption
+- **`iq ape prompt --name <name>`** — sub-agent prompts assembled from YAML + state
+- **`completion_authority`** — per-state field that tells the scheduler whether to ask the user or transition automatically
+- **Dispatch model** — the scheduler never performs sub-agent work; it delegates via the `agent` tool
+
+The design principle: **the CLI is the algorithm, the LLM is just the executor**. Version **v0.2.0** landed with the redesign, followed immediately by **v0.2.1** with smoke-test fixes.
+
+## What emerged
+
+The system I built to solve a communication problem — AI assumes things, misinterprets words, acts without authorization — turned out to be something larger. Inquiry forces clarity *before* AI acts. The analysis phase eliminates ambiguity. The plan phase makes the solution explicit. By the time execution starts, the problem is already solved — whether a human or an AI writes the code doesn't change the result.
+
+The unexpected discovery: I recognize the code the AI produces as my own. Not because I wrote it, but because I designed it. Every decision was made during analysis and planning. The AI implemented *my* design, following *my* conventions, under *my* constraints. The methodology doesn't replace the engineer — it amplifies them.
+
+Inquiry is, at its core, a thinking tool. The oldest kind there is.
+
+---
+
+*For the philosophical foundations, see [Philo SophIA](https://github.com/ccisnedev/philo_sophia). For the technical architecture, see [`docs/architecture.md`](architecture.md). For the lore, see [`docs/lore.md`](lore.md).*


### PR DESCRIPTION
Closes #152

## Summary
Full state encapsulation for the Inquiry FSM. Agents see only events and mission descriptions — no destination states, no CLI hints, no hardcoded sub-agent names.

## Changes (8 phases)
- **Phase 1**: Prechecks on IDLE->ANALYZE (require issue + branch)
- **Phase 2**: Remove next_state from transitions JSON
- **Phase 3**: Mission descriptions replace state instructions
- **Phase 4**: issue-start skill uses CLI instead of direct YAML writes
- **Phase 5**: SOCRATES-idle triage sub-agent in IDLE
- **Phase 6**: Firmware v0.3.0 — state-agnostic generic dispatch loop
- **Phase 7**: Full validation (300/300 tests, dart analyze clean)
- **Phase 8**: Remove 'to' from APE sub-FSM transitions

## Verification
- 300/300 tests pass
- dart analyze: no issues
- Field-tested in inquiry_lab with gemma4/crush and Claude
- Encapsulation confirmed: no next_state, no to, mission descriptions active