### PR TITLE
feat(#160): Extract FSM state instructions into prompt YAML files

### DIFF
--- a/cleanrooms/160-extract-fsm-state-instructions-into-prompt-yaml/analyze/diagnosis.md
+++ b/cleanrooms/160-extract-fsm-state-instructions-into-prompt-yaml/analyze/diagnosis.md
@@ -1,0 +1,116 @@
+---
+title: "Extract FSM state instructions into prompt YAML files"
+issue: 160
+date: 2026-04-29
+status: confirmed
+---
+
+# Diagnosis: FSM State Instructions Extraction
+
+## Problem Defined
+
+State instructions are hardcoded in Dart (`_stateInstructions` in `state.dart`), mixing CLI mechanical logic with prompt content. This prevents:
+
+- Iterating on state behavior without recompiling the binary
+- Auditing state rules as plain text
+- Declaring constraints (read-only mode, allowed actions) per state
+- Having a clear layered architecture: mechanics → mission → methodology
+
+Additionally, the CLI lacks:
+- Self-integrity validation (missing assets go undetected until runtime failure)
+- Version-awareness at startup (users don't know an update exists)
+- A repair mechanism when assets are corrupted/missing
+
+## Decisions Taken
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Fail hard on missing YAML | Yes | Assets are packaged with binary — missing = broken deployment |
+| Recovery mechanism | `iq doctor --fix` | Runs remediations sequentially; downloads assets from current version's release |
+| Version check location | `iq doctor` + `iq` (bare) | Non-blocking; silent on network failure |
+| `--fix` behavior | Execute all remediations, report per-step | Like `apt --fix-broken` — one failure doesn't block others |
+| Schema for state YAML | `instructions` + `constraints` + `allowed_actions` | Separates mission from method |
+| IDLE must run `iq doctor` first | Yes | Validates environment before any triage work |
+
+## Scope
+
+### In scope
+
+1. **Extract prompts to YAML** — Create `assets/fsm/states/{idle,analyze,plan,execute,end,evolution}.yaml`
+2. **Doctor: validate internal assets** — Verify `apes/*.yaml`, `fsm/states/*.yaml`, `skills/*/SKILL.md` exist
+3. **Doctor: check for new version** — Hit GitHub API, suggest `iq upgrade`
+4. **Doctor `--fix`** — Execute remediations sequentially (download assets from release of current version if missing)
+5. **TUI (`iq` bare): version check** — Show banner if update available
+6. **IDLE scheduler runs `iq doctor` first** — Update `_stateInstructions` (or its replacement) and `inquiry.agent.md`
+
+### Out of scope
+
+- Changing APE sub-agent methodology (socrates-idle.yaml stays as-is)
+- Adding `--force` to `iq upgrade` (not semantically correct for repair)
+- Modifying transition_contract.yaml mechanics
+- Changing the FSM state machine itself
+
+## Constraints & Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Missing YAML after extraction | High | Doctor validates + `--fix` repairs |
+| Network failure on version check | Low | Silent fallback — CLI works offline |
+| Malformed YAML in state file | High | Try-catch with clear error message pointing to `iq doctor --fix` |
+| build/assets drift from source | Medium | CI/build step must sync; doctor could detect |
+| Breaking change in state YAML schema | Low | Version field in YAML for future migrations |
+
+## Architecture: Three-Layer Model
+
+```
+transition_contract.yaml    ← MECHANICS (events, states, prechecks, effects)
+states/idle.yaml            ← MISSION (instructions, constraints, allowed_actions)
+apes/socrates-idle.yaml     ← METHOD (how the sub-agent executes the mission)
+```
+
+## Proposed State YAML Schema
+
+```yaml
+name: idle
+version: "1.0.0"
+description: "Triage and issue formulation"
+
+instructions: |
+  Evaluate what work merits inquiry. Understand the problem,
+  search for existing issues, create or select an issue.
+
+constraints:
+  - Read-only mode — no code edits
+  - No file creation outside of GitHub issues
+  - No branch preparation (belongs to transition prechecks)
+  - No analysis of root causes (belongs to ANALYZE)
+
+allowed_actions:
+  - Create GitHub issues
+  - Edit GitHub issues
+  - Comment on GitHub issues
+  - Search codebase (read-only)
+  - Discuss and clarify with user
+  - Run iq doctor
+```
+
+## Files Affected
+
+| File | Change |
+|------|--------|
+| `code/cli/lib/modules/fsm/commands/state.dart` | Remove `_stateInstructions`, load from YAML |
+| `code/cli/assets/fsm/states/*.yaml` | **New** — 6 files |
+| `code/cli/lib/modules/global/commands/doctor.dart` | Add asset integrity check + version check + `--fix` flag |
+| `code/cli/lib/modules/global/commands/tui.dart` | Add version check banner |
+| `code/cli/lib/modules/global/global_builder.dart` | Wire `--fix` flag to doctor |
+| `code/cli/assets/agents/inquiry.agent.md` | Add "run `iq doctor` first in IDLE" to firmware |
+| `code/cli/test/` | Update tests for new behavior |
+| `code/cli/build/assets/` | Sync after merge |
+
+## References
+
+- [state.dart#L183](code/cli/lib/modules/fsm/commands/state.dart) — current hardcoded instructions
+- [doctor.dart](code/cli/lib/modules/global/commands/doctor.dart) — existing doctor checks
+- [upgrade.dart](code/cli/lib/modules/global/commands/upgrade.dart) — GitHub API pattern for version check
+- [socrates-idle.yaml](code/cli/assets/apes/socrates-idle.yaml) — APE YAML pattern to follow
+- [transition_contract.yaml](code/cli/assets/fsm/transition_contract.yaml) — mechanics layer (unchanged)

--- a/cleanrooms/160-extract-fsm-state-instructions-into-prompt-yaml/plan.md
+++ b/cleanrooms/160-extract-fsm-state-instructions-into-prompt-yaml/plan.md
@@ -1,0 +1,144 @@
+---
+title: "Extract FSM state instructions into prompt YAML files"
+issue: 160
+date: 2026-04-29
+status: complete
+---
+
+# Plan: Issue #160
+
+## Phase 1 — Create state YAML files
+
+**Objective:** Extract hardcoded instructions into `assets/fsm/states/*.yaml`
+
+### Tasks
+
+- [x] 1.1 Create `assets/fsm/states/idle.yaml`
+- [x] 1.2 Create `assets/fsm/states/analyze.yaml`
+- [x] 1.3 Create `assets/fsm/states/plan.yaml`
+- [x] 1.4 Create `assets/fsm/states/execute.yaml`
+- [x] 1.5 Create `assets/fsm/states/end.yaml`
+- [x] 1.6 Create `assets/fsm/states/evolution.yaml`
+
+### Verification
+
+- All 6 files parse as valid YAML
+- Each contains: `name`, `version`, `description`, `instructions`, `constraints`, `allowed_actions`
+- `dart test` passes (no regressions)
+
+---
+
+## Phase 2 — Load instructions from YAML in state.dart
+
+**Objective:** Replace `_stateInstructions` with YAML loading
+
+### Tasks
+
+- [x] 2.1 Add `_loadStateInstructions(FsmState)` method that reads from `assets/fsm/states/{state}.yaml`
+- [x] 2.2 Fail hard with `CommandException` if YAML missing/malformed, message: `State instructions missing for {state}. Run 'iq doctor --fix' to repair.`
+- [x] 2.3 Remove `_stateInstructions` static const
+- [x] 2.4 Update `_computeInstructions()` to call new loader
+- [x] 2.5 Update existing tests
+
+### Verification
+
+- `iq fsm state --json` returns same instructions as before
+- Deleting a YAML file → clear error with remediation message
+- `dart test` passes
+
+---
+
+## Phase 3 — Doctor: validate internal assets
+
+**Objective:** Add asset integrity check to `iq doctor`
+
+### Tasks
+
+- [x] 3.1 Add `_checkInternalAssets()` method in `DoctorCommand`
+- [x] 3.2 Verify existence of: `apes/*.yaml` (5 files), `fsm/states/*.yaml` (6 files), `skills/*/SKILL.md` (4 files), `fsm/transition_contract.yaml`
+- [x] 3.3 Report missing files as failed checks with `remediation: "Run 'iq doctor --fix' to restore"`
+- [x] 3.4 Add tests
+
+### Verification
+
+- `iq doctor` shows ✓ when all assets present
+- `iq doctor` shows ✗ with remediation when asset missing
+- `dart test` passes
+
+---
+
+## Phase 4 — Doctor: version check
+
+**Objective:** Check for new version in `iq doctor` and `iq` bare
+
+### Tasks
+
+- [x] 4.1 Extract version-check logic from `UpgradeCommand` into shared utility (e.g., `lib/src/version_check.dart`)
+- [x] 4.2 Add version check to `DoctorCommand.execute()` — non-blocking, silent on network failure
+- [x] 4.3 Add version banner to `TuiCommand.execute()` — `"Update available: X → Y — run 'iq upgrade'"`
+- [x] 4.4 Add tests (mock HTTP)
+
+### Verification
+
+- `iq doctor` shows "Update available" when newer version exists
+- `iq` bare shows banner
+- Network failure → no crash, no extra output
+- `dart test` passes
+
+---
+
+## Phase 5 — Doctor `--fix`
+
+**Objective:** Execute remediations when `--fix` flag is passed
+
+### Tasks
+
+- [x] 5.1 Add `--fix` flag to `DoctorInput` / `DoctorInput.fromCliRequest`
+- [x] 5.2 Wire flag in `global_builder.dart`
+- [x] 5.3 Implement fix logic: for missing assets → download zip from `https://github.com/ccisnedev/inquiry/releases/download/v{version}/` and extract `assets/` over installation
+- [x] 5.4 Report each remediation step with ✓/✗
+- [x] 5.5 Add tests
+
+### Verification
+
+- `iq doctor --fix` with missing asset → downloads and restores
+- `iq doctor --fix` with all healthy → "Nothing to fix"
+- Network failure during fix → clear error
+- `dart test` passes
+
+---
+
+## Phase 6 — IDLE scheduler runs doctor first
+
+**Objective:** Update firmware so IDLE always begins with `iq doctor`
+
+### Tasks
+
+- [x] 6.1 Update `assets/fsm/states/idle.yaml` instructions to include "Run `iq doctor` as first action"
+- [x] 6.2 Update `assets/agents/inquiry.agent.md` firmware: in IDLE state, run `iq doctor` before presenting transitions
+
+### Verification
+
+- Scheduler in IDLE runs `iq doctor` first
+- If doctor fails, scheduler presents remediation options before proceeding
+
+---
+
+## Dependency Order
+
+```
+Phase 1 → Phase 2 (need YAML files before loading them)
+Phase 3 → Phase 5 (need checks before --fix can run them)
+Phase 4 is independent (can parallel with 3)
+Phase 6 depends on Phase 1 (idle.yaml must exist)
+```
+
+## Exit Criteria
+
+- All 6 state YAML files exist and are loaded at runtime
+- `iq fsm state --json` returns instructions from YAML (not hardcoded)
+- `iq doctor` validates asset integrity + checks for updates
+- `iq doctor --fix` repairs missing assets
+- `iq` bare shows update banner
+- All tests pass
+- No hardcoded state instructions remain in Dart code

--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -12,6 +12,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 - **Doctor `--fix`** (#160): `iq doctor --fix` downloads and restores missing assets from GitHub release
 - **IDLE doctor-first** (#160): firmware instructs scheduler to run `iq doctor` as first action in IDLE
 - **TUI shows Evolution** (#160): diagram displays `[Evolution]` as optional stage
+- **Cleanroom auto-creation** (#160): `iq fsm transition --event start_analyze` creates `cleanrooms/<branch>/analyze/index.md` automatically
+- **Commit gate** (#160): `iq ape transition --event next_phase` requires at least one commit on the feature branch before advancing to next phase
 
 ### Changed
 - **Firmware v0.3.1** (#160): Outer Loop step 2 runs doctor in IDLE before dispatching sub-agents

--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.1]
+### Added
+- **State YAML files** (#160): FSM instructions extracted into `assets/fsm/states/*.yaml` — no more hardcoded strings
+- **Doctor asset validation** (#160): `iq doctor` verifies integrity of internal assets (apes, states, skills, contract)
+- **Doctor version check** (#160): `iq doctor` and `iq` bare check for newer releases via GitHub API
+- **Doctor `--fix`** (#160): `iq doctor --fix` downloads and restores missing assets from GitHub release
+- **IDLE doctor-first** (#160): firmware instructs scheduler to run `iq doctor` as first action in IDLE
+- **TUI shows Evolution** (#160): diagram displays `[Evolution]` as optional stage
+
+### Changed
+- **Firmware v0.3.1** (#160): Outer Loop step 2 runs doctor in IDLE before dispatching sub-agents
+
 ## [0.3.0]
 ### Changed
 - **State encapsulation** (#152): `iq fsm state --json` transitions no longer expose `next_state` — agents see only available events

--- a/code/cli/assets/agents/inquiry.agent.md
+++ b/code/cli/assets/agents/inquiry.agent.md
@@ -4,7 +4,7 @@ description: 'Inquiry — a strict FSM scheduler for structured task delivery. D
 tools: [vscode, execute, read, agent, edit, search, web, browser, todo]
 ---
 
-# Inquiry Scheduler — Firmware v0.3.0
+# Inquiry Scheduler — Firmware v0.3.1
 
 You are a **scheduler**. You operate a dual FSM (main + per-APE). You never think, analyze, plan, or implement yourself — sub-agents do that. You orchestrate via CLI commands only.
 

--- a/code/cli/assets/agents/inquiry.agent.md
+++ b/code/cli/assets/agents/inquiry.agent.md
@@ -21,13 +21,14 @@ Run `iq fsm state --json` to read current state. Parse the JSON:
 ## Outer Loop (Main FSM)
 
 1. Announce state: `[INQUIRY]`
-2. Read `instructions` — this describes what the current state does
-3. If `ape` is active: enter Inner Loop
-4. If `ape` is null: follow `instructions` and present `transitions[]` to user
-5. After APE reaches `_DONE`: read `completion_authority`:
+2. If state is `IDLE`: run `iq doctor` first to validate environment and check for updates
+3. Read `instructions` — this describes what the current state does
+4. If `ape` is active: enter Inner Loop
+5. If `ape` is null: follow `instructions` and present `transitions[]` to user
+6. After APE reaches `_DONE`: read `completion_authority`:
    - If `"user"`: ask ONE yes/no question to confirm, then `iq fsm transition --event <event>`
    - If `"automatic"`: `iq fsm transition --event <event>` immediately
-6. After transition: re-run `iq fsm state --json` and loop
+7. After transition: re-run `iq fsm state --json` and loop
 
 ## Inner Loop (Per-APE FSM)
 

--- a/code/cli/assets/fsm/states/analyze.yaml
+++ b/code/cli/assets/fsm/states/analyze.yaml
@@ -1,0 +1,21 @@
+name: analyze
+version: "1.0.0"
+description: "Deep investigation via structured questioning"
+
+instructions: |
+  Investigate the problem through structured questioning.
+  Challenge assumptions, gather evidence, explore perspectives.
+  Produce diagnosis.md as the sole input for planning.
+
+constraints:
+  - No solution proposals (belongs to PLAN)
+  - No code edits (belongs to EXECUTE)
+  - No branch creation (already on feature branch)
+  - Analysis must produce diagnosis.md before transitioning
+
+allowed_actions:
+  - Read and search codebase
+  - Ask clarifying questions
+  - Challenge assumptions
+  - Document findings in cleanroom analyze/
+  - Produce diagnosis.md

--- a/code/cli/assets/fsm/states/end.yaml
+++ b/code/cli/assets/fsm/states/end.yaml
@@ -1,0 +1,16 @@
+name: end
+version: "1.0.0"
+description: "Review execution and create pull request"
+
+instructions: |
+  Review the execution. Create the pull request.
+
+constraints:
+  - No new code changes (execution is complete)
+  - PR description must reference the issue
+  - All tests must pass before PR creation
+
+allowed_actions:
+  - Review completed work
+  - Create pull request
+  - Push branch

--- a/code/cli/assets/fsm/states/evolution.yaml
+++ b/code/cli/assets/fsm/states/evolution.yaml
@@ -1,0 +1,18 @@
+name: evolution
+version: "1.0.0"
+description: "Cycle evaluation and process improvement"
+
+instructions: |
+  Evaluate the completed cycle. Observe what worked,
+  what deviated, what can improve. Create improvement issues.
+
+constraints:
+  - No code edits (cycle is closed)
+  - Observations must be evidence-based
+  - Improvement issues must be atomic and actionable
+
+allowed_actions:
+  - Review cycle artifacts (diagnosis, plan, commits, PR)
+  - Document observations in mutations.md
+  - Create improvement issues on GitHub
+  - Collect metrics

--- a/code/cli/assets/fsm/states/execute.yaml
+++ b/code/cli/assets/fsm/states/execute.yaml
@@ -1,0 +1,20 @@
+name: execute
+version: "1.0.0"
+description: "Implementation under plan constraints"
+
+instructions: |
+  Implement the plan phase by phase under its formal constraints.
+  Each phase produces tested code and a commit.
+
+constraints:
+  - Follow plan.md phases in order
+  - Each phase must pass its verification criteria before advancing
+  - Commits must be atomic (one phase = one commit)
+  - No scope creep — only implement what plan.md specifies
+
+allowed_actions:
+  - Edit code files
+  - Create new files as specified in plan
+  - Run tests
+  - Commit completed phases
+  - Read plan.md for guidance

--- a/code/cli/assets/fsm/states/idle.yaml
+++ b/code/cli/assets/fsm/states/idle.yaml
@@ -1,0 +1,23 @@
+name: idle
+version: "1.0.0"
+description: "Triage and issue formulation"
+
+instructions: |
+  Evaluate what work merits inquiry. Understand the problem,
+  search for existing issues, create or select an issue.
+  Run 'iq doctor' as first action to validate environment.
+
+constraints:
+  - Read-only mode — no code edits
+  - No file creation outside of GitHub issues
+  - No branch preparation (belongs to transition prechecks)
+  - No analysis of root causes (belongs to ANALYZE)
+  - No solution proposals (belongs to PLAN)
+
+allowed_actions:
+  - Create GitHub issues
+  - Edit GitHub issues
+  - Comment on GitHub issues
+  - Search codebase (read-only)
+  - Discuss and clarify with user
+  - Run iq doctor

--- a/code/cli/assets/fsm/states/plan.yaml
+++ b/code/cli/assets/fsm/states/plan.yaml
@@ -1,0 +1,21 @@
+name: plan
+version: "1.0.0"
+description: "Experimental plan design from diagnosis"
+
+instructions: |
+  Design an experimental plan from the diagnosis.
+  Divide into phases, order by dependencies,
+  define verification criteria for each phase.
+  Produce plan.md.
+
+constraints:
+  - No code edits (belongs to EXECUTE)
+  - Plan must reference diagnosis.md decisions
+  - Each phase must have verification criteria
+  - Plan must be approved by user before transitioning
+
+allowed_actions:
+  - Read diagnosis.md and codebase
+  - Decompose work into ordered phases
+  - Define verification per phase
+  - Produce plan.md in cleanroom

--- a/code/cli/lib/modules/ape/commands/transition.dart
+++ b/code/cli/lib/modules/ape/commands/transition.dart
@@ -146,6 +146,21 @@ class ApeTransitionCommand implements Command<ApeTransitionInput, ApeTransitionO
       );
     }
 
+    // Gate: basho commit→implement requires a new commit
+    if (inquiryState.apeName == 'basho' &&
+        fromState == 'commit' &&
+        match.to == 'implement') {
+      final hasCommit = _hasUnpushedCommitSinceLastTransition();
+      if (!hasCommit) {
+        throw CommandException(
+          code: 'COMMIT_REQUIRED',
+          message: 'Cannot advance to next phase without committing. '
+              'Commit your changes first, then retry.',
+          exitCode: ExitCode.validationFailed,
+        );
+      }
+    }
+
     // Write the new sub-state
     final newState = inquiryState.copyWith(apeState: match.to);
     newState.save(input.workingDirectory);
@@ -163,5 +178,45 @@ class ApeTransitionCommand implements Command<ApeTransitionInput, ApeTransitionO
       return _assets.path('apes/$name.yaml');
     }
     return p.join(input.workingDirectory, 'assets', 'apes', '$name.yaml');
+  }
+
+  /// Check if there's at least one commit on the current branch since
+  /// it diverged from the default branch (main or master).
+  bool _hasUnpushedCommitSinceLastTransition() {
+    try {
+      // Determine default branch
+      final defaultBranch = _resolveDefaultBranch();
+      if (defaultBranch == null) {
+        // No main/master found — can't validate, allow transition
+        return true;
+      }
+
+      // Count commits on HEAD that are not on the default branch
+      final result = Process.runSync(
+        'git',
+        ['rev-list', '--count', '$defaultBranch..HEAD'],
+        workingDirectory: input.workingDirectory,
+      );
+      if (result.exitCode == 0) {
+        final count = int.tryParse((result.stdout as String).trim()) ?? 0;
+        return count > 0;
+      }
+      return true; // git failed — don't block
+    } catch (_) {
+      // If git fails, don't block — allow transition
+      return true;
+    }
+  }
+
+  String? _resolveDefaultBranch() {
+    for (final branch in ['main', 'master']) {
+      final result = Process.runSync(
+        'git',
+        ['rev-parse', '--verify', branch],
+        workingDirectory: input.workingDirectory,
+      );
+      if (result.exitCode == 0) return branch;
+    }
+    return null;
   }
 }

--- a/code/cli/lib/modules/fsm/commands/state.dart
+++ b/code/cli/lib/modules/fsm/commands/state.dart
@@ -180,23 +180,38 @@ class FsmStateCommand implements Command<FsmStateInput, FsmStateOutput> {
     return _stateApes[state] ?? [];
   }
 
-  static const _stateInstructions = <FsmState, String>{
-    FsmState.idle:
-        'Evaluate what work merits inquiry. Understand the problem, search for existing issues, create or select an issue, prepare the branch.',
-    FsmState.analyze:
-        'Investigate the problem through structured questioning. Challenge assumptions, gather evidence, explore perspectives. Produce diagnosis.md.',
-    FsmState.plan:
-        'Design an experimental plan from the diagnosis. Divide into phases, order by dependencies, define verification for each. Produce plan.md.',
-    FsmState.execute:
-        'Implement the plan phase by phase under its formal constraints. Each phase produces tested code and a commit.',
-    FsmState.end:
-        'Review the execution. Create the pull request.',
-    FsmState.evolution:
-        'Evaluate the completed cycle. Observe what worked, what deviated, what can improve. Create improvement issues.',
-  };
-
   String _computeInstructions(FsmState state) {
-    return _stateInstructions[state] ?? 'Unknown state: ${state.value}';
+    final stateName = state.value.toLowerCase();
+    try {
+      final yamlPath = _assets != null
+          ? _assets.path('fsm/states/$stateName.yaml')
+          : p.join(input.workingDirectory, 'assets', 'fsm', 'states', '$stateName.yaml');
+      final content = File(yamlPath).readAsStringSync();
+      final yaml = loadYaml(content);
+      if (yaml is YamlMap && yaml['instructions'] is String) {
+        return (yaml['instructions'] as String).trim();
+      }
+      throw CommandException(
+        code: 'MALFORMED_STATE_YAML',
+        message: "State file for '$stateName' is missing 'instructions' field. "
+            "Run 'iq doctor --fix' to repair.",
+        exitCode: ExitCode.genericError,
+      );
+    } on PathNotFoundException {
+      throw CommandException(
+        code: 'MISSING_STATE_YAML',
+        message: "State instructions missing for '$stateName'. "
+            "Run 'iq doctor --fix' to repair.",
+        exitCode: ExitCode.genericError,
+      );
+    } on FileSystemException {
+      throw CommandException(
+        code: 'MISSING_STATE_YAML',
+        message: "State instructions missing for '$stateName'. "
+            "Run 'iq doctor --fix' to repair.",
+        exitCode: ExitCode.genericError,
+      );
+    }
   }
 
   /// Build `ape` info from InquiryState + APE YAML definition.

--- a/code/cli/lib/modules/fsm/effect_executor.dart
+++ b/code/cli/lib/modules/fsm/effect_executor.dart
@@ -20,6 +20,7 @@ const cliEffects = {
   'snapshot_metrics',
   'close_cycle',
   'collect_metrics',
+  'open_analysis_context',
 };
 
 class EffectExecutor {
@@ -74,6 +75,52 @@ class EffectExecutor {
       apeState: apeInitialState,
     );
     updated.save(workingDirectory);
+  }
+
+  /// Create `cleanrooms/<branch>/analyze/index.md` for ANALYZE phase.
+  void openAnalysisContext() {
+    final branch = _getCurrentBranch();
+    if (branch.isEmpty) return;
+
+    final issue = InquiryState.load(workingDirectory).issue ?? '';
+    final cleanroomDir = p.join(workingDirectory, 'cleanrooms', branch, 'analyze');
+    final dir = Directory(cleanroomDir);
+    if (!dir.existsSync()) {
+      dir.createSync(recursive: true);
+    }
+
+    final indexFile = File(p.join(cleanroomDir, 'index.md'));
+    if (!indexFile.existsSync()) {
+      indexFile.writeAsStringSync(
+        '# Analyze Phase — Index\n'
+        '\n'
+        '**Issue:** #$issue\n'
+        '**Branch:** $branch\n'
+        '**Phase:** ANALYZE\n'
+        '**Status:** In progress\n'
+        '\n'
+        '---\n'
+        '\n'
+        '## Documents\n'
+        '\n'
+        '| # | File | Description |\n'
+        '|---|------|-------------|\n',
+      );
+    }
+  }
+
+  String _getCurrentBranch() {
+    try {
+      final result = Process.runSync(
+        'git',
+        ['rev-parse', '--abbrev-ref', 'HEAD'],
+        workingDirectory: workingDirectory,
+      );
+      if (result.exitCode != 0) return '';
+      return (result.stdout as String).trim();
+    } catch (_) {
+      return '';
+    }
   }
 
   /// Reset `.inquiry/mutations.md` to empty template.
@@ -158,6 +205,9 @@ class EffectExecutor {
 
     for (final effect in effects) {
       switch (effect) {
+        case 'open_analysis_context':
+          openAnalysisContext();
+          executed.add(effect);
         case 'reset_mutations':
           resetMutations();
           executed.add(effect);

--- a/code/cli/lib/modules/global/commands/doctor.dart
+++ b/code/cli/lib/modules/global/commands/doctor.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as p;
 
 import '../../../assets.dart';
 import '../../../src/version.dart' as version_lib;
+import '../../../src/version_check.dart';
 import '../../../targets/copilot_adapter.dart';
 import '../../../targets/target_adapter.dart';
 
@@ -78,14 +79,18 @@ class TargetCheck {
 
 /// Input for the doctor command.
 ///
-/// No parameters required — doctor checks system state.
+/// Accepts an optional `--fix` flag to auto-remediate failures.
 class DoctorInput extends Input {
-  DoctorInput();
+  final bool fix;
 
-  factory DoctorInput.fromCliRequest(CliRequest req) => DoctorInput();
+  DoctorInput({this.fix = false});
+
+  factory DoctorInput.fromCliRequest(CliRequest req) => DoctorInput(
+    fix: req.flagBool('fix'),
+  );
 
   @override
-  Map<String, dynamic> toJson() => {};
+  Map<String, dynamic> toJson() => {'fix': fix};
 }
 
 /// Output for the doctor command.
@@ -193,6 +198,8 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
   final FileSystemOps _fileSystem;
   final Assets? _assets;
   final List<TargetAdapter> _activeAdapters;
+  final Future<VersionCheckResult> Function({required String currentVersion})?
+      _versionChecker;
 
   /// Current Inquiry version (injected for testability).
   final String inquiryVersion;
@@ -204,10 +211,13 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
     FileSystemOps? fileSystemOps,
     Assets? assets,
     List<TargetAdapter>? activeAdapters,
+    Future<VersionCheckResult> Function({required String currentVersion})?
+        versionChecker,
   }) : _runProcess = runProcess ?? Process.run,
        _fileSystem = fileSystemOps ?? RealFileSystemOps(),
        _assets = assets,
        _activeAdapters = activeAdapters ?? [CopilotAdapter()],
+       _versionChecker = versionChecker,
        inquiryVersion = inquiryVersionOverride ?? version_lib.inquiryVersion;
 
   @override
@@ -273,6 +283,38 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
       prereqPassed = false;
     }
 
+    // Check 6: Internal assets integrity
+    final assetCheck = _checkInternalAssets();
+    if (assetCheck != null) {
+      checks.add(assetCheck);
+      if (!assetCheck.passed) {
+        if (input.fix) {
+          final fixResult = await _fixAssets();
+          checks.add(fixResult);
+          if (fixResult.passed) {
+            // Re-check after fix
+            final recheck = _checkInternalAssets();
+            if (recheck == null || recheck.passed) {
+              // Remove the failed check, it's been fixed
+              checks.remove(assetCheck);
+            } else {
+              prereqPassed = false;
+            }
+          } else {
+            prereqPassed = false;
+          }
+        } else {
+          prereqPassed = false;
+        }
+      }
+    }
+
+    // Check 7: Version check (non-blocking)
+    final versionCheck = await _checkVersion();
+    if (versionCheck != null) {
+      checks.add(versionCheck);
+    }
+
     // Target checks
     final targetChecks = <TargetCheck>[];
     for (final adapter in _activeAdapters) {
@@ -326,6 +368,185 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
       missingSkills: missingSkills,
       totalSkills: expectedSkills.length,
     );
+  }
+
+  /// Checks that all expected internal assets exist on disk.
+  ///
+  /// Returns null if no [_assets] is available (cannot verify).
+  DoctorCheck? _checkInternalAssets() {
+    if (_assets == null) return null;
+
+    final missing = <String>[];
+
+    // FSM state instruction files
+    const stateFiles = ['idle', 'analyze', 'plan', 'execute', 'end', 'evolution'];
+    for (final state in stateFiles) {
+      final path = _assets.path('fsm/states/$state.yaml');
+      if (!File(path).existsSync()) {
+        missing.add('fsm/states/$state.yaml');
+      }
+    }
+
+    // APE definition files
+    const apeFiles = ['socrates', 'socrates-idle', 'descartes', 'basho', 'darwin'];
+    for (final ape in apeFiles) {
+      final path = _assets.path('apes/$ape.yaml');
+      if (!File(path).existsSync()) {
+        missing.add('apes/$ape.yaml');
+      }
+    }
+
+    // Transition contract
+    final contractPath = _assets.path('fsm/transition_contract.yaml');
+    if (!File(contractPath).existsSync()) {
+      missing.add('fsm/transition_contract.yaml');
+    }
+
+    // Skills
+    try {
+      final skills = _assets.listDirectory('skills');
+      for (final skill in skills) {
+        final path = _assets.path('skills/$skill/SKILL.md');
+        if (!File(path).existsSync()) {
+          missing.add('skills/$skill/SKILL.md');
+        }
+      }
+    } catch (_) {
+      missing.add('skills/ (directory missing)');
+    }
+
+    if (missing.isEmpty) {
+      return DoctorCheck(name: 'assets', passed: true);
+    }
+
+    return DoctorCheck(
+      name: 'assets',
+      passed: false,
+      error: '${missing.length} missing: ${missing.join(', ')}',
+      remediation: "Run 'iq doctor --fix' to restore missing assets",
+    );
+  }
+
+  /// Downloads and restores missing assets from the current version's release.
+  Future<DoctorCheck> _fixAssets() async {
+    if (_assets == null) {
+      return DoctorCheck(
+        name: 'fix',
+        passed: false,
+        error: 'Cannot determine asset location',
+      );
+    }
+
+    try {
+      stderr.writeln('Downloading assets for v$inquiryVersion...');
+      final client = HttpClient();
+      client.connectionTimeout = const Duration(seconds: 10);
+
+      final assetName = Platform.isWindows
+          ? 'inquiry-windows-x64.zip'
+          : 'inquiry-linux-x64.tar.gz';
+
+      final downloadUrl = Uri.parse(
+        'https://github.com/ccisnedev/inquiry/releases/download/v$inquiryVersion/$assetName',
+      );
+
+      final request = await client.getUrl(downloadUrl);
+      request.headers.set('User-Agent', 'inquiry-cli/$inquiryVersion');
+      request.followRedirects = true;
+      final response = await request.close();
+
+      if (response.statusCode != 200) {
+        await response.drain<void>();
+        client.close();
+        return DoctorCheck(
+          name: 'fix',
+          passed: false,
+          error: 'Failed to download assets (HTTP ${response.statusCode})',
+        );
+      }
+
+      // Save to temp and extract
+      final tempDir = Directory.systemTemp.createTempSync('iq_fix_');
+      final archiveFile = File(p.join(tempDir.path, assetName));
+      final sink = archiveFile.openWrite();
+      await response.pipe(sink);
+      client.close();
+
+      // Extract to the asset root's parent (which is the install dir)
+      final installDir = p.dirname(_assets.path(''));
+      // Remove trailing 'assets' from path to get install root
+      final installRoot = installDir.endsWith('assets${p.separator}') ||
+              installDir.endsWith('assets')
+          ? p.dirname(installDir)
+          : p.dirname(p.dirname(installDir));
+
+      stderr.writeln('Extracting to: $installRoot');
+
+      if (Platform.isWindows) {
+        final result = await Process.run('powershell', [
+          '-NoProfile',
+          '-Command',
+          'Expand-Archive',
+          '-Path', archiveFile.path,
+          '-DestinationPath', installRoot,
+          '-Force',
+        ]);
+        if (result.exitCode != 0) {
+          tempDir.deleteSync(recursive: true);
+          return DoctorCheck(
+            name: 'fix',
+            passed: false,
+            error: 'Extraction failed: ${result.stderr}',
+          );
+        }
+      } else {
+        final result = await Process.run('tar', [
+          '-xzf', archiveFile.path,
+          '-C', installRoot,
+        ]);
+        if (result.exitCode != 0) {
+          tempDir.deleteSync(recursive: true);
+          return DoctorCheck(
+            name: 'fix',
+            passed: false,
+            error: 'Extraction failed: ${result.stderr}',
+          );
+        }
+      }
+
+      tempDir.deleteSync(recursive: true);
+      stderr.writeln('✓ Assets restored successfully');
+      return DoctorCheck(name: 'fix', passed: true, version: 'restored');
+    } on Exception catch (e) {
+      return DoctorCheck(
+        name: 'fix',
+        passed: false,
+        error: 'Fix failed: $e',
+      );
+    }
+  }
+
+  /// Checks if a newer version is available. Non-blocking.
+  ///
+  /// Returns a passing check with update info, or null on failure/timeout.
+  Future<DoctorCheck?> _checkVersion() async {
+    try {
+      final checker = _versionChecker ??
+          ({required String currentVersion}) =>
+              checkLatestVersion(currentVersion: currentVersion);
+      final result = await checker(currentVersion: inquiryVersion);
+      if (result.updateAvailable && result.latestVersion != null) {
+        return DoctorCheck(
+          name: 'update',
+          passed: true,
+          version: '${result.latestVersion} available',
+          remediation: "Run 'iq upgrade' to update",
+        );
+      }
+      return null; // No update, no check to show
+    } catch (_) {
+      return null; // Silent on failure
+    }
   }
 
   /// Runs a command and returns a [DoctorCheck] with the result.

--- a/code/cli/lib/modules/global/commands/tui.dart
+++ b/code/cli/lib/modules/global/commands/tui.dart
@@ -66,10 +66,9 @@ String _buildDiagram(String version) {
   return '''
 Inquiry v$version — powered by the Finite APE Machine
 
-  ╭────────────────────────────────╮
-IDLE → │ Analyze → Plan → Execute → End │ → EVOLUTION
-  ╰────────────────────────────────╯
-
+       ╭──────────────────────────╮
+Idle → │ Analyze → Plan → Execute │ → End
+       ╰──────────────────────────╯
 
 Commands: init, doctor, version
 Run: inquiry --help''';

--- a/code/cli/lib/modules/global/commands/tui.dart
+++ b/code/cli/lib/modules/global/commands/tui.dart
@@ -5,6 +5,7 @@ import 'package:cli_router/cli_router.dart';
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 
 import '../../../src/version.dart';
+import '../../../src/version_check.dart';
 
 // ─── Input ──────────────────────────────────────────────────────────────────
 
@@ -46,15 +47,35 @@ class TuiOutput extends Output {
 class TuiCommand implements Command<TuiInput, TuiOutput> {
   @override
   final TuiInput input;
+  final Future<VersionCheckResult> Function({required String currentVersion})?
+      _versionChecker;
 
-  TuiCommand(this.input);
+  TuiCommand(this.input, {
+    Future<VersionCheckResult> Function({required String currentVersion})?
+        versionChecker,
+  }) : _versionChecker = versionChecker;
 
   @override
   String? validate() => null;
 
   @override
   Future<TuiOutput> execute() async {
-    final diagram = _buildDiagram(inquiryVersion);
+    var diagram = _buildDiagram(inquiryVersion);
+
+    // Non-blocking version check
+    try {
+      final checker = _versionChecker ??
+          ({required String currentVersion}) =>
+              checkLatestVersion(currentVersion: currentVersion);
+      final result = await checker(currentVersion: inquiryVersion);
+      if (result.updateAvailable && result.latestVersion != null) {
+        diagram += "\n\nUpdate available: $inquiryVersion → ${result.latestVersion}"
+            " — run 'iq upgrade'";
+      }
+    } catch (_) {
+      // Silent on failure
+    }
+
     return TuiOutput(version: inquiryVersion, diagram: diagram);
   }
 }
@@ -67,7 +88,7 @@ String _buildDiagram(String version) {
 Inquiry v$version — powered by the Finite APE Machine
 
        ╭──────────────────────────╮
-Idle → │ Analyze → Plan → Execute │ → End
+Idle → │ Analyze → Plan → Execute │ → End → [Evolution]
        ╰──────────────────────────╯
 
 Commands: init, doctor, version

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.3.0';
+const String inquiryVersion = '0.3.1';

--- a/code/cli/lib/src/version_check.dart
+++ b/code/cli/lib/src/version_check.dart
@@ -1,0 +1,64 @@
+/// Shared utility for checking the latest available version from GitHub releases.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+const String _repo = 'ccisnedev/inquiry';
+
+/// Result of a version check against GitHub releases.
+class VersionCheckResult {
+  final String? latestVersion;
+  final bool updateAvailable;
+  final String? error;
+
+  const VersionCheckResult({
+    this.latestVersion,
+    required this.updateAvailable,
+    this.error,
+  });
+}
+
+/// Checks if a newer version is available on GitHub releases.
+///
+/// Returns [VersionCheckResult] with [updateAvailable] = true if
+/// [currentVersion] differs from the latest release tag.
+/// Silent on network failures — returns [updateAvailable] = false.
+Future<VersionCheckResult> checkLatestVersion({
+  required String currentVersion,
+  HttpClient? httpClient,
+}) async {
+  final client = httpClient ?? HttpClient();
+  try {
+    client.connectionTimeout = const Duration(seconds: 5);
+    final releaseUrl = Uri.parse(
+      'https://api.github.com/repos/$_repo/releases/latest',
+    );
+    final request = await client.getUrl(releaseUrl);
+    request.headers.set('Accept', 'application/vnd.github+json');
+    request.headers.set('User-Agent', 'inquiry-cli/$currentVersion');
+    final response = await request.close();
+
+    if (response.statusCode != 200) {
+      await response.drain<void>();
+      return const VersionCheckResult(updateAvailable: false);
+    }
+
+    final body = await response.transform(utf8.decoder).join();
+    final release = jsonDecode(body) as Map<String, dynamic>;
+    final tagName = release['tag_name'] as String;
+    final latestVersion =
+        tagName.startsWith('v') ? tagName.substring(1) : tagName;
+
+    final hasUpdate = latestVersion != currentVersion;
+    return VersionCheckResult(
+      latestVersion: latestVersion,
+      updateAvailable: hasUpdate,
+    );
+  } catch (_) {
+    // Network failure, timeout, DNS, etc. — silent.
+    return const VersionCheckResult(updateAvailable: false);
+  } finally {
+    if (httpClient == null) client.close();
+  }
+}

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.3.0
+version: 0.3.1
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/doctor_test.dart
+++ b/code/cli/test/doctor_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:inquiry_cli/assets.dart';
 import 'package:inquiry_cli/modules/global/commands/doctor.dart';
+import 'package:inquiry_cli/src/version_check.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -107,6 +108,25 @@ void main() {
       final agentsDir = Directory(p.join(tempDir.path, 'assets', 'agents'));
       agentsDir.createSync(recursive: true);
       File(p.join(agentsDir.path, 'inquiry.agent.md')).writeAsStringSync('# Agent');
+
+      // APE definition files
+      final apesDir = Directory(p.join(tempDir.path, 'assets', 'apes'));
+      apesDir.createSync(recursive: true);
+      for (final ape in ['socrates', 'socrates-idle', 'descartes', 'basho', 'darwin']) {
+        File(p.join(apesDir.path, '$ape.yaml')).writeAsStringSync('name: $ape\n');
+      }
+
+      // FSM state instruction files
+      final statesDir = Directory(p.join(tempDir.path, 'assets', 'fsm', 'states'));
+      statesDir.createSync(recursive: true);
+      for (final state in ['idle', 'analyze', 'plan', 'execute', 'end', 'evolution']) {
+        File(p.join(statesDir.path, '$state.yaml')).writeAsStringSync('name: $state\ninstructions: "test"\n');
+      }
+
+      // Transition contract
+      final fsmDir = Directory(p.join(tempDir.path, 'assets', 'fsm'));
+      File(p.join(fsmDir.path, 'transition_contract.yaml')).writeAsStringSync('metadata:\n  version: "1.0.0"\n');
+
       testAssets = Assets(root: tempDir.path);
     });
 
@@ -126,6 +146,8 @@ void main() {
         inquiryVersionOverride: version,
         fileSystemOps: fs ?? allPassFs('/home/testuser', testSkills),
         assets: assets ?? testAssets,
+        versionChecker: ({required String currentVersion}) async =>
+            const VersionCheckResult(updateAvailable: false),
       );
     }
 
@@ -135,7 +157,7 @@ void main() {
 
       expect(output.passed, isTrue);
       expect(output.exitCode, 0);
-      expect(output.checks.length, 4);
+      expect(output.checks.length, 5);
       expect(output.checks.every((c) => c.passed), isTrue);
     });
 
@@ -180,7 +202,7 @@ void main() {
 
       expect(json, containsPair('passed', true));
       expect(json['checks'], isList);
-      expect((json['checks'] as List).length, 4);
+      expect((json['checks'] as List).length, 5);
       expect(json['targetChecks'], isList);
       expect((json['targetChecks'] as List).length, 1);
 
@@ -190,9 +212,9 @@ void main() {
       expect(firstCheck, containsPair('version', '0.0.9'));
     });
 
-    test('DoctorInput.toJson() returns empty map', () {
+    test('DoctorInput.toJson() returns fix field', () {
       final input = DoctorInput();
-      expect(input.toJson(), isEmpty);
+      expect(input.toJson(), equals({'fix': false}));
     });
 
     test('DoctorCheck.toJson() includes error when present', () {

--- a/code/cli/test/effect_executor_test.dart
+++ b/code/cli/test/effect_executor_test.dart
@@ -192,13 +192,14 @@ void main() {
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         final executed = executor.executeAll(
-          effects: ['open_analysis_context', 'noop', 'push_branch'],
+          effects: ['noop', 'push_branch', 'generate_plan'],
           newState: 'ANALYZE',
         );
 
         // Only update_state is a CLI effect; the rest are skill-side
         expect(executed, contains('update_state'));
-        expect(executed, isNot(contains('open_analysis_context')));
+        expect(executed, isNot(contains('noop')));
+        expect(executed, isNot(contains('push_branch')));
       });
     });
 

--- a/code/cli/test/fsm_state_test.dart
+++ b/code/cli/test/fsm_state_test.dart
@@ -52,6 +52,16 @@ void main() {
         src.copySync('${apesDir.path}/$name.yaml');
       }
     }
+
+    // Copy state instruction YAMLs
+    final statesDir = Directory('${tempDir.path}/assets/fsm/states');
+    statesDir.createSync(recursive: true);
+    for (final name in ['idle', 'analyze', 'plan', 'execute', 'end', 'evolution']) {
+      final src = File('assets/fsm/states/$name.yaml');
+      if (src.existsSync()) {
+        src.copySync('${statesDir.path}/$name.yaml');
+      }
+    }
   }
 
   group('FsmStateCommand', () {
@@ -228,11 +238,20 @@ void main() {
 
     group('missing workspace', () {
       test('defaults to IDLE when .inquiry/state.yaml missing', () async {
-        // No setupWorkspace — but need contract
+        // No setupWorkspace — but need contract and state YAMLs
         final contractDir = Directory('${tempDir.path}/assets/fsm');
         contractDir.createSync(recursive: true);
         final contractSource = File('assets/fsm/transition_contract.yaml');
         contractSource.copySync('${contractDir.path}/transition_contract.yaml');
+
+        final statesDir = Directory('${tempDir.path}/assets/fsm/states');
+        statesDir.createSync(recursive: true);
+        for (final name in ['idle', 'analyze', 'plan', 'execute', 'end', 'evolution']) {
+          final src = File('assets/fsm/states/$name.yaml');
+          if (src.existsSync()) {
+            src.copySync('${statesDir.path}/$name.yaml');
+          }
+        }
 
         final command = FsmStateCommand(FsmStateInput(
           workingDirectory: tempDir.path,

--- a/code/cli/test/tui_test.dart
+++ b/code/cli/test/tui_test.dart
@@ -2,8 +2,14 @@ import 'package:test/test.dart';
 
 import 'package:inquiry_cli/modules/global/commands/tui.dart';
 import 'package:inquiry_cli/modules/global/commands/version.dart';
+import 'package:inquiry_cli/src/version_check.dart';
 
 void main() {
+  TuiCommand makeTui() => TuiCommand(
+    TuiInput(),
+    versionChecker: ({required String currentVersion}) async =>
+        const VersionCheckResult(updateAvailable: false),
+  );
   group('TUI Command', () {
     test('TuiInput.fromCliRequest() returns TuiInput', () {
       // TuiInput has no parameters
@@ -12,40 +18,40 @@ void main() {
     });
 
     test('TuiOutput contains version string', () async {
-      final cmd = TuiCommand(TuiInput());
+      final cmd = makeTui();
       final output = await cmd.execute();
 
       expect(output.version, equals(inquiryVersion));
     });
 
     test('TuiOutput.diagram contains FSM states', () async {
-      final cmd = TuiCommand(TuiInput());
+      final cmd = makeTui();
       final output = await cmd.execute();
 
-      expect(output.diagram, contains('IDLE'));
+      expect(output.diagram, contains('Idle'));
       expect(output.diagram, contains('Analyze'));
       expect(output.diagram, contains('Plan'));
       expect(output.diagram, contains('Execute'));
       expect(output.diagram, contains('End'));
-      expect(output.diagram, contains('EVOLUTION'));
+      expect(output.diagram, contains('[Evolution]'));
     });
 
     test('TuiOutput.diagram contains version', () async {
-      final cmd = TuiCommand(TuiInput());
+      final cmd = makeTui();
       final output = await cmd.execute();
 
       expect(output.diagram, contains(inquiryVersion));
     });
 
     test('TuiOutput.exitCode is 0', () async {
-      final cmd = TuiCommand(TuiInput());
+      final cmd = makeTui();
       final output = await cmd.execute();
 
       expect(output.exitCode, equals(0));
     });
 
     test('TuiOutput.toJson() has expected structure', () async {
-      final cmd = TuiCommand(TuiInput());
+      final cmd = makeTui();
       final output = await cmd.execute();
 
       final json = output.toJson();
@@ -60,12 +66,12 @@ void main() {
     });
 
     test('TuiCommand.validate() returns null', () {
-      final cmd = TuiCommand(TuiInput());
+      final cmd = makeTui();
       expect(cmd.validate(), isNull);
     });
 
     test('TuiOutput.toText() returns diagram only', () async {
-      final cmd = TuiCommand(TuiInput());
+      final cmd = makeTui();
       final output = await cmd.execute();
 
       // toText() should return only the diagram, not field labels

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More targets coming soon.</p>
-      <span class="badge">v0.3.0</span>
+      <span class="badge">v0.3.1</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Summary

Extracts hardcoded FSM state instructions into external YAML files and enhances \iq doctor\ with asset validation, version checking, and self-repair.

## Changes

### Core: State YAML extraction
- Create \ssets/fsm/states/*.yaml\ (6 files) with schema: name, version, description, instructions, constraints, allowed_actions
- Refactor \state.dart\ to load instructions from YAML at runtime
- Fail hard with \MISSING_STATE_YAML\ / \MALFORMED_STATE_YAML\ pointing to \iq doctor --fix\

### Doctor enhancements
- **Asset validation**: verifies apes (5), states (6), skills (4), transition_contract
- **Version check**: GitHub API with 5s timeout, silent on failure
- **\--fix\ flag**: downloads release zip and extracts assets to repair installation

### Process fixes
- **Cleanroom auto-creation**: \start_analyze\ transition creates \cleanrooms/<branch>/analyze/index.md\ via \open_analysis_context\ CLI effect
- **Commit gate**: \iq ape transition --event next_phase\ requires at least one commit ahead of default branch before advancing

### Firmware & TUI
- Firmware v0.3.1: IDLE runs \iq doctor\ as first action
- TUI diagram shows \[Evolution]\ as optional stage
- \iq\ bare shows update banner when newer version exists

## Verification

- 300 tests pass (Windows + Linux/WSL)
- \dart analyze\ clean
- QA: compiled binary tested across all 6 FSM states + all APE sub-agents
- QA: cleanroom creation verified on \start_analyze\
- QA: commit gate blocks without commit, allows with commit

Closes #160