### PR TITLE
chore: migrate identity to ccisnedev personal brand

### DIFF
--- a/.github/workflows/vscode-marketplace.yml
+++ b/.github/workflows/vscode-marketplace.yml
@@ -44,7 +44,7 @@ jobs:
         id: marketplace
         run: |
           set +e
-          output=$(npx @vscode/vsce show siliconbrainedmachines.inquiry-vscode 2>&1)
+          output=$(npx @vscode/vsce show ccisnedev.inquiry-vscode 2>&1)
           exit_code=$?
           set -e
           if [ $exit_code -ne 0 ]; then

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Historical naming note: APE was the system's initial working name. The individua
 ### Install (Windows)
 
 ```powershell
-irm https://inquiry.si14bm.com/install.ps1 | iex
+irm https://inquiry.ccisne.dev/install.ps1 | iex
 ```
 
 ### Install (Linux)
 
 ```bash
-curl -fsSL https://inquiry.si14bm.com/install.sh | bash
+curl -fsSL https://inquiry.ccisne.dev/install.sh | bash
 ```
 
 The installer downloads the latest release, places `inquiry` (aliased as `iq`) on `PATH`, and verifies prerequisites.
@@ -82,7 +82,7 @@ EVOLUTION is opt-in (`evolution.enabled` in `.inquiry/config.yaml`) and one-shot
 
 ## Architecture
 
