### PR TITLE
feat: TUI banner redesign + semver version check fix (#169)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.3]
+### Changed
+- **TUI banner**: redesigned `iq` logo using Unicode half-block characters (`▀▄`) as pixel unit — lighthouse metaphor with green beacon `●` above serif `i` and circular `q` with descender (#169)
+
 ## [0.3.2]
 ### Fixed
 - **Firmware v0.3.3**: eliminate false approval gates — scheduler dispatches sub-agents immediately without asking

--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -5,8 +5,11 @@ The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.3.3]
+### Fixed
+- **Version check**: semver comparison now uses numeric major.minor.patch ordering instead of string equality — eliminates false "update available" when local version is ahead of remote (#169)
+
 ### Changed
-- **TUI banner**: redesigned `iq` logo using Unicode half-block characters (`▀▄`) as pixel unit — lighthouse metaphor with green beacon `●` above serif `i` and circular `q` with descender (#169)
+- **TUI banner**: redesigned `iq` logo using Unicode half-block characters (`▀▄`) as pixel unit — Gatsby's green light metaphor with green beacon `●` above serif `i` and circular `q` with descender (#169)
 
 ## [0.3.2]
 ### Fixed

--- a/code/cli/lib/modules/global/commands/tui.dart
+++ b/code/cli/lib/modules/global/commands/tui.dart
@@ -82,15 +82,43 @@ class TuiCommand implements Command<TuiInput, TuiOutput> {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+// ANSI escape codes for terminal colors.
+const _r = '\x1B[0m'; // reset
+const _b = '\x1B[1m'; // bold
+const _d = '\x1B[2m'; // dim
+const _wht = '\x1B[37m'; // white
+const _red = '\x1B[31m'; // red
+// const _grn = '\x1B[32m'; // green
+const _ylw = '\x1B[33m'; // yellow
+// const _blu = '\x1B[34m'; // blue
+// const _mag = '\x1B[35m'; // magenta
+// const _cyn = '\x1B[36m'; // cyan
+const _bgrn = '\x1B[92m'; // bright green
+
 /// Builds the FSM diagram with the given version.
 String _buildDiagram(String version) {
-  return '''
-Inquiry v$version — powered by the Finite APE Machine
+  // Logo: serif "i" — beacon (●) is the dot, ──█── are the serifs
+  final logo =
+      '\n$_bgrn  ●    $_r'
+      '\n$_wht ▀█ ▄▀▀█$_r  $_b${_red}Inquiry$_r v$version'
+      '\n$_wht▄▄█▄▀▄▄█$_r  ${_d}powered by the Finite APE Machine$_r'
+      '\n$_wht       ▀$_r'
+  ;
 
-       ╭──────────────────────────╮
-Idle → │ Analyze → Plan → Execute │ → End → [Evolution]
-       ╰──────────────────────────╯
+  // FSM: backward arrows above, Evolution loop below
+  final fsm =
+      '$_d             ╭───────────────────────────────╮$_r\n'
+      '$_d             ├─────────────────────╮         │$_r\n'
+      '$_d             ▼                     │         │$_r\n'
+      '  Idle$_r ──▶ $_b${_red}Analyze$_r ──▶ $_b${_red}Plan$_r ──▶ $_b${_red}Execute$_r ──▶ End$_r\n'
+      '$_d   ▲                                         │$_r\n'
+      '$_d   ╰──────────── $_b$_ylw[Evolution]$_r$_d ◂───────────────╯$_r'
+  ;
 
-Commands: init, doctor, version
-Run: inquiry --help''';
+  final footer =
+      '  ${_d}Commands: init, doctor, version$_r\n'
+      '  ${_d}Run: iq --help$_r'
+  ;
+
+  return '$logo\n\n$fsm\n\n$footer';
 }

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.3.2';
+const String inquiryVersion = '0.3.3';

--- a/code/cli/lib/src/version_check.dart
+++ b/code/cli/lib/src/version_check.dart
@@ -50,7 +50,7 @@ Future<VersionCheckResult> checkLatestVersion({
     final latestVersion =
         tagName.startsWith('v') ? tagName.substring(1) : tagName;
 
-    final hasUpdate = latestVersion != currentVersion;
+    final hasUpdate = _isNewerVersion(latestVersion, currentVersion);
     return VersionCheckResult(
       latestVersion: latestVersion,
       updateAvailable: hasUpdate,
@@ -61,4 +61,23 @@ Future<VersionCheckResult> checkLatestVersion({
   } finally {
     if (httpClient == null) client.close();
   }
+}
+
+/// Returns true only if [remote] is strictly greater than [current]
+/// using semantic versioning (major.minor.patch).
+bool _isNewerVersion(String remote, String current) {
+  final r = _parseSemver(remote);
+  final c = _parseSemver(current);
+  if (r == null || c == null) return false;
+  if (r[0] != c[0]) return r[0] > c[0];
+  if (r[1] != c[1]) return r[1] > c[1];
+  return r[2] > c[2];
+}
+
+List<int>? _parseSemver(String version) {
+  final parts = version.split('.');
+  if (parts.length != 3) return null;
+  final nums = parts.map(int.tryParse).toList();
+  if (nums.any((n) => n == null)) return null;
+  return nums.cast<int>();
 }

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.3.2
+version: 0.3.3
 
 environment:
   sdk: ^3.8.1

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More targets coming soon.</p>
-      <span class="badge">v0.3.2</span>
+      <span class="badge">v0.3.3</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Resumen

Dos cambios incluidos en este ciclo (#169):

### feat: TUI banner — Gatsby's green light

Rediseño del logo `iq` en el banner de la TUI usando caracteres Unicode de medio bloque (`▀▄`) como unidad de píxel. La metáfora visual es la luz verde de Gatsby: un faro verde (`●`) sobre la `i` en serif y la `q` circular con descendente.

### fix: version check con comparación semver correcta

El check de versión usaba `!=` entre strings, causando falsos positivos cuando la versión local superaba a la remota. Ahora compara major.minor.patch numéricamente con `_isNewerVersion()`.

## Archivos cambiados

- `lib/modules/global/commands/tui.dart`: nuevo logo con half-blocks
- `lib/src/version_check.dart`: `_isNewerVersion()` + `_parseSemver()`
- `lib/src/version.dart`, `pubspec.yaml`, `CHANGELOG.md`, `site/index.html`: bump a v0.3.3

## Tests

303/303 passing.