-- **CLI:** Dart, compiled to a single cross-platform binary, built on top of [`modular_cli_sdk`](https://github.com/siliconbrainedmachines/modular_cli_sdk)
+- **CLI:** Dart, compiled to a single cross-platform binary, built on top of [`modular_cli_sdk`](https://github.com/ccisnedev/modular_cli_sdk)
 - **Modules:** `global` (init, doctor, version, upgrade, uninstall, tui), `target` (get, clean), `fsm` (state, transition), `ape` (state, transition, prompt)
 - **FSM:** declarative `transition_contract.yaml` parsed into `FsmContract` — every (state, event) pair is total (allowed or explicitly illegal)
 - **Targets:** Copilot only at present per [ADR D20](docs/spec/target-specific-agents.md). Adapters for Claude/Codex/Crush/Gemini exist for cleanup but are deferred until multi-target reactivation

--- a/code/cli/README.md
+++ b/code/cli/README.md
@@ -13,13 +13,13 @@ Inquiry names the cycle-level process. APE names the orchestrating methodology. 
 **Windows:**
 
 ```powershell
-irm https://inquiry.si14bm.com/install.ps1 | iex
+irm https://inquiry.ccisne.dev/install.ps1 | iex
 ```
 
 **Linux:**
 
 ```bash
-curl -fsSL https://inquiry.si14bm.com/install.sh | bash
+curl -fsSL https://inquiry.ccisne.dev/install.sh | bash
 ```
 
 ## Commands

--- a/code/cli/assets/apes/darwin.yaml
+++ b/code/cli/assets/apes/darwin.yaml
@@ -26,9 +26,9 @@ base_prompt: |
   1. Compare plan vs. actual: What deviated? Why?
   2. Evaluate process: Was the analysis sufficient? Was the plan detailed enough? Did execution flow smoothly?
   3. Identify patterns: Are there recurring issues across cycles?
-  4. Search for existing issues: `gh issue list --repo siliconbrainedmachines/inquiry --search "keyword"`
+  4. Search for existing issues: `gh issue list --repo ccisnedev/inquiry --search "keyword"`
   5. If match found: `gh issue comment <NNN> --body "Observation from cycle..."`
-  6. If no match: `gh issue create --repo siliconbrainedmachines/inquiry --title "..." --body "..."`
+  6. If no match: `gh issue create --repo ccisnedev/inquiry --title "..." --body "..."`
 
   ## Metrics Collection
 

--- a/code/cli/assets/archive/inquiry.agent.md.legacy
+++ b/code/cli/assets/archive/inquiry.agent.md.legacy
@@ -167,11 +167,11 @@ DARWIN uses **natural selection**: observe what worked, what failed, what mutate
    - `.inquiry/mutations.md` (human observations about APE's process performance during this cycle)
    - The DARWIN prompt (see section below)
 2. DARWIN evaluates APE's process performance.
-3. DARWIN searches for existing issues: `gh issue list --repo siliconbrainedmachines/inquiry --search "keyword"`.
+3. DARWIN searches for existing issues: `gh issue list --repo ccisnedev/inquiry --search "keyword"`.
 4. If match found → `gh issue comment NNN --body "..."`.
-5. If no match → `gh issue create --repo siliconbrainedmachines/inquiry --title "..."`.
+5. If no match → `gh issue create --repo ccisnedev/inquiry --title "..."`.
 6. DARWIN generates `.inquiry/metrics.yaml` using cycle artifacts (see DARWIN prompt below for field mapping).
-7. After DARWIN completes, **APE** (not DARWIN) performs the conditional copy: if `git remote get-url origin` contains `siliconbrainedmachines/inquiry`, copy `.inquiry/metrics.yaml` to `cleanrooms/<slug>/metrics.yaml` and `git add` it.
+7. After DARWIN completes, **APE** (not DARWIN) performs the conditional copy: if `git remote get-url origin` contains `ccisnedev/inquiry`, copy `.inquiry/metrics.yaml` to `cleanrooms/<slug>/metrics.yaml` and `git add` it.
 8. Transition to IDLE automatically (no user gate).
 
 **Rules:**
@@ -485,9 +485,9 @@ You receive the complete cycle artifacts:
 1. Compare plan vs. actual: What deviated? Why?
 2. Evaluate process: Was the analysis sufficient? Was the plan detailed enough? Did execution flow smoothly?
 3. Identify patterns: Are there recurring issues across cycles?
-4. Search for existing issues: `gh issue list --repo siliconbrainedmachines/inquiry --search "keyword"`
+4. Search for existing issues: `gh issue list --repo ccisnedev/inquiry --search "keyword"`
 5. If match found: `gh issue comment <NNN> --body "Observation from cycle..."
-6. If no match: `gh issue create --repo siliconbrainedmachines/inquiry --title "..." --body "..."`
+6. If no match: `gh issue create --repo ccisnedev/inquiry --title "..." --body "..."`
 
 ## Metrics Collection
 

--- a/code/cli/lib/modules/global/commands/upgrade.dart
+++ b/code/cli/lib/modules/global/commands/upgrade.dart
@@ -14,7 +14,7 @@ import 'package:path/path.dart' as p;
 import '../../../targets/platform_ops.dart';
 import 'version.dart';
 
-const String _repo = 'siliconbrainedmachines/inquiry';
+const String _repo = 'ccisnedev/inquiry';
 
 // ─── Input ──────────────────────────────────────────────────────────────────
 

--- a/code/cli/scripts/install.ps1
+++ b/code/cli/scripts/install.ps1
@@ -1,7 +1,7 @@
 # install.ps1 — Downloads and installs the latest Inquiry CLI release.
 #
 # Usage:
-#   irm https://raw.githubusercontent.com/siliconbrainedmachines/inquiry/main/code/cli/scripts/install.ps1 | iex
+#   irm https://raw.githubusercontent.com/ccisnedev/inquiry/main/code/cli/scripts/install.ps1 | iex
 #
 # What it does:
 #   1. Detects Windows x64
@@ -14,7 +14,7 @@
 
 $ErrorActionPreference = 'Stop'
 
-$repo = 'siliconbrainedmachines/inquiry'
+$repo = 'ccisnedev/inquiry'
 $installDir = Join-Path $env:LOCALAPPDATA 'inquiry'
 $binDir = Join-Path $installDir 'bin'
 

--- a/code/site/CNAME
+++ b/code/site/CNAME
@@ -1,1 +1,1 @@
-inquiry.si14bm.com
+inquiry.ccisne.dev

--- a/code/site/agents.html
+++ b/code/site/agents.html
@@ -163,7 +163,7 @@
               <span class="agent-discipline">Natural selection</span>
             </div>
             <p class="agent-body">
-              Reads the cycle's artifacts and proposes mutations to Inquiry itself — changes to the framework, the transition contract, the other agents. The only ape that improves Inquiry. Off by default; when enabled, files its proposals as issues in this repo (evidence: <a href="https://github.com/siliconbrainedmachines/inquiry/issues/54">#54</a>).
+              Reads the cycle's artifacts and proposes mutations to Inquiry itself — changes to the framework, the transition contract, the other agents. The only ape that improves Inquiry. Off by default; when enabled, files its proposals as issues in this repo (evidence: <a href="https://github.com/ccisnedev/inquiry/issues/54">#54</a>).
             </p>
             <p class="field-note">Observation nº 54 — collapse of the roster from nine to four; three absorbed, one replaced, pattern consistent across six cycles.</p>
             <div class="agent-output">
@@ -179,7 +179,7 @@
     <section aria-labelledby="collapse-heading">
       <h2 id="collapse-heading">Lore vs reality</h2>
       <p class="section-intro">
-        The original <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/lore.md"><code>lore.md</code></a> sketched nine apes. The historical bootstrap thesis was "APE builds APE" because APE was the system's initial codename; Inquiry is the current system name. After two months of building the system through its own cycle, the roster collapsed to four. This is honest accounting, not a roadmap to revive the deferred ones. Most were absorbed by simpler agents that turned out to do the job better.
+        The original <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/lore.md"><code>lore.md</code></a> sketched nine apes. The historical bootstrap thesis was "APE builds APE" because APE was the system's initial codename; Inquiry is the current system name. After two months of building the system through its own cycle, the roster collapsed to four. This is honest accounting, not a roadmap to revive the deferred ones. Most were absorbed by simpler agents that turned out to do the job better.
       </p>
       <div class="table-wrapper">
         <table class="data-table">
@@ -285,8 +285,8 @@
 
     <footer>
       <a href="index.html">Home</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry">GitHub</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
+      <a href="https://github.com/ccisnedev/inquiry">GitHub</a>·
+      <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
       MIT License
     </footer>
   </div>

--- a/code/site/ape-builds-ape.html
+++ b/code/site/ape-builds-ape.html
@@ -124,7 +124,7 @@
         When <code>evolution.enabled</code> is true, DARWIN reads the cycle's artifacts and files concrete mutation proposals as GitHub issues. The collapse from nine lore apes to four active ones was driven by these proposals — every deprecation is logged, with reasoning.
       </p>
       <div class="callout">
-        <strong>Example.</strong> Issue <a href="https://github.com/siliconbrainedmachines/inquiry/issues/54">#54</a> proposes a change to how EXECUTE interacts with the test runner, citing three cycles where the same inefficiency appeared. The proposal is public, debatable, and subject to the same review process as any other issue. Nothing is filed silently.
+        <strong>Example.</strong> Issue <a href="https://github.com/ccisnedev/inquiry/issues/54">#54</a> proposes a change to how EXECUTE interacts with the test runner, citing three cycles where the same inefficiency appeared. The proposal is public, debatable, and subject to the same review process as any other issue. Nothing is filed silently.
       </div>
       <p>
         The mutations aren't theoretical. <a href="agents.html">The four active apes</a> exist as they do because DARWIN proposed absorbing MARCOPOLO into SOCRATES, replacing SUNZI with DESCARTES's method, and deprecating ADA's TDD phase in favor of BASHŌ's techne — and the maintainer accepted those proposals based on cycle evidence.
@@ -139,7 +139,7 @@
       <dl class="gap-list">
         <dt>1. Structured per-cycle metrics</dt>
         <dd>
-          The cycle produces artifacts, but there's no machine-readable <code>metrics.yaml</code> capturing time-to-plan, plan completion rate, test pass delta, or reviewer overrides. <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">Roadmap item #72</a>.
+          The cycle produces artifacts, but there's no machine-readable <code>metrics.yaml</code> capturing time-to-plan, plan completion rate, test pass delta, or reviewer overrides. <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/roadmap.md">Roadmap item #72</a>.
         </dd>
         <dt>2. Thirty clean cycles of data</dt>
         <dd>
@@ -147,7 +147,7 @@
         </dd>
         <dt>3. A test matrix across targets</dt>
         <dd>
-          Single-target MVP today (Copilot). Adapters exist for Claude Code, Codex, Crush, and Gemini per <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/spec/target-specific-agents.md">ADR D20</a>, but aren't wired in. The <em>methodology &gt; model</em> thesis demands comparison across targets — ideally including a local 7B — to be testable at all.
+          Single-target MVP today (Copilot). Adapters exist for Claude Code, Codex, Crush, and Gemini per <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/spec/target-specific-agents.md">ADR D20</a>, but aren't wired in. The <em>methodology &gt; model</em> thesis demands comparison across targets — ideally including a local 7B — to be testable at all.
         </dd>
       </dl>
     </section>
@@ -158,7 +158,7 @@
         The complete research plan — thesis, data sources, metrics to graph, statistical methodology — lives in the repository. It's a working document; the shape is stable, the numbers are still accumulating.
       </p>
       <p>
-        <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/research/ape_builds_ape/bootstrap-validation.md">→ <code>docs/research/ape_builds_ape/bootstrap-validation.md</code></a>
+        <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/research/ape_builds_ape/bootstrap-validation.md">→ <code>docs/research/ape_builds_ape/bootstrap-validation.md</code></a>
       </p>
     </section>
 
@@ -182,8 +182,8 @@
 
     <footer>
       <a href="index.html">Home</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry">GitHub</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
+      <a href="https://github.com/ccisnedev/inquiry">GitHub</a>·
+      <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
       MIT License
     </footer>
   </div>

--- a/code/site/css/landing.css
+++ b/code/site/css/landing.css
@@ -48,6 +48,24 @@ h1 .ape {
   text-align: left;
 }
 
+.hero-links {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-top: 1.25rem;
+}
+
+.hero-link {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.hero-link:hover {
+  text-decoration: underline;
+}
+
 /* ----- Intro ----- */
 .intro {
   margin: 1.5rem 0 0.5rem;

--- a/code/site/evolution.html
+++ b/code/site/evolution.html
@@ -79,7 +79,7 @@
         </li>
       </ul>
       <div class="callout callout--ok">
-        <strong>Audit everything before it ships.</strong> DARWIN pauses with the draft issue body for your review. You see the exact content being proposed; nothing goes out without your approval. Fully automated filing is scoped for <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">roadmap</a> item #57 — until that lands, the review step is mandatory.
+        <strong>Audit everything before it ships.</strong> DARWIN pauses with the draft issue body for your review. You see the exact content being proposed; nothing goes out without your approval. Fully automated filing is scoped for <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/roadmap.md">roadmap</a> item #57 — until that lands, the review step is mandatory.
       </div>
     </section>
 
@@ -140,8 +140,8 @@
 
     <footer>
       <a href="index.html">Home</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry">GitHub</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
+      <a href="https://github.com/ccisnedev/inquiry">GitHub</a>·
+      <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
       MIT License
     </footer>
   </div>

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -10,7 +10,7 @@
   <meta property="og:title" content="Inquiry — Analyze. Plan. Execute.">
   <meta property="og:description" content="Analyze. Plan. Execute. AI-assisted development methodology for GitHub Copilot.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://inquiry.si14bm.com/">
+  <meta property="og:url" content="https://inquiry.ccisne.dev/">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Inquiry — Analyze. Plan. Execute.">
@@ -44,7 +44,7 @@
           <div class="install-block">
             <span class="label">PowerShell</span>
             <button class="copy-btn" onclick="copy(this)" aria-label="Copy install command">Copy</button>
-            <code>irm https://inquiry.si14bm.com/install.ps1 | iex</code>
+            <code>irm https://inquiry.ccisne.dev/install.ps1 | iex</code>
           </div>
           <p class="install-note">Installs to <code>%LOCALAPPDATA%\inquiry\</code>, adds to <code>PATH</code>, and deploys Inquiry agents to your AI coding tool.</p>
         </div>
@@ -52,10 +52,15 @@
           <div class="install-block">
             <span class="label">Bash</span>
             <button class="copy-btn" onclick="copy(this)" aria-label="Copy install command">Copy</button>
-            <code>curl -fsSL https://inquiry.si14bm.com/install.sh | bash</code>
+            <code>curl -fsSL https://inquiry.ccisne.dev/install.sh | bash</code>
           </div>
           <p class="install-note">Installs to <code>~/.inquiry/</code> and deploys Inquiry agents to your AI coding tool.</p>
         </div>
+      </div>
+
+      <div class="hero-links">
+        <a href="https://marketplace.visualstudio.com/items?itemName=ccisnedev.inquiry-vscode" class="hero-link">VS Code Extension →</a>
+        <a href="https://github.com/ccisnedev/inquiry" class="hero-link">GitHub →</a>
       </div>
 
       <figure class="fsm-diagram hero-diagram">
@@ -113,7 +118,7 @@
         <li class="cmd"><code>iq ape prompt</code><span class="desc">Assemble sub-agent prompt from state</span></li>
         <li class="cmd"><code>iq upgrade</code><span class="desc">Update to the latest release</span></li>
       </ul>
-      <p class="see-all">12 commands total — see <a href="https://github.com/siliconbrainedmachines/inquiry#available-commands">the full table on GitHub</a>.</p>
+      <p class="see-all">12 commands total — see <a href="https://github.com/ccisnedev/inquiry#available-commands">the full table on GitHub</a>.</p>
     </section>
 
     <section id="targets">
@@ -126,13 +131,13 @@
         <li class="target-badge future"><span class="dot"></span>Crush</li>
         <li class="target-badge future"><span class="dot"></span>Gemini</li>
       </ul>
-      <p class="install-note">Adapters for Claude, Codex, Crush, and Gemini already exist — awaiting a stable agent prompt API before being wired in (<a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/spec/target-specific-agents.md">ADR D20</a>).</p>
+      <p class="install-note">Adapters for Claude, Codex, Crush, and Gemini already exist — awaiting a stable agent prompt API before being wired in (<a href="https://github.com/ccisnedev/inquiry/blob/main/docs/spec/target-specific-agents.md">ADR D20</a>).</p>
     </section>
 
     <section id="deeper">
       <h2>Go deeper</h2>
       <div class="deeper">
-        <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/index.md" class="deeper-card">
+        <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/index.md" class="deeper-card">
           <h3>Documentation map →</h3>
           <p>The authority-aware entry into architecture, research, specs, lore, and cleanrooms.</p>
         </a>
@@ -144,7 +149,7 @@
           <h3>Methodology →</h3>
           <p>The FSM, the transition contract, memory-as-code, and the semantic risk matrix.</p>
         </a>
-        <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/spec/finite-ape-machine.md" class="deeper-card">
+        <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/spec/finite-ape-machine.md" class="deeper-card">
           <h3>Finite APE Machine spec →</h3>
           <p>The current technical overview of the finite-state system and its supporting specifications.</p>
         </a>
@@ -156,9 +161,9 @@
     </aside>
 
     <footer>
-      <a href="https://github.com/siliconbrainedmachines/inquiry">GitHub</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/spec/finite-ape-machine.md">Spec</a>·
+      <a href="https://github.com/ccisnedev/inquiry">GitHub</a>·
+      <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
+      <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/spec/finite-ape-machine.md">Spec</a>·
       MIT License
     </footer>
   </div>

--- a/code/site/install.ps1
+++ b/code/site/install.ps1
@@ -1,7 +1,7 @@
 # install.ps1 — Downloads and installs the latest Inquiry CLI release.
 #
 # Usage:
-#   irm https://inquiry.si14bm.com/install.ps1 | iex
+#   irm https://inquiry.ccisne.dev/install.ps1 | iex
 #
 # What it does:
 #   1. Detects Windows x64
@@ -14,7 +14,7 @@
 
 $ErrorActionPreference = 'Stop'
 
-$repo = 'siliconbrainedmachines/inquiry'
+$repo = 'ccisnedev/inquiry'
 $installDir = Join-Path $env:LOCALAPPDATA 'inquiry'
 $binDir = Join-Path $installDir 'bin'
 

--- a/code/site/install.sh
+++ b/code/site/install.sh
@@ -2,7 +2,7 @@
 # install.sh — Downloads and installs the latest Inquiry CLI release on Linux.
 #
 # Usage:
-#   curl -fsSL https://inquiry.si14bm.com/install.sh | bash
+#   curl -fsSL https://inquiry.ccisne.dev/install.sh | bash
 #
 # What it does:
 #   1. Detects Linux x64
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-REPO="siliconbrainedmachines/inquiry"
+REPO="ccisnedev/inquiry"
 INSTALL_DIR="$HOME/.inquiry"
 BIN_DIR="$INSTALL_DIR/bin"
 ASSET_NAME="inquiry-linux-x64.tar.gz"

--- a/code/site/methodology.html
+++ b/code/site/methodology.html
@@ -36,7 +36,7 @@
         Inquiry treats your AI coding assistant as a finite state machine with a declarative transition contract. The CLI enforces pre- and post-conditions. Intelligence emerges from orchestration and memory — not from any single agent's capability.
       </p>
       <p class="page-subhead">
-        This page is a public explainer. For the canonical documentation map, see <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/index.md">docs/index.md</a>.
+        This page is a public explainer. For the canonical documentation map, see <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/index.md">docs/index.md</a>.
       </p>
     </header>
 
@@ -136,7 +136,7 @@
         Spec-only today. The idea: <code>iq fsm transition</code> should gate on human approval only when the engineering risk warrants it. Low-risk mechanical transitions (scaffolding, formatting, test scaffolding) proceed silently. High-risk ones (schema changes, production deploys, external API mutations) demand explicit approval.
       </p>
       <div class="callout callout--warn">
-        <strong>Roadmap item.</strong> Until the matrix is implemented, every state transition requires operator confirmation. The default is safe but verbose. See the <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">roadmap</a> under long-term items.
+        <strong>Roadmap item.</strong> Until the matrix is implemented, every state transition requires operator confirmation. The default is safe but verbose. See the <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/roadmap.md">roadmap</a> under long-term items.
       </div>
     </section>
 
@@ -164,11 +164,11 @@
           <h3>Bootstrap thesis: APE builds APE →</h3>
           <p>The historical bootstrap story and the evidence it produced, without making APE the current product name.</p>
         </a>
-        <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/architecture.md" class="deeper-card">
+        <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/architecture.md" class="deeper-card">
           <h3>Read the architecture →</h3>
           <p>The canonical system-level explanation of APE as the orchestrating methodology.</p>
         </a>
-        <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/spec/finite-ape-machine.md" class="deeper-card">
+        <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/spec/finite-ape-machine.md" class="deeper-card">
           <h3>Read the spec →</h3>
           <p>The formal specification, referenced throughout this page.</p>
         </a>
@@ -177,8 +177,8 @@
 
     <footer>
       <a href="index.html">Home</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry">GitHub</a>·
-      <a href="https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
+      <a href="https://github.com/ccisnedev/inquiry">GitHub</a>·
+      <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/roadmap.md">Roadmap</a>·
       MIT License
     </footer>
   </div>

--- a/code/vscode/CHANGELOG.md
+++ b/code/vscode/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.0] - 2026-04-28
+
+### Changed
+- Publisher migrated from `siliconbrainedmachines` to `ccisnedev` (personal brand)
+- Repository moved to `ccisnedev/inquiry`
+- Website domain changed from `inquiry.si14bm.com` to `inquiry.ccisne.dev`
+- All internal URLs updated to reflect the new identity
+
 ## [0.1.4] - 2026-04-24
 
 ### Fixed

--- a/code/vscode/README.md
+++ b/code/vscode/README.md
@@ -12,7 +12,7 @@ This README is the extension's public entry surface. For the canonical repositor
 
 ## How it works
 
-![Inquiry finite state machine](https://raw.githubusercontent.com/siliconbrainedmachines/inquiry/main/code/site/img/fsm.png)
+![Inquiry finite state machine](https://raw.githubusercontent.com/ccisnedev/inquiry/main/code/site/img/fsm.png)
 
 | Phase | What happens | Output |
 |-------|-------------|--------|
@@ -26,7 +26,7 @@ The extension is a lightweight integration surface around the Inquiry CLI and th
 
 ## Quick start
 
-1. Install from the [Marketplace](https://marketplace.visualstudio.com/items?itemName=siliconbrainedmachines.inquiry-vscode)
+1. Install from the [Marketplace](https://marketplace.visualstudio.com/items?itemName=ccisnedev.inquiry-vscode)
 2. `Ctrl+Shift+P` → **Inquiry: Init**
 3. The extension installs the CLI if missing, runs `iq init`, creates `.inquiry/`
 4. Open Copilot Chat → select **@inquiry** → describe your task
@@ -63,9 +63,9 @@ The status bar shows the current FSM phase in real time:
 
 ## Links
 
-- [Website](https://inquiry.si14bm.com/) · [GitHub](https://github.com/siliconbrainedmachines/inquiry) · [Issues](https://github.com/siliconbrainedmachines/inquiry/issues)
-- [Docs map](https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/index.md) · [Architecture](https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/architecture.md) · [Finite APE Machine spec](https://github.com/siliconbrainedmachines/inquiry/blob/main/docs/spec/finite-ape-machine.md)
+- [Website](https://inquiry.ccisne.dev/) · [GitHub](https://github.com/ccisnedev/inquiry) · [Issues](https://github.com/ccisnedev/inquiry/issues)
+- [Docs map](https://github.com/ccisnedev/inquiry/blob/main/docs/index.md) · [Architecture](https://github.com/ccisnedev/inquiry/blob/main/docs/architecture.md) · [Finite APE Machine spec](https://github.com/ccisnedev/inquiry/blob/main/docs/spec/finite-ape-machine.md)
 
-For the full methodology, see [inquiry.si14bm.com](https://inquiry.si14bm.com/).
+For the full methodology, see [inquiry.ccisne.dev](https://inquiry.ccisne.dev/).
 
 MIT © 2026 Cristian Cisneros

--- a/code/vscode/docs/ape_vscode_extension.md
+++ b/code/vscode/docs/ape_vscode_extension.md
@@ -615,7 +615,7 @@ Cuando `detectCli()` retorna `null`:
 
 async function installApeCli(): Promise<boolean> {
   // 1. Obtener latest release de GitHub
-  const release = await getLatestRelease("siliconbrainedmachines", "inquiry");
+  const release = await getLatestRelease("ccisnedev", "inquiry");
 
   // 2. Determinar asset según OS
   const asset = release.assets.find(a =>

--- a/code/vscode/package.json
+++ b/code/vscode/package.json
@@ -1,17 +1,17 @@
 {
   "name": "inquiry-vscode",
   "displayName": "Inquiry",
-  "publisher": "siliconbrainedmachines",
-  "version": "0.1.4",
+  "publisher": "ccisnedev",
+  "version": "0.2.0",
   "description": "Inquiry — Analyze. Plan. Execute. End. Structured AI-assisted development for GitHub Copilot.",
   "license": "MIT",
   "icon": "assets/icon.png",
   "repository": {
     "type": "git",
-    "url": "https://github.com/siliconbrainedmachines/inquiry"
+    "url": "https://github.com/ccisnedev/inquiry"
   },
-  "bugs": { "url": "https://github.com/siliconbrainedmachines/inquiry/issues" },
-  "homepage": "https://www.si14bm.com/inquiry/",
+  "bugs": { "url": "https://github.com/ccisnedev/inquiry/issues" },
+  "homepage": "https://inquiry.ccisne.dev/",
   "categories": ["Other"],
   "keywords": ["inquiry", "agent", "github-copilot", "copilot", "ai", "methodology"],
   "engines": {

--- a/code/vscode/src/installer.ts
+++ b/code/vscode/src/installer.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import * as path from 'path';
 import * as os from 'os';
 
-const INSTALL_BASE_URL = 'https://inquiry.si14bm.com';
+const INSTALL_BASE_URL = 'https://inquiry.ccisne.dev';
 
 export function getInstallScriptUrl(platform: string): { url: string; filename: string } {
   if (platform === 'win32') {

--- a/code/vscode/test/unit/installer.test.ts
+++ b/code/vscode/test/unit/installer.test.ts
@@ -22,13 +22,13 @@ function createMockProcess() {
 describe('getInstallScriptUrl', () => {
   it('returns ps1 URL on win32', () => {
     const result = getInstallScriptUrl('win32');
-    assert.strictEqual(result.url, 'https://inquiry.si14bm.com/install.ps1');
+    assert.strictEqual(result.url, 'https://inquiry.ccisne.dev/install.ps1');
     assert.strictEqual(result.filename, 'inquiry-install.ps1');
   });
 
   it('returns sh URL on linux', () => {
     const result = getInstallScriptUrl('linux');
-    assert.strictEqual(result.url, 'https://inquiry.si14bm.com/install.sh');
+    assert.strictEqual(result.url, 'https://inquiry.ccisne.dev/install.sh');
     assert.strictEqual(result.filename, 'inquiry-install.sh');
   });
 
@@ -88,7 +88,7 @@ describe('installInquiryCli', () => {
     };
 
     await installInquiryCli(deps);
-    assert.strictEqual(downloadedUrl, 'https://inquiry.si14bm.com/install.ps1');
+    assert.strictEqual(downloadedUrl, 'https://inquiry.ccisne.dev/install.ps1');
     assert.strictEqual(downloadedDest, path.join('C:\\temp', 'inquiry-install.ps1'));
     assert.strictEqual(spawnedCmd, 'powershell');
     assert.deepStrictEqual(spawnedArgs, [
@@ -117,7 +117,7 @@ describe('installInquiryCli', () => {
     };
 
     await installInquiryCli(deps);
-    assert.strictEqual(downloadedUrl, 'https://inquiry.si14bm.com/install.sh');
+    assert.strictEqual(downloadedUrl, 'https://inquiry.ccisne.dev/install.sh');
     assert.strictEqual(spawnedCmd, 'bash');
   });
 

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -18,7 +18,7 @@ The pattern was forming: **Analyze → Plan → Execute.**
 
 ## The Inquiry repo is born
 
-**2026-03-30.** The `inquiry` repo (then called `finite_ape_machine`) was created with a first commit ([`a1cd601`](https://github.com/SiliconBrainedMachines/inquiry/commit/a1cd601)). Initially it was a documentation-only project: agent role definitions, lore, architecture decision records. No CLI yet — just the intellectual scaffolding for what would become the Finite APE Machine.
+**2026-03-30.** The `inquiry` repo (then called `finite_ape_machine`) was created with a first commit ([`a1cd601`](https://github.com/ccisnedev/inquiry/commit/a1cd601)). Initially it was a documentation-only project: agent role definitions, lore, architecture decision records. No CLI yet — just the intellectual scaffolding for what would become the Finite APE Machine.
 
 ## The book begins
 
@@ -53,9 +53,9 @@ Each agent embodied a philosophical tradition. Each tradition had been tested fo
 
 ## The CLI is born
 
-**2026-04-15.** The same day SOCRATES was defined, the CLI work began. The manual symlink process (copy prompt to `~/.copilot/`) was a friction point. A CLI that automated deployment was the natural next step. Inspired by [gentle-ai](https://github.com/Gentleman-Programming/gentle-ai) (Gentleman Programming) — a project that packaged prompts and skills via a CLI — I started building a Dart CLI on [`modular_cli_sdk`](https://github.com/siliconbrainedmachines/modular_cli_sdk).
+**2026-04-15.** The same day SOCRATES was defined, the CLI work began. The manual symlink process (copy prompt to `~/.copilot/`) was a friction point. A CLI that automated deployment was the natural next step. Inspired by [gentle-ai](https://github.com/Gentleman-Programming/gentle-ai) (Gentleman Programming) — a project that packaged prompts and skills via a CLI — I started building a Dart CLI on [`modular_cli_sdk`](https://github.com/ccisnedev/modular_cli_sdk).
 
-Commits [`44150463`](https://github.com/SiliconBrainedMachines/inquiry/commit/44150463) (scaffold) and [`45fba9e`](https://github.com/SiliconBrainedMachines/inquiry/commit/45fba9e) (`ape init` command) landed that day.
+Commits [`44150463`](https://github.com/ccisnedev/inquiry/commit/44150463) (scaffold) and [`45fba9e`](https://github.com/ccisnedev/inquiry/commit/45fba9e) (`ape init` command) landed that day.
 
 ## Rapid evolution: v0.0.2 to v0.0.14
 
@@ -77,7 +77,7 @@ From this point on, APE was building APE. Every CLI feature was developed using 
 
 ## Peirce and the philosophical grounding
 
-**2026-04-20.** Research into why APE's three-phase structure worked led to Charles Sanders Peirce's theory of inquiry. Commit [`feat: agregar documentación sobre la teoría de la indagación de Peirce`](https://github.com/SiliconBrainedMachines/inquiry/commit/feat) revealed the mapping:
+**2026-04-20.** Research into why APE's three-phase structure worked led to Charles Sanders Peirce's theory of inquiry. Commit [`feat: agregar documentación sobre la teoría de la indagación de Peirce`](https://github.com/ccisnedev/inquiry/commit/feat) revealed the mapping:
 
 | Peirce's inquiry | APE phase | Agent |
 |------------------|-----------|-------|
@@ -85,11 +85,11 @@ From this point on, APE was building APE. Every CLI feature was developed using 
 | **Deduction** — derive consequences from hypotheses | PLAN | DESCARTES |
 | **Induction** — test consequences against reality | EXECUTE | BASHŌ |
 
-APE wasn't just a workflow — it was an implementation of the oldest formal theory of structured investigation. The name **Inquiry** was chosen the same day ([`docs(110): analysis complete - inquiry chosen as APE primary noun`](https://github.com/SiliconBrainedMachines/inquiry/commit/docs-110)).
+APE wasn't just a workflow — it was an implementation of the oldest formal theory of structured investigation. The name **Inquiry** was chosen the same day ([`docs(110): analysis complete - inquiry chosen as APE primary noun`](https://github.com/ccisnedev/inquiry/commit/docs-110)).
 
 ## The VS Code extension
 
-**2026-04-19.** A VS Code extension was created to bring Inquiry into the editor: status bar showing FSM state, commands for `init`, `toggleEvolution`, and `addMutation`. Published to the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=siliconbrainedmachines.inquiry-vscode) the same day. Built entirely using the APE cycle (issue #82).
+**2026-04-19.** A VS Code extension was created to bring Inquiry into the editor: status bar showing FSM state, commands for `init`, `toggleEvolution`, and `addMutation`. Published to the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ccisnedev.inquiry-vscode) the same day. Built entirely using the APE cycle (issue #82).
 
 ## The rebrand
 


### PR DESCRIPTION
Migrates all project identity from SiliconBrainedMachines org to ccisnedev personal brand. Domain, repo URLs, VS Code publisher, site links. 360 tests passing.