### PR TITLE
Separate thinking-tool identity from operational context in sub-agent YAMLs

### DIFF
--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/architectural-assumptions.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/architectural-assumptions.md
@@ -1,0 +1,59 @@
+---
+id: architectural-assumptions
+title: Surfaced assumptions behind the identity and operational split
+date: 2026-05-09
+status: active
+tags: [assumptions, architecture, prompts]
+author: socrates
+---
+
+# Assumptions Surfaced
+
+This note records the hidden assumptions beneath the current framing for issue #154 after the clarification pass.
+
+## A1: FSM state contracts can become the operational prompt layer
+
+The current framing assumes the phase mission and operational contract can live outside the named APE YAMLs because those contracts already exist in FSM state assets. However, the live prompt assembler still delivers only APE-authored prompt text plus an inquiry-context block.
+
+Why this matters:
+- Removing operational text from APE YAMLs is not sufficient by itself.
+- Some richer runtime carrier must deliver state instructions, constraints, and allowed actions to the sub-agent.
+
+Evidence:
+- code/cli/assets/fsm/states/analyze.yaml stores instructions, constraints, and allowed actions for ANALYZE.
+- code/cli/assets/fsm/states/evolution.yaml does the same for EVOLUTION.
+- code/cli/assets/agents/inquiry.agent.md treats FSM `instructions` as authoritative scheduler input.
+- code/cli/lib/modules/ape/commands/prompt.dart currently resolves only a narrow context map before assembly.
+- code/cli/lib/modules/ape/ape_definition.dart assembles prompts as base prompt + APE sub-state prompt + inquiry-context.
+
+## A2: Thinking-tool identity remains coherent after artifact and command text is removed
+
+The intended split assumes each named APE still has a stable cognitive core after repository-specific outputs, paths, and command surfaces are stripped away. That assumption is plausible in the repository doctrine, but the current APE YAMLs have not yet been factored enough to prove it mechanically.
+
+Why this matters:
+- The refactor must preserve method-specific mindset and questioning style.
+- It should move only the phase contract, not hollow out the thinking tool itself.
+
+## A3: DARWIN needs abstract process knowledge, not concrete repository procedure
+
+The clarified DARWIN nuance depends on a narrower exception than the other APEs. DARWIN appears to need a model of the ideal process in order to compare an actual cycle against it, but that does not imply that DARWIN should own repository-specific commands, folder paths, or file-writing rules.
+
+Why this matters:
+- If there is no abstract process representation outside the YAML, DARWIN will keep reabsorbing operational detail.
+- The real boundary is between methodology knowledge and implementation-specific procedure, not between process awareness and total ignorance.
+
+Evidence:
+- code/cli/assets/fsm/states/evolution.yaml expresses EVOLUTION as a generic evaluation mission.
+- code/cli/assets/apes/darwin.yaml mixes that evaluation role with concrete `gh issue` commands and `.inquiry/metrics.yaml` mechanics.
+
+## A4: Inquiry CLI prompt engineering is a first-class architectural surface
+
+The current framing assumes prompt composition in Inquiry CLI is part of the architecture, not incidental glue. If that assumption is false, externalizing operational context into CLI-owned prompt layers would itself become a layering violation.
+
+Why this matters:
+- Issue #154 is not just a YAML cleanup.
+- The prompt-composition boundary becomes a place that needs explicit contracts, documentation, and tests.
+
+# Conclusion From This Pass
+
+The clarified architecture is internally coherent, but it depends on delivery assumptions that are not yet fully materialized in the runtime. The most important hidden premise is that Inquiry CLI will become the place where FSM mission text, operational contract, and APE identity are recomposed cleanly at dispatch time.

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/confirmed.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/confirmed.md
@@ -1,0 +1,77 @@
+---
+id: confirmed
+title: "Confirmed findings"
+date: 2026-05-09
+status: active
+tags: [findings, confirmed]
+author: socrates
+---
+
+# Confirmed Findings
+
+> Living document. Update as findings are confirmed, revised, or invalidated.
+> Format: ## F<N>: <title> — CONFIRMED|REVISED|INVALIDATED
+
+## F1: Named sub-agents are architecturally defined as thinking tools, not as the scheduler or phase runtime — CONFIRMED
+
+The repository's canonical architecture already distinguishes the named operators from the orchestrating system. Thinking Tools are described as reusable reasoning methods that are dispatched through phases, while Inquiry, APE, and the Finite APE Machine are explicitly described as the cycle, scheduler, and state machine rather than thinking tools.
+
+Evidence:
+- docs/thinking-tools.md defines Thinking Tools as intellectual instruments used inside the cycle, not the cycle or scheduler.
+- docs/spec/cooperative-multitasking-model.md states that the FSM has no intelligence and that sub-agents are launched with clean context and a phase-specific prompt.
+- code/cli/assets/agents/inquiry.agent.md describes Inquiry as the scheduler that dispatches sub-agents as thinking tools.
+
+## F2: The live CLI prompt composition currently combines APE-authored prompt text with injected runtime context, but the APE YAML still carries substantial operational content — CONFIRMED
+
+The runtime assembles the effective prompt by concatenating the APE base prompt, the active APE sub-state prompt, and an optional inquiry-context block. Because the current composition path does not inject FSM mission text into the APE prompt, operational responsibilities, artifacts, and guardrails are currently encoded inside the APE YAML itself.
+
+Evidence:
+- code/cli/lib/modules/ape/ape_definition.dart assembles prompts as basePrompt + state.prompt + inquiry-context.
+- code/cli/lib/modules/ape/commands/prompt.dart resolves operational context such as output_dir, confirmed_doc, analysis_input, plan_file, and allowed command surfaces before assembly.
+
+## F3: The responsibility mix is systemic across current APE YAMLs; DEWEY only partially approximates the intended separation — CONFIRMED
+
+SOCRATES, DESCARTES, BASHO, and DARWIN all embed concrete deliverables, repository artifacts, or command surfaces directly in their YAML definitions. DEWEY is the closest partial approximation because the create_or_select sub-state can consume injected triage objective, deterministic skill, and allowed command surface, but DEWEY still embeds issue-triage workflow and command examples in its own YAML.
+
+Evidence:
+- code/cli/assets/apes/socrates.yaml embeds diagnosis.md and documentation protocol details.
+- code/cli/assets/apes/descartes.yaml embeds analysis_input and plan output semantics.
+- code/cli/assets/apes/basho.yaml embeds plan.md, retrospective.md, commit behavior, and validation reporting.
+- code/cli/assets/apes/darwin.yaml embeds gh issue commands, .inquiry paths, and metrics.yaml generation rules.
+
+## F4: The intended separation already assumes FSM state files, not APE YAMLs, are the natural home for phase mission and contract — CONFIRMED
+
+The repository already stores phase instructions, constraints, and allowed actions in FSM state assets, and the scheduler firmware treats state `instructions` as authoritative. At the same time, the live APE prompt assembler does not yet deliver that state contract to sub-agents; it only assembles APE-authored prompt text and a narrow inquiry-context block. This confirms that issue #154 is not merely subtractive: removing operational content from APE YAMLs will require a richer runtime delivery layer for the phase contract.
+
+Evidence:
+- code/cli/assets/fsm/states/analyze.yaml defines ANALYZE instructions, constraints, and allowed actions.
+- code/cli/assets/fsm/states/evolution.yaml defines EVOLUTION instructions, constraints, and allowed actions.
+- code/cli/assets/agents/inquiry.agent.md instructs the scheduler to read FSM `instructions` and operate from them.
+- code/cli/lib/modules/ape/commands/prompt.dart resolves only a limited context map before prompt assembly.
+- code/cli/lib/modules/ape/ape_definition.dart assembles prompts as APE base prompt + APE sub-state prompt + inquiry-context.
+
+## F5: DARWIN's valid exception depends on separating abstract process knowledge from concrete repository procedure — CONFIRMED
+
+DARWIN's legitimate role is to evaluate a completed cycle against an ideal process, which makes some abstract process awareness acceptable. But the current DARWIN YAML mixes that evaluative identity with concrete repository-specific commands and `.inquiry` file mechanics. This confirms that the Darwin nuance is real: the refactor must preserve abstract methodology knowledge while externalizing command surfaces, folder paths, and implementation-specific procedures.
+
+Evidence:
+- code/cli/assets/fsm/states/evolution.yaml describes EVOLUTION as a generic evaluation and improvement mission.
+- code/cli/assets/apes/darwin.yaml embeds concrete `gh issue` commands and `.inquiry/metrics.yaml` generation rules.
+
+## F6: Backwards-compatible separation requires additive prompt delivery, not immediate prompt subtraction — CONFIRMED
+
+Because the current prompt runtime assembles only the APE base prompt, active sub-state prompt, and a narrow inquiry-context block, live agent behavior still depends on operational text embedded in the APE YAMLs. Removing that text before a replacement operational layer is delivered would create an immediate behavior regression. This confirms that issue #154 must preserve effective prompt semantics during migration rather than treating YAML cleanup as behavior-neutral.
+
+Evidence:
+- code/cli/lib/modules/ape/ape_definition.dart assembles prompts as basePrompt + state.prompt + inquiry-context.
+- code/cli/lib/modules/ape/commands/prompt.dart injects only a limited context map for current APEs.
+- code/cli/assets/apes/socrates.yaml, code/cli/assets/apes/descartes.yaml, code/cli/assets/apes/basho.yaml, and code/cli/assets/apes/darwin.yaml still embed operational instructions that affect live behavior.
+
+## F7: The analysis is now asking the right architectural question for planning — CONFIRMED
+
+The investigation no longer needs to ask whether Inquiry conceptually distinguishes thinking-tool identity from operational runtime. That distinction already exists in doctrine and in parts of the implementation. The right planning question is now how Inquiry CLI should deliver the phase contract at prompt-assembly time so that named APE YAMLs can contract toward identity and sub-state modulation while preserving current behavior and inspectability.
+
+Evidence:
+- cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/evidence-inventory.md shows that doctrine, FSM state assets, and prompt assembly already exist as distinct runtime surfaces.
+- cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/implications-and-consequences.md shows that the necessary change is an additive prompt-delivery refactor rather than prose cleanup.
+- code/cli/lib/modules/ape/commands/prompt.dart and code/cli/lib/modules/ape/ape_definition.dart show that the remaining defect sits at prompt delivery and ownership, not at the existence of a composition mechanism.

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/diagnosis.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/diagnosis.md
@@ -1,0 +1,84 @@
+---
+id: diagnosis
+title: "Diagnosis — Issue #154: Separate thinking-tool identity from operational contract"
+date: 2026-05-09
+status: final
+tags: [diagnosis, prompts, architecture, thinking-tools, runtime]
+author: socrates
+---
+
+# Diagnosis
+
+## Problem defined
+
+Issue #154 is no longer diagnosing whether Inquiry lacks any separation between thinking-tool identity and runtime procedure. The repository already has meaningful partial separation: the canonical documentation describes named sub-agents as thinking tools, FSM state assets already carry phase mission and contract text, and Inquiry CLI already assembles prompts through a dedicated runtime surface.
+
+The live contradiction is narrower and more architectural. Named APEs are supposed to encode method, stance, and sub-state modulation, but the effective prompt still depends on APE YAML prose to carry phase mission details, artifact contracts, command surfaces, and documentation protocol. The right diagnosis question is therefore not "how do we rewrite the agent prose?" but "how should Inquiry deliver the operational contract at prompt assembly time so that APE YAMLs can contract toward thinking-tool identity without changing behavior?"
+
+## Decisions taken with justification
+
+### D1. Treat the core defect as prompt-delivery ownership, not as missing architectural surfaces
+
+The evidence does not support a theory that Inquiry needs an entirely new architectural concept in order to separate identity from operation. The repository already exposes three relevant surfaces: doctrine that defines named APEs as thinking tools, FSM state assets that describe phase mission and constraints, and a runtime prompt assembler that composes the effective prompt. What remains misallocated is ownership of operational contract inside APE-authored prose.
+
+### D2. Preserve the boundary: FSM states own phase mission, APE YAMLs own thinking-tool identity, Inquiry CLI owns composition
+
+The repository's own doctrine already points to this boundary, and the current runtime partially implements it. Planning should therefore preserve, not replace, that division of responsibility. Phase mission, allowed actions, and operational contract should not remain primarily embedded in named APE YAMLs. By the same logic, the refactor should not hollow out APE prompts into generic shells; their legitimate responsibility is to preserve cognitive identity, method, tone, and sub-state modulation.
+
+### D3. Make the migration additive first, because current behavior still depends on operational prose in APE YAMLs
+
+The effective prompt currently consists of APE base prompt, active sub-state prompt, and a narrow inquiry-context block. That means live behavior still depends on operational material embedded in SOCRATES, DESCARTES, BASHO, DEWEY, and DARWIN YAMLs today. Planning must therefore introduce a replacement operational-contract layer before trimming APE prose. Otherwise the repository would ship a prompt regression disguised as architecture cleanup.
+
+### D4. Keep the assembled prompt inspectable as a first-class contract
+
+Once operational ownership moves further into Inquiry CLI, the assembled prompt becomes the critical debugging and trust surface. The architecture should continue to expose the exact effective prompt through iq ape prompt or an equivalent surface. If prompt composition becomes hidden runtime glue, the refactor would solve one layering problem by creating another.
+
+### D5. Constrain DARWIN to an abstract-process exception, not a repository-procedure exception
+
+DARWIN is the only named APE with a plausible need for ideal-process knowledge, because it evaluates actual cycles against an abstract standard. That nuance is legitimate but narrow. It does not justify concrete ownership of repository-specific gh issue procedures, .inquiry file mechanics, or metrics-generation rules. Planning should preserve methodology knowledge while externalizing implementation-specific procedure.
+
+### D6. Leave carrier-shape selection to planning without reopening the diagnosis
+
+The diagnosis does not need to decide whether the replacement operational layer is delivered as raw FSM instruction text, normalized injected fields, or a hybrid composition model. That is a planning concern. What is now fixed is the boundary any implementation must preserve: no duplicate operational ownership across FSM and APE layers, no hidden prompt glue, and no behavior regression during migration.
+
+## Constraints and risks identified
+
+## Constraints
+
+- Preserve current effective behavior during migration.
+- Keep the final assembled prompt inspectable.
+- Avoid duplicating responsibility across FSM state assets, CLI composition, and APE YAMLs.
+- Preserve the legible thinking-tool identity of each named APE after separation.
+- Treat DARWIN's exception, if any, as abstract methodology knowledge only.
+
+## Risks
+
+- A subtractive YAML cleanup would remove live operational constraints before a replacement layer exists.
+- A CLI-owned operational layer could become opaque if not surfaced explicitly in assembled prompt output and documentation.
+- Partial refactoring across only some APEs would leave the architecture in a mixed and unstable state.
+- Injecting operational material without prompt discipline could preserve ownership but degrade prompt quality.
+- Leaving no abstract process surface outside DARWIN would encourage exception creep back into the DARWIN YAML.
+
+## Scope
+
+In scope for this diagnosis: identifying the true defect in the current architecture, fixing the ownership boundary conceptually, and defining the constraints any implementation plan must satisfy.
+
+Out of scope for this diagnosis: selecting the final runtime carrier format, enumerating file-by-file implementation edits, or drafting the concrete migration sequence. Those belong to planning, provided the chosen plan preserves single ownership of operational contract, prompt inspectability, and materially equivalent behavior.
+
+## References
+
+- cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/confirmed.md
+- cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/identity-vs-operational-boundary.md
+- cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/architectural-assumptions.md
+- cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/evidence-inventory.md
+- cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/perspectives-and-objections.md
+- cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/implications-and-consequences.md
+- code/cli/lib/modules/ape/ape_definition.dart
+- code/cli/lib/modules/ape/commands/prompt.dart
+- code/cli/assets/fsm/states/analyze.yaml
+- code/cli/assets/fsm/states/evolution.yaml
+- code/cli/assets/apes/socrates.yaml
+- code/cli/assets/apes/descartes.yaml
+- code/cli/assets/apes/basho.yaml
+- code/cli/assets/apes/dewey.yaml
+- code/cli/assets/apes/darwin.yaml

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/evidence-inventory.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/evidence-inventory.md
@@ -1,0 +1,85 @@
+---
+id: evidence-inventory
+title: Evidence inventory for identity vs operational separation
+date: 2026-05-09
+status: active
+tags: [evidence, architecture, prompts]
+author: socrates
+---
+
+# Evidence Inventory
+
+This note consolidates concrete code, runtime, and documentation evidence for issue #154 during the SOCRATES `evidence` sub-phase.
+
+# Evidence That The System Already Respects Part Of The Boundary
+
+## 1. Named sub-agents are documented as thinking tools, not as the scheduler
+
+The repository's canonical documentation already separates cognitive identity from orchestration.
+
+- [docs/thinking-tools.md](docs/thinking-tools.md) defines Thinking Tools as reusable reasoning methods used inside the Inquiry cycle rather than the cycle, methodology, or finite-state system itself.
+- [docs/spec/cooperative-multitasking-model.md](docs/spec/cooperative-multitasking-model.md) describes the outer FSM as a scheduler with no intelligence and the sub-agents as phase-specific tasks launched with clean context.
+- [docs/spec/agent-lifecycle.md](docs/spec/agent-lifecycle.md) assigns each phase a thinking tool while keeping APE as the scheduler and closure gate.
+
+## 2. FSM mission text already lives in a distinct asset family and is exposed separately at runtime
+
+The phase mission and contract are already modeled outside the APE YAMLs.
+
+- [code/cli/assets/fsm/states/analyze.yaml](code/cli/assets/fsm/states/analyze.yaml) stores ANALYZE `instructions`, `constraints`, and `allowed_actions`.
+- [code/cli/lib/modules/fsm/commands/state.dart](code/cli/lib/modules/fsm/commands/state.dart) reads `instructions` from `assets/fsm/states/<state>.yaml` and returns them in `FsmStateOutput`.
+- Live runtime observation from this pass confirms the split delivery surface: `iq fsm state --json` returned `state: ANALYZE`, `ape.name: socrates`, `ape.state: evidence`, and a distinct `instructions` field sourced from the FSM state.
+
+## 3. The APE prompt assembler is already a separate composition surface
+
+The current prompt runtime does not simply dump the FSM state YAML into the APE YAML. It has an explicit prompt-composition boundary.
+
+- [code/cli/lib/modules/ape/ape_definition.dart](code/cli/lib/modules/ape/ape_definition.dart) assembles prompts as APE `basePrompt` plus sub-state `prompt`, then optionally appends an `inquiry-context` block.
+- [code/cli/lib/modules/ape/commands/prompt.dart](code/cli/lib/modules/ape/commands/prompt.dart) resolves only a narrow context map such as `output_dir`, `confirmed_doc`, `analysis_input`, `plan_file`, or selected command surfaces before calling `assemblePrompt`.
+- Live runtime observation from this pass confirms the behavior: `iq ape prompt --name socrates` produced SOCRATES base prompt, the `evidence` sub-state prompt, and the active `inquiry-context` block for the cleanroom analyze directory.
+
+# Evidence That The Current System Violates The Intended Boundary
+
+## 1. SOCRATES still embeds analyze deliverables and documentation protocol in the APE YAML
+
+The SOCRATES YAML still carries operational material that belongs to phase contract or runtime composition rather than to Socratic identity alone.
+
+- [code/cli/assets/apes/socrates.yaml](code/cli/assets/apes/socrates.yaml) requires `diagnosis.md` as the final deliverable.
+- The same file embeds mandatory `confirmed.md` update rules, output-directory rules, and index-maintenance protocol.
+
+## 2. DESCARTES still embeds artifact-path semantics and output contract
+
+DESCARTES still mixes planning method with repository-specific plan wiring.
+
+- [code/cli/assets/apes/descartes.yaml](code/cli/assets/apes/descartes.yaml) defines `analysis_input` as a path from inquiry-context and directs output to `plan_file`.
+- The same file dictates immutable `plan.md` structure, commit-line requirements, and final-phase release obligations.
+
+## 3. BASHO still embeds execution workflow, reporting rules, and artifact expectations
+
+BASHO is not limited to implementation craft; it also owns operational reporting details.
+
+- [code/cli/assets/apes/basho.yaml](code/cli/assets/apes/basho.yaml) frames input as the current phase from `plan.md`.
+- The same file requires test/lint/build execution, validation reporting, retrospective production, and commit behavior.
+
+## 4. DARWIN still embeds repository-specific commands and file procedures
+
+DARWIN is the clearest example of process evaluation being mixed with concrete repository mechanics.
+
+- [code/cli/assets/apes/darwin.yaml](code/cli/assets/apes/darwin.yaml) hardcodes `gh issue` command examples against the Inquiry repository.
+- The same file specifies `.inquiry/metrics.yaml` generation rules and concrete field derivations from repository artifacts.
+
+## 5. DEWEY only partially approximates the target separation
+
+DEWEY shows the beginnings of the intended pattern, but it has not completed the separation.
+
+- [code/cli/lib/modules/ape/commands/prompt.dart](code/cli/lib/modules/ape/commands/prompt.dart) injects IDLE create-or-select context dynamically as `triage_objective`, `deterministic_skill`, and `allowed_commands`.
+- [code/cli/assets/apes/dewey.yaml](code/cli/assets/apes/dewey.yaml) still embeds deduplication workflow, issue-readiness semantics, and direct `gh issue list --search` usage guidance.
+
+# Synthesis
+
+The evidence does not support a claim that the repository lacks separation mechanisms altogether. It already has three distinct architectural surfaces:
+
+1. canonical documentation that distinguishes thinking-tool identity from scheduler/runtime role,
+2. FSM state assets that carry phase mission text, and
+3. CLI prompt composition that can inject runtime context at dispatch time.
+
+The current violation is narrower and more concrete: most APE YAMLs still contain phase contract, artifact contract, and repository procedure that should be owned by FSM state assets or CLI prompt composition. Issue #154 therefore concerns relocating operational contract out of APE-authored identity text, not inventing separation from scratch.

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/identity-vs-operational-boundary.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/identity-vs-operational-boundary.md
@@ -1,0 +1,85 @@
+---
+id: identity-vs-operational-boundary
+title: Clarified boundary between thinking-tool identity and operational context
+date: 2026-05-09
+status: active
+tags: [clarification, architecture, prompts]
+author: socrates
+---
+
+# Clarification Target
+
+This note clarifies what issue #154 is separating, using the current repository architecture and live prompt-composition code as the reference point.
+
+# Terms Clarified
+
+## Thinking-tool identity
+
+In this repository, a named sub-agent is supposed to embody a reasoning method, not a workflow container. The canonical role descriptions define DEWEY, SOCRATES, DESCARTES, BASHO, and DARWIN by the cognitive method each one brings to a phase: problematization, Socratic questioning, Cartesian method, constrained implementation craft, and natural selection.
+
+Relevant sources:
+- docs/thinking-tools.md
+- docs/spec/agent-lifecycle.md
+- code/cli/assets/agents/inquiry.agent.md
+
+## Operational context
+
+Operational context is the phase-specific machinery needed to make that reasoning useful inside Inquiry. In the current runtime, that includes mission framing, artifact paths, output contracts, allowed commands, deterministic skills, and workflow guardrails.
+
+Concrete examples from the live system:
+- analyze/ output locations and confirmation documents for SOCRATES
+- diagnosis.md and plan.md path contracts for DESCARTES
+- plan execution, commit, and retrospective requirements for BASHO
+- GitHub issue commands and .inquiry metrics surfaces for DARWIN
+- issue-create fast-path objective and allowed command surface for DEWEY
+
+# Boundary Clarified
+
+The intended boundary is:
+
+- FSM state defines the mission and operational contract of the phase.
+- The named APE/sub-agent defines the way of thinking applied inside that mission.
+- Inquiry CLI composes the effective prompt by combining those layers at dispatch time.
+
+This boundary is already consistent with the repository's architectural doctrine. The docs describe the scheduler as dispatching thinking tools with clean context, and the live CLI already reconstructs and injects some runtime context at prompt assembly time.
+
+# What The Current Runtime Actually Does
+
+The current composition path in code/cli/lib/modules/ape/commands/prompt.dart loads an APE YAML, resolves some dynamic context, and asks ApeDefinition.assemblePrompt to concatenate:
+
+1. the APE base prompt
+2. the active APE sub-state prompt
+3. an optional inquiry-context block
+
+This is an important clarification: the composition mechanism already exists, but it currently composes around APE-authored prompt text that still includes a large amount of operational material. The separation problem is therefore not whether composition exists. The problem is that the composed layers are not yet cleanly factored by responsibility.
+
+# Scope Clarified For Issue 154
+
+Issue #154 is not merely about moving a few file paths out of YAML. The broader clarification is that current APE definitions often conflate at least two layers:
+
+1. cognitive identity: how the agent should think
+2. operational contract: what this phase may touch, produce, or invoke
+
+Repository evidence shows this is systemic across the current active APE set:
+
+- SOCRATES embeds diagnosis deliverable and documentation protocol rules.
+- DESCARTES embeds plan-file contracts and planning output invariants.
+- BASHO embeds plan execution mechanics, commit behavior, and retrospective obligations.
+- DARWIN embeds repository command usage and .inquiry metrics behavior.
+- DEWEY partially externalizes create_or_select context, but still mixes thinking style with issue-triage workflow text.
+
+# Darwin Nuance
+
+The clarified nuance for DARWIN is narrower than a total removal of process awareness. DARWIN may legitimately need abstract knowledge of the ideal process so it can compare actual cycles against that ideal. What it should not need is direct knowledge of concrete command surfaces, repository folders, or implementation-specific operational handles. That distinction preserves DARWIN as a comparative thinking tool rather than making it the owner of runtime procedure.
+
+# Residual Clarification Questions
+
+The following questions remain open after this clarification pass, but they are now sharper:
+
+1. Which operational constraints belong in FSM state files versus CLI-side prompt injection versus reusable skills?
+2. Should the effective prompt eventually include explicit FSM-state instruction text, or should the CLI translate that contract into inquiry-context fields only?
+3. How much abstract process knowledge does DARWIN need before it stops being a thinking tool and starts becoming an operational controller?
+
+# Interim Conclusion
+
+The architectural intent and the repository's own doctrine already agree: sub-agents are thinking tools, and the scheduler/runtime owns operational delivery. The current mismatch is that the live APE YAMLs still carry a large share of the operational contract. That gives issue #154 a clarified scope: separate identity from operation without removing the CLI's role as the structured prompt composer.

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/implications-and-consequences.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/implications-and-consequences.md
@@ -1,0 +1,92 @@
+---
+id: implications-and-consequences
+title: Architectural and behavioral implications of separating thinking-tool identity from operational context
+date: 2026-05-09
+status: active
+tags: [implications, architecture, prompts]
+author: socrates
+---
+
+# Implication Pass
+
+This note records the concrete consequences if the current thesis is true: the repository already has distinct runtime surfaces for FSM mission text and APE prompt assembly, but operational ownership is still materially embedded inside APE YAML content.
+
+## What must change
+
+### 1. Prompt assembly must gain an explicit operational-contract layer
+
+If the named APE is only the thinking tool, then artifact contracts, allowed command surfaces, workflow guardrails, and documentation protocol cannot remain primarily encoded inside agent prose. Inquiry CLI has to own and deliver that operational layer explicitly at prompt assembly time.
+
+Consequence:
+- Issue #154 is a prompt-delivery refactor, not a wording cleanup in YAML files.
+
+### 2. APE YAMLs must contract toward identity and sub-state modulation
+
+The named APE definitions should still carry cognitive stance, method, tone, and sub-state-specific modulation. They should stop being the main place where repository procedure is defined.
+
+Consequence:
+- The migration target is not an empty or generic APE prompt.
+- The migration target is a cleaner APE prompt that still preserves the reasoning identity of SOCRATES, DESCARTES, BASHO, DEWEY, and DARWIN.
+
+### 3. The runtime boundary must remain inspectable
+
+Once more of the operational contract moves into Inquiry CLI, the assembled prompt becomes the critical debugging surface. If the system cannot show the exact effective prompt after recomposition, the architecture becomes harder to reason about even if the layering is cleaner on paper.
+
+Consequence:
+- Inspectability through iq ape prompt or an equivalent assembled-prompt surface is part of the architecture, not an incidental convenience.
+
+### 4. DARWIN's exception must stay abstract, not procedural
+
+If DARWIN is allowed to keep process knowledge, that exception has to be constrained to an abstract model of the ideal cycle. It cannot be allowed to keep reabsorbing repository-specific commands, paths, or file-generation mechanics under the label of "process awareness."
+
+Consequence:
+- The exception boundary is methodology versus implementation procedure, not process-aware versus process-blind.
+
+## What must not change
+
+- FSM state assets should remain the owner of phase mission and high-level phase contract.
+- Inquiry CLI should remain the place where prompt layers are assembled for dispatch.
+- Effective behavior must remain materially equivalent during migration; removing operational prose before a replacement layer exists would be a live behavior change.
+- The thinking-tool identity of each named APE must remain legible after separation.
+- DARWIN should not become a repository-procedure exception merely because it needs an abstract standard for comparison.
+
+## Risks of partial separation
+
+## 1. Behavioral regression disguised as architectural cleanup
+
+If operational prose is removed from APE YAMLs before the runtime supplies an equivalent contract, the assembled prompt loses constraints, artifact obligations, and guardrails immediately.
+
+## 2. Opaque glue replacing visible prompt ownership
+
+If the CLI takes ownership of the operational layer but does so through hidden composition rules, the repository trades one design problem for another: prompt behavior becomes harder to audit, explain, and test.
+
+## 3. Inconsistent separation across agents
+
+If one or two APEs are cleaned up while others remain operationally overloaded, the system ends up with an unstable architecture where exceptions keep expanding and future edits have no clear home.
+
+## 4. Prompt-quality degradation despite cleaner layering
+
+A technically separated system can still fail if the runtime injects raw operational data in a way that overwhelms or distorts the thinking-tool identity. Separation has to preserve prompt quality, not just ownership diagrams.
+
+## What happens if the current design remains as-is
+
+- Operational rules remain scattered across APE YAML prose instead of being owned by a clearly inspectable runtime layer.
+- Phase-contract edits remain expensive to audit because behavior is distributed across agent text rather than explicit prompt-delivery surfaces.
+- Thinking tools remain harder to compare, reuse, and reason about because their identity stays mixed with repository procedure.
+- DARWIN remains vulnerable to exception creep because concrete procedure has no stronger home outside the agent YAML.
+- Future architectural work keeps paying a translation tax between documented doctrine and live prompt content.
+
+## Overall implication
+
+If the thesis is true, the work for issue #154 is to make Inquiry CLI the explicit owner of operational prompt delivery while preserving current effective behavior and keeping the final prompt inspectable. Anything less leaves the boundary only partially separated; anything more that hollows out APE identity would overshoot the goal.
+
+## References
+
+- [confirmed.md](cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/confirmed.md)
+- [identity-vs-operational-boundary.md](cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/identity-vs-operational-boundary.md)
+- [architectural-assumptions.md](cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/architectural-assumptions.md)
+- [perspectives-and-objections.md](cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/perspectives-and-objections.md)
+- [code/cli/lib/modules/ape/ape_definition.dart](code/cli/lib/modules/ape/ape_definition.dart)
+- [code/cli/lib/modules/ape/commands/prompt.dart](code/cli/lib/modules/ape/commands/prompt.dart)
+- [code/cli/assets/apes/socrates.yaml](code/cli/assets/apes/socrates.yaml)
+- [code/cli/assets/fsm/states/analyze.yaml](code/cli/assets/fsm/states/analyze.yaml)

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/index.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/index.md
@@ -1,0 +1,20 @@
+# Analyze Phase — Index
+
+**Issue:** #154
+**Branch:** 154-separate-thinking-tool-identity-from-operational-c
+**Phase:** ANALYZE
+**Status:** Diagnosis complete
+
+---
+
+## Documents
+
+| # | File | Title | Status | Tags |
+|---|------|-------|--------|------|
+| 1 | confirmed.md | Confirmed findings | active | findings, confirmed |
+| 2 | identity-vs-operational-boundary.md | Clarified boundary between thinking-tool identity and operational context | active | clarification, architecture, prompts |
+| 3 | architectural-assumptions.md | Surfaced assumptions behind the identity and operational split | active | assumptions, architecture, prompts |
+| 4 | evidence-inventory.md | Evidence inventory for identity vs operational separation | active | evidence, architecture, prompts |
+| 5 | perspectives-and-objections.md | Perspective pass on architecture, compatibility, and operator concerns | active | perspectives, objections, architecture, prompts |
+| 6 | implications-and-consequences.md | Architectural and behavioral implications of separating thinking-tool identity from operational context | active | implications, architecture, prompts |
+| 7 | diagnosis.md | Diagnosis: issue #154 is a prompt-delivery refactor that externalizes operational contract while preserving inspectability and behavior | final | diagnosis, prompts, architecture, thinking-tools, runtime |

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/perspectives-and-objections.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/analyze/perspectives-and-objections.md
@@ -1,0 +1,65 @@
+---
+id: perspectives-and-objections
+title: Perspective pass on architecture, compatibility, and operator concerns
+date: 2026-05-09
+status: active
+tags: [perspectives, objections, architecture, prompts]
+author: socrates
+---
+
+# Perspective Pass
+
+This note tests issue #154 from multiple viewpoints in order to surface the objections that would matter before planning.
+
+## Runtime architecture perspective
+
+From the runtime's point of view, the repository already has the raw surfaces needed for separation: FSM state assets carry phase mission text, APE definitions carry identity and sub-state modulation, and Inquiry CLI assembles the prompt at dispatch time. The strongest architectural objection is therefore not "where could the operational contract live?" but "what runtime layer will actually deliver it once it leaves the APE YAMLs?"
+
+Implication:
+- The refactor must enrich prompt delivery, not merely delete prose from the APE assets.
+
+## Maintainability perspective
+
+The current system scatters phase contract across multiple APE YAMLs. That makes operational changes expensive to reason about because a change in artifact expectations, command surfaces, or documentation protocol is expressed inside agent prose rather than in a clearly owned runtime layer.
+
+Objection:
+- Centralizing everything in CLI code could simply replace scattered prose with opaque glue unless the new ownership boundary is explicit, documented, and testable.
+
+## Prompt-engineering integrity perspective
+
+Mixing cognitive identity with repository procedure weakens the prompt as a design artifact. A named thinking tool becomes harder to reuse, compare, and reason about when its base prompt also has to carry file paths, output contracts, and command examples. The current SOCRATES and DARWIN prompts illustrate this drift clearly.
+
+Objection:
+- A raw operational data dump from the runtime could also damage prompt quality if the CLI injects context without preserving the voice and scope of the thinking tool.
+
+## Backwards compatibility perspective
+
+The live prompt assembler currently delivers APE base prompt, sub-state prompt, and a narrow inquiry-context block. That means the effective behavior still depends on operational content embedded directly in APE YAMLs today. Removing that content before an equivalent runtime-owned layer exists would change live agent behavior immediately.
+
+Implication:
+- The safe migration path is additive first: introduce the replacement delivery surface, then trim the APE YAML once prompt-equivalent behavior is preserved.
+
+## Operator and user experience perspective
+
+For the operator, a cleaner separation could improve predictability. Phase-owned instructions, paths, and allowed surfaces would stop changing merely because a different thinking tool is dispatched. It would also make it easier to explain why the system asked for or produced a given artifact.
+
+Objection:
+- If composition becomes harder to inspect, debugging prompt behavior gets worse. The current `iq ape prompt` surface is therefore not incidental; operator trust depends on keeping the assembled prompt inspectable.
+
+## Exceptional-agent perspective: DARWIN
+
+DARWIN is the narrowest justified exception. It likely needs abstract knowledge of the ideal cycle so it can compare actual execution against a standard. But that does not justify direct ownership of repository-specific `gh issue` procedures, `.inquiry` file mechanics, or concrete metrics-generation rules.
+
+Objection:
+- If the ideal process is not represented outside DARWIN's YAML, the special case will keep reabsorbing operational detail and the exception will expand.
+
+## Overall judgment
+
+From these perspectives, issue #154 remains well-aimed, but the real work is a layered prompt-delivery refactor rather than a prompt-edit cleanup. The most serious objection is backwards compatibility during migration, followed by the risk of replacing visible prompt ownership with opaque runtime glue.
+
+## References
+
+- [confirmed.md](confirmed.md)
+- [identity-vs-operational-boundary.md](identity-vs-operational-boundary.md)
+- [architectural-assumptions.md](architectural-assumptions.md)
+- [evidence-inventory.md](evidence-inventory.md)

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
@@ -213,12 +213,12 @@ expect repository procedure to move out of darwin.yaml while the abstract proces
 
 **TDD:** Yes. RED first: protect the allowed DARWIN exception and forbid the procedural one. GREEN second: move the procedure until the gate passes.
 
-- [ ] Extend `code/cli/assets/fsm/states/evolution.yaml` and `code/cli/build/assets/fsm/states/evolution.yaml` with the abstract-process contract that DARWIN may legitimately consume outside its own YAML.
-- [ ] Edit `code/cli/assets/apes/darwin.yaml` and `code/cli/build/assets/apes/darwin.yaml` so DARWIN keeps evaluation identity but stops owning the primary repository procedure.
-- [ ] Update `code/cli/lib/modules/ape/commands/prompt.dart` and nearby prompt-contract helpers so EVOLUTION injects repository procedure and metrics mechanics explicitly at assembly time.
-- [ ] Update `code/cli/test/ape_prompt_test.dart`, `code/cli/test/ape_definition_test.dart`, `code/cli/test/fsm_state_test.dart`, and `code/cli/test/assets_test.dart` so the DARWIN exception is bounded by executable tests.
-- [ ] Run `dart test test/ape_prompt_test.dart test/ape_definition_test.dart test/fsm_state_test.dart test/assets_test.dart test/firmware_agent_test.dart` and the `rg` verification above until the DARWIN boundary is GREEN.
-- [ ] Commit: "refactor(cli): bound darwin exception for #154"
+- [x] Extend `code/cli/assets/fsm/states/evolution.yaml` and `code/cli/build/assets/fsm/states/evolution.yaml` with the abstract-process contract that DARWIN may legitimately consume outside its own YAML.
+- [x] Edit `code/cli/assets/apes/darwin.yaml` and `code/cli/build/assets/apes/darwin.yaml` so DARWIN keeps evaluation identity but stops owning the primary repository procedure.
+- [x] Update `code/cli/lib/modules/ape/commands/prompt.dart` and nearby prompt-contract helpers so EVOLUTION injects repository procedure and metrics mechanics explicitly at assembly time.
+- [x] Update `code/cli/test/ape_prompt_test.dart`, `code/cli/test/ape_definition_test.dart`, `code/cli/test/fsm_state_test.dart`, and `code/cli/test/assets_test.dart` so the DARWIN exception is bounded by executable tests.
+- [x] Run `dart test test/ape_prompt_test.dart test/ape_definition_test.dart test/fsm_state_test.dart test/assets_test.dart test/firmware_agent_test.dart` and the `rg` verification above until the DARWIN boundary is GREEN.
+- [x] Commit: "refactor(cli): bound darwin exception for #154"
 
 ## Phase 6 — Align doctrine, release surfaces, and final validation (P6)
 

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
@@ -169,12 +169,12 @@ expect IDLE/runtime surfaces to own the concrete procedure rather than dewey.yam
 
 **TDD:** Yes. RED first: codify IDLE-owned routing and prompt expectations. GREEN second: move the procedure until the same gate passes.
 
-- [ ] Edit `code/cli/assets/fsm/states/idle.yaml` and `code/cli/build/assets/fsm/states/idle.yaml` so IDLE explicitly owns the operational contract for create/select routing and issue work.
-- [ ] Edit `code/cli/assets/apes/dewey.yaml` and `code/cli/build/assets/apes/dewey.yaml` so DEWEY preserves methodology while dropping primary ownership of concrete repository procedure.
-- [ ] Update `code/cli/lib/modules/ape/commands/prompt.dart` and nearby prompt-contract helpers so DEWEY receives the new IDLE-owned contract at assembly time.
-- [ ] Update `code/cli/test/ape_prompt_test.dart`, `code/cli/test/ape_transition_test.dart`, `code/cli/test/fsm_state_test.dart`, and `code/cli/test/fsm_contract_test.dart` so the IDLE/DEWEY ownership boundary is protected.
-- [ ] Run `dart test test/ape_prompt_test.dart test/ape_transition_test.dart test/fsm_state_test.dart test/fsm_contract_test.dart test/firmware_agent_test.dart` and the `rg` verification above until the DEWEY boundary is GREEN.
-- [ ] Commit: "refactor(cli): externalize idle routing from dewey for #154"
+- [x] Edit `code/cli/assets/fsm/states/idle.yaml` and `code/cli/build/assets/fsm/states/idle.yaml` so IDLE explicitly owns the operational contract for create/select routing and issue work.
+- [x] Edit `code/cli/assets/apes/dewey.yaml` and `code/cli/build/assets/apes/dewey.yaml` so DEWEY preserves methodology while dropping primary ownership of concrete repository procedure.
+- [x] Update `code/cli/lib/modules/ape/commands/prompt.dart` and nearby prompt-contract helpers so DEWEY receives the new IDLE-owned contract at assembly time.
+- [x] Update `code/cli/test/ape_prompt_test.dart`, `code/cli/test/ape_transition_test.dart`, `code/cli/test/fsm_state_test.dart`, and `code/cli/test/fsm_contract_test.dart` so the IDLE/DEWEY ownership boundary is protected.
+- [x] Run `dart test test/ape_prompt_test.dart test/ape_transition_test.dart test/fsm_state_test.dart test/fsm_contract_test.dart test/firmware_agent_test.dart` and the `rg` verification above until the DEWEY boundary is GREEN.
+- [x] Commit: "refactor(cli): externalize idle routing from dewey for #154"
 
 ## Phase 5 — Bound DARWIN's abstract-process exception and externalize repository procedure (P5)
 

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
@@ -264,9 +264,13 @@ expect docs and firmware to describe the final validated ownership boundary, pre
 
 **TDD:** No. This phase aligns explanation and release surfaces after the executable contract is already green.
 
-- [ ] Update the explanatory documentation in `docs/architecture.md`, `docs/thinking-tools.md`, `docs/spec/agent-lifecycle.md`, `docs/spec/finite-ape-machine.md`, and `docs/spec/target-specific-agents.md` so they describe the validated ownership boundary and the bounded DARWIN exception.
-- [ ] Reconcile `code/cli/assets/agents/inquiry.agent.md` with the final runtime wording if earlier phases left any temporary wording behind.
-- [ ] Update `code/cli/CHANGELOG.md` with the prompt-boundary refactor.
-- [ ] Bump the release surfaces in `code/cli/pubspec.yaml`, `code/cli/lib/src/version.dart`, and `code/site/index.html`.
-- [ ] Run `dart analyze`, `dart test`, `dart test test/version_sync_test.dart`, and the `rg` verification above until the repository is release-ready.
-- [ ] Commit: "release(cli): finalize prompt-boundary separation for #154"
+- [x] Update the explanatory documentation in `docs/architecture.md`, `docs/thinking-tools.md`, `docs/spec/agent-lifecycle.md`, `docs/spec/finite-ape-machine.md`, and `docs/spec/target-specific-agents.md` so they describe the validated ownership boundary and the bounded DARWIN exception.
+- [x] Reconcile `code/cli/assets/agents/inquiry.agent.md` with the final runtime wording if earlier phases left any temporary wording behind.
+- [x] Update `code/cli/CHANGELOG.md` with the prompt-boundary refactor.
+- [x] Bump the release surfaces in `code/cli/pubspec.yaml`, `code/cli/lib/src/version.dart`, and `code/site/index.html`.
+- [x] Run `dart analyze`, `dart test`, `dart test test/version_sync_test.dart`, and the `rg` verification above until the repository is release-ready.
+- [x] Commit: "release(cli): finalize prompt-boundary separation for #154"
+
+Deviation: `dart analyze` exposed a preexisting unused import in `code/cli/lib/modules/ape/operational_contract.dart`; it was removed to satisfy the approved release-readiness gate without changing prompt behavior.
+
+Deviation: The approved P6 checklist did not enumerate the prompt-required final retrospective artifact, so the cleanroom validation record is captured in `retrospective.md` without widening the release scope.

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
@@ -43,11 +43,11 @@ expect representative prompt assembly, visible inquiry-context, and inspectabili
 
 **TDD:** Yes. RED first: tighten prompt-contract assertions before changing prompt ownership. GREEN second: keep this gate green through all later phases.
 
-- [ ] Expand `code/cli/test/ape_prompt_test.dart` with representative assembled-prompt assertions for SOCRATES, DESCARTES, BASHO, DEWEY, and DARWIN before any operational prose is removed.
-- [ ] Add or adjust prompt-test fixtures so each active APE can be assembled deterministically without depending on the live repository state.
-- [ ] Update `code/cli/test/firmware_agent_test.dart` so prompt inspectability through `iq ape prompt` is protected as a first-class contract.
-- [ ] Run `dart test test/ape_prompt_test.dart test/firmware_agent_test.dart` until the prompt baseline is GREEN.
-- [ ] Commit: "test(cli): lock assembled prompt contract for #154"
+- [x] Expand `code/cli/test/ape_prompt_test.dart` with representative assembled-prompt assertions for SOCRATES, DESCARTES, BASHO, DEWEY, and DARWIN before any operational prose is removed.
+- [x] Add or adjust prompt-test fixtures so each active APE can be assembled deterministically without depending on the live repository state.
+- [x] Update `code/cli/test/firmware_agent_test.dart` so prompt inspectability through `iq ape prompt` is protected as a first-class contract.
+- [x] Run `dart test test/ape_prompt_test.dart test/firmware_agent_test.dart` until the prompt baseline is GREEN.
+- [x] Commit: "test(cli): lock assembled prompt contract for #154"
 
 ## Phase 2 — Introduce a CLI-owned operational-contract layer (P2)
 

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
@@ -127,11 +127,11 @@ expect matches to be absent or reduced to identity-preserving references rather 
 
 **TDD:** Yes. RED first: tighten the standard-APE prompt expectations against the new contract carrier. GREEN second: contract the YAMLs until the gate passes.
 
-- [ ] Edit `code/cli/assets/apes/socrates.yaml`, `code/cli/assets/apes/descartes.yaml`, and `code/cli/assets/apes/basho.yaml` so they retain thinking-tool identity and sub-state modulation but stop owning the primary operational contract.
-- [ ] Mirror the updated standard APE YAMLs into `code/cli/build/assets/apes/socrates.yaml`, `code/cli/build/assets/apes/descartes.yaml`, and `code/cli/build/assets/apes/basho.yaml`.
-- [ ] Update prompt-composition tests and any nearby asset expectations in `code/cli/test/ape_prompt_test.dart`, `code/cli/test/ape_definition_test.dart`, and `code/cli/test/assets_test.dart` so the new ownership boundary is enforced.
-- [ ] Run `dart test test/ape_prompt_test.dart test/ape_definition_test.dart test/assets_test.dart test/firmware_agent_test.dart` and the `rg` verification above until the standard-APE boundary is GREEN.
-- [ ] Commit: "refactor(cli): externalize standard ape procedure for #154"
+- [x] Edit `code/cli/assets/apes/socrates.yaml`, `code/cli/assets/apes/descartes.yaml`, and `code/cli/assets/apes/basho.yaml` so they retain thinking-tool identity and sub-state modulation but stop owning the primary operational contract.
+- [x] Mirror the updated standard APE YAMLs into `code/cli/build/assets/apes/socrates.yaml`, `code/cli/build/assets/apes/descartes.yaml`, and `code/cli/build/assets/apes/basho.yaml`.
+- [x] Update prompt-composition tests and any nearby asset expectations in `code/cli/test/ape_prompt_test.dart`, `code/cli/test/ape_definition_test.dart`, and `code/cli/test/assets_test.dart` so the new ownership boundary is enforced.
+- [x] Run `dart test test/ape_prompt_test.dart test/ape_definition_test.dart test/assets_test.dart test/firmware_agent_test.dart` and the `rg` verification above until the standard-APE boundary is GREEN.
+- [x] Commit: "refactor(cli): externalize standard ape procedure for #154"
 
 ## Phase 4 — Externalize IDLE routing and DEWEY procedure from the APE YAML (P4)
 

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
@@ -83,13 +83,13 @@ expect the new operational-contract fragment to be visible in assembled prompts,
 
 **TDD:** Yes. RED first: add the new prompt-composition expectations. GREEN second: introduce the carrier and keep the same gate green.
 
-- [ ] Add a dedicated operational-contract assembly helper/model under `code/cli/lib/modules/ape/` and wire it into `code/cli/lib/modules/ape/commands/prompt.dart` so the assembled prompt order is explicitly APE identity -> phase-owned operational contract -> inquiry-context.
-- [ ] Treat existing FSM state `instructions`, `constraints`, and `allowed_actions` as the primary carrier for phase-owned mission and contract, and introduce new explicit state fields only where prompt delivery still needs data that those surfaces cannot express cleanly.
-- [ ] Extend the phase-owned runtime sources under `code/cli/assets/fsm/states/analyze.yaml`, `code/cli/assets/fsm/states/plan.yaml`, `code/cli/assets/fsm/states/execute.yaml`, `code/cli/assets/fsm/states/end.yaml`, `code/cli/assets/fsm/states/idle.yaml`, and `code/cli/assets/fsm/states/evolution.yaml` with only the additive contract fields still required after that normalization, then mirror those edits into `code/cli/build/assets/fsm/states/`.
-- [ ] Update `code/cli/test/ape_prompt_test.dart`, `code/cli/test/fsm_state_test.dart`, `code/cli/test/fsm_contract_test.dart`, and `code/cli/test/firmware_agent_test.dart` so the CLI-owned operational-contract fragment and inspectable composition boundary are protected.
-- [ ] Update `code/cli/assets/agents/inquiry.agent.md` so the firmware explicitly describes the assembled prompt as APE identity + phase-owned operational contract + inquiry-context.
-- [ ] Run `dart test test/ape_prompt_test.dart test/fsm_state_test.dart test/fsm_contract_test.dart test/firmware_agent_test.dart` until the additive carrier is GREEN.
-- [ ] Commit: "feat(cli): add operational contract layer for #154"
+- [x] Add a dedicated operational-contract assembly helper/model under `code/cli/lib/modules/ape/` and wire it into `code/cli/lib/modules/ape/commands/prompt.dart` so the assembled prompt order is explicitly APE identity -> phase-owned operational contract -> inquiry-context.
+- [x] Treat existing FSM state `instructions`, `constraints`, and `allowed_actions` as the primary carrier for phase-owned mission and contract, and introduce new explicit state fields only where prompt delivery still needs data that those surfaces cannot express cleanly.
+- [x] Extend the phase-owned runtime sources under `code/cli/assets/fsm/states/analyze.yaml`, `code/cli/assets/fsm/states/plan.yaml`, `code/cli/assets/fsm/states/execute.yaml`, `code/cli/assets/fsm/states/end.yaml`, `code/cli/assets/fsm/states/idle.yaml`, and `code/cli/assets/fsm/states/evolution.yaml` with only the additive contract fields still required after that normalization, then mirror those edits into `code/cli/build/assets/fsm/states/`.
+- [x] Update `code/cli/test/ape_prompt_test.dart`, `code/cli/test/fsm_state_test.dart`, `code/cli/test/fsm_contract_test.dart`, and `code/cli/test/firmware_agent_test.dart` so the CLI-owned operational-contract fragment and inspectable composition boundary are protected.
+- [x] Update `code/cli/assets/agents/inquiry.agent.md` so the firmware explicitly describes the assembled prompt as APE identity + phase-owned operational contract + inquiry-context.
+- [x] Run `dart test test/ape_prompt_test.dart test/fsm_state_test.dart test/fsm_contract_test.dart test/firmware_agent_test.dart` until the additive carrier is GREEN.
+- [x] Commit: "feat(cli): add operational contract layer for #154"
 
 ## Phase 3 — Migrate the standard thinking tools to identity-first prompts (P3)
 

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/plan.md
@@ -1,0 +1,272 @@
+# Plan — Issue #154: Separate thinking-tool identity from operational contract
+
+**Input:** [analyze/diagnosis.md](analyze/diagnosis.md)
+**Draft scope:** DESCARTES `enumeration`. Decomposition, ordering, and verification are already locked as P1 -> P2 -> P3 -> P4 -> P5 -> P6; this pass refines completeness only and confirms that every phase has entry criteria, executable steps, verification, risk coverage where needed, and a commit line without changing phase boundaries or sequence.
+**Plan invariant:** After approval, only checkbox state and deviation annotations may change.
+**Execution root:** Run all `dart`, `iq`, and `rg` commands from `code/cli` unless a step explicitly names the repository root.
+**Deviation rule:** If execution shows that operational contract cannot move out of APE YAMLs without either hidden prompt glue or a material prompt regression, stop, add a deviation note under the active phase, and return to ANALYZE before opening a new implementation slice.
+**Verification rule:** A phase is not complete until its phase-local verification gate passes and `iq ape prompt` still exposes the exact assembled prompt for the touched surfaces.
+**Verification focus:** Every phase-local gate must explicitly protect preserved effective behavior, visible prompt assembly, and the rule that DARWIN may keep only abstract-process methodology rather than repository procedure.
+**Dependency graph:** P1 → P2 → P3 → P4 → P5 → P6.
+**Ordering rationale:** P3 is the common-case migration and should prove the identity-first prompt boundary on the simplest APEs before any special-case routing or exception work begins. P4 comes next because IDLE/DEWEY adds state-specific routing but still follows the general separation model once the standard APE path is stable. P5 is last among the migration phases because DARWIN is the only legitimate abstract-process exception and should be constrained only after the non-exception and IDLE-specific carriers are already validated.
+
+## Phase 1 — Lock the live assembled-prompt contract before migration (P1)
+
+**Entry:** [analyze/diagnosis.md](analyze/diagnosis.md) is approved; the current runtime still depends on operational prose embedded in APE YAMLs; no executable guard yet defines what behavior must remain visible during migration.
+**Depends on:** None.
+**Risk:** High — if the current assembled prompts are not captured first, later APE cleanup can silently remove artifact obligations, command surfaces, or inspectability.
+**Produces:** A prompt-contract regression harness that protects the current visible behavior of `iq ape prompt` for SOCRATES, DESCARTES, BASHO, DEWEY, and DARWIN.
+**Why first:** This is the smallest additive slice and it creates the falsifiable baseline needed before moving ownership boundaries.
+
+**Test definitions (pseudocode):**
+
+```text
+for each ape in [socrates, descartes, basho, dewey, darwin]
+when a representative assembled prompt is rendered in its active FSM state
+then the exact prompt remains inspectable through iq ape prompt
+and the output still contains the behavior-critical operational guidance currently relied upon
+and any inquiry-context block remains explicit in the rendered text
+and the locked assertions name the visible prompt fragments later phases must preserve even if ownership moves
+
+firmware := inquiry.agent.md
+when the operator prompt-delivery contract is read
+then iq ape prompt is still documented as the way to inspect the exact effective prompt
+```
+
+**Verification gate (pseudocode):**
+
+```text
+run dart test test/ape_prompt_test.dart test/firmware_agent_test.dart
+expect exit 0
+expect representative prompt assembly, visible inquiry-context, and inspectability assertions to be GREEN before any YAML contraction begins
+```
+
+**TDD:** Yes. RED first: tighten prompt-contract assertions before changing prompt ownership. GREEN second: keep this gate green through all later phases.
+
+- [ ] Expand `code/cli/test/ape_prompt_test.dart` with representative assembled-prompt assertions for SOCRATES, DESCARTES, BASHO, DEWEY, and DARWIN before any operational prose is removed.
+- [ ] Add or adjust prompt-test fixtures so each active APE can be assembled deterministically without depending on the live repository state.
+- [ ] Update `code/cli/test/firmware_agent_test.dart` so prompt inspectability through `iq ape prompt` is protected as a first-class contract.
+- [ ] Run `dart test test/ape_prompt_test.dart test/firmware_agent_test.dart` until the prompt baseline is GREEN.
+- [ ] Commit: "test(cli): lock assembled prompt contract for #154"
+
+## Phase 2 — Introduce a CLI-owned operational-contract layer (P2)
+
+**Entry:** Phase 1 is GREEN; the current prompt shape is now protected, but operational rules are still materially authored inside APE YAMLs.
+**Depends on:** Phase 1.
+**Risk:** High — centralizing ownership in CLI code can replace scattered prose with opaque glue unless the contract stays visible, phase-owned, and testable.
+**Produces:** A single visible operational-contract layer assembled by Inquiry CLI from phase-owned runtime surfaces plus inquiry-context, while the existing APE YAML prose remains temporarily intact for additive migration.
+**Why after P1:** The new carrier must be introduced while the old behavior is still guarded, otherwise the migration cannot distinguish cleanup from regression.
+
+**Test definitions (pseudocode):**
+
+```text
+prompt := assembled prompt for an active ape
+when the new composition layer is enabled
+then the output contains one explicit operational-contract fragment owned outside the ape yaml
+and phase mission/constraints/allowed actions come from phase-owned runtime surfaces
+and issue-specific paths or protocol fields still come from CLI-resolved inquiry-context
+and iq ape prompt still prints the exact effective prompt without hidden composition
+and no duplicate primary ownership of the same operational contract remains across FSM state assets and ape yaml prose
+
+state assets := analyze/plan/execute/end/idle/evolution yaml
+when the phase-owned contract is inspected
+then the runtime exposes the contract needed for prompt assembly without shifting identity back into the ape yaml
+```
+
+**Verification gate (pseudocode):**
+
+```text
+run dart test test/ape_prompt_test.dart test/fsm_state_test.dart test/fsm_contract_test.dart test/firmware_agent_test.dart
+expect exit 0
+expect the new operational-contract fragment to be visible in assembled prompts, sourced from runtime-owned surfaces, and still inspectable through iq ape prompt
+```
+
+**TDD:** Yes. RED first: add the new prompt-composition expectations. GREEN second: introduce the carrier and keep the same gate green.
+
+- [ ] Add a dedicated operational-contract assembly helper/model under `code/cli/lib/modules/ape/` and wire it into `code/cli/lib/modules/ape/commands/prompt.dart` so the assembled prompt order is explicitly APE identity -> phase-owned operational contract -> inquiry-context.
+- [ ] Treat existing FSM state `instructions`, `constraints`, and `allowed_actions` as the primary carrier for phase-owned mission and contract, and introduce new explicit state fields only where prompt delivery still needs data that those surfaces cannot express cleanly.
+- [ ] Extend the phase-owned runtime sources under `code/cli/assets/fsm/states/analyze.yaml`, `code/cli/assets/fsm/states/plan.yaml`, `code/cli/assets/fsm/states/execute.yaml`, `code/cli/assets/fsm/states/end.yaml`, `code/cli/assets/fsm/states/idle.yaml`, and `code/cli/assets/fsm/states/evolution.yaml` with only the additive contract fields still required after that normalization, then mirror those edits into `code/cli/build/assets/fsm/states/`.
+- [ ] Update `code/cli/test/ape_prompt_test.dart`, `code/cli/test/fsm_state_test.dart`, `code/cli/test/fsm_contract_test.dart`, and `code/cli/test/firmware_agent_test.dart` so the CLI-owned operational-contract fragment and inspectable composition boundary are protected.
+- [ ] Update `code/cli/assets/agents/inquiry.agent.md` so the firmware explicitly describes the assembled prompt as APE identity + phase-owned operational contract + inquiry-context.
+- [ ] Run `dart test test/ape_prompt_test.dart test/fsm_state_test.dart test/fsm_contract_test.dart test/firmware_agent_test.dart` until the additive carrier is GREEN.
+- [ ] Commit: "feat(cli): add operational contract layer for #154"
+
+## Phase 3 — Migrate the standard thinking tools to identity-first prompts (P3)
+
+**Entry:** Phase 2 is GREEN; the CLI can now deliver operational contract explicitly, but SOCRATES, DESCARTES, and BASHO still duplicate repository procedure inside their YAML prose.
+**Depends on:** Phase 2.
+**Risk:** High — these three APEs currently carry artifact destinations, documentation protocol, planning/execution procedure, and commit-oriented workflow details that execution still relies on.
+**Produces:** SOCRATES, DESCARTES, and BASHO YAMLs reduced to thinking-tool identity and sub-state modulation, with their operational contract delivered by the new CLI/FSM-owned layer.
+**Why first after P2:** The three standard working APEs share the same architectural defect and can prove the common migration pattern before IDLE- or EVOLUTION-specific exceptions are introduced.
+
+**Test definitions (pseudocode):**
+
+```text
+for each ape in [socrates, descartes, basho]
+when the assembled prompt is rendered in its active state
+then reasoning identity, tone, and sub-state modulation remain in the ape yaml
+and output_dir / analysis_input / plan_file / doc protocol / phase procedure come from the CLI-owned operational contract
+and the rendered prompt remains materially equivalent for the operator
+and iq ape prompt still exposes the same effective prompt shape without hidden recovery glue
+
+ape yaml := socrates.yaml / descartes.yaml / basho.yaml
+when the source is inspected
+then repository-specific procedure is no longer the primary owner inside these yaml files
+```
+
+**Verification gate (pseudocode):**
+
+```text
+run dart test test/ape_prompt_test.dart test/ape_definition_test.dart test/assets_test.dart test/firmware_agent_test.dart
+expect exit 0
+expect standard-APE prompts to remain materially equivalent and inspectable while the new ownership boundary stays explicit
+
+run rg "output_dir|analysis_input|plan_file|doc-read|doc-write|Commit:" assets/apes/socrates.yaml assets/apes/descartes.yaml assets/apes/basho.yaml
+expect matches to be absent or reduced to identity-preserving references rather than the primary operational contract
+```
+
+**TDD:** Yes. RED first: tighten the standard-APE prompt expectations against the new contract carrier. GREEN second: contract the YAMLs until the gate passes.
+
+- [ ] Edit `code/cli/assets/apes/socrates.yaml`, `code/cli/assets/apes/descartes.yaml`, and `code/cli/assets/apes/basho.yaml` so they retain thinking-tool identity and sub-state modulation but stop owning the primary operational contract.
+- [ ] Mirror the updated standard APE YAMLs into `code/cli/build/assets/apes/socrates.yaml`, `code/cli/build/assets/apes/descartes.yaml`, and `code/cli/build/assets/apes/basho.yaml`.
+- [ ] Update prompt-composition tests and any nearby asset expectations in `code/cli/test/ape_prompt_test.dart`, `code/cli/test/ape_definition_test.dart`, and `code/cli/test/assets_test.dart` so the new ownership boundary is enforced.
+- [ ] Run `dart test test/ape_prompt_test.dart test/ape_definition_test.dart test/assets_test.dart test/firmware_agent_test.dart` and the `rg` verification above until the standard-APE boundary is GREEN.
+- [ ] Commit: "refactor(cli): externalize standard ape procedure for #154"
+
+## Phase 4 — Externalize IDLE routing and DEWEY procedure from the APE YAML (P4)
+
+**Entry:** Phase 3 is GREEN; the standard APE migration pattern is validated, but DEWEY still retains repository procedure and routing detail that belongs to IDLE orchestration.
+**Depends on:** Phase 3.
+**Risk:** High — DEWEY touches `create_or_select`, deterministic issue handling, and GitHub command surfaces, so a partial change can regress IDLE behavior even if the prompt still renders.
+**Produces:** IDLE-owned routing and issue-work contract delivered through runtime composition, with DEWEY reduced to methodology and sub-state modulation.
+**Why after P3:** IDLE routing is a distinct operational surface with fast-path and GitHub-command semantics, so it should build on the already-proven standard migration path instead of introducing two new prompt-boundary changes at once.
+
+**Test definitions (pseudocode):**
+
+```text
+dewey := assembled prompt in create_or_select
+when iq ape prompt --name dewey is rendered from IDLE
+then triage objective, deterministic skill, and allowed command surface come from the CLI/FSM-owned contract
+and dewey yaml remains methodology-focused
+and the operator can still inspect the full routing contract in the assembled prompt without hidden IDLE-only glue
+
+idle := idle state instructions and transition metadata
+when the IDLE contract is inspected
+then create/select routing and issue procedure are owned outside dewey.yaml
+and the assembled prompt remains fully inspectable
+```
+
+**Verification gate (pseudocode):**
+
+```text
+run dart test test/ape_prompt_test.dart test/ape_transition_test.dart test/fsm_state_test.dart test/fsm_contract_test.dart test/firmware_agent_test.dart
+expect exit 0
+expect IDLE-owned routing to preserve create/select behavior while the prompt remains explicitly inspectable
+
+run rg "gh issue|issue-create|create_or_select|allowed_commands" assets/apes/dewey.yaml assets/fsm/states/idle.yaml lib/modules/ape/commands/prompt.dart
+expect IDLE/runtime surfaces to own the concrete procedure rather than dewey.yaml
+```
+
+**TDD:** Yes. RED first: codify IDLE-owned routing and prompt expectations. GREEN second: move the procedure until the same gate passes.
+
+- [ ] Edit `code/cli/assets/fsm/states/idle.yaml` and `code/cli/build/assets/fsm/states/idle.yaml` so IDLE explicitly owns the operational contract for create/select routing and issue work.
+- [ ] Edit `code/cli/assets/apes/dewey.yaml` and `code/cli/build/assets/apes/dewey.yaml` so DEWEY preserves methodology while dropping primary ownership of concrete repository procedure.
+- [ ] Update `code/cli/lib/modules/ape/commands/prompt.dart` and nearby prompt-contract helpers so DEWEY receives the new IDLE-owned contract at assembly time.
+- [ ] Update `code/cli/test/ape_prompt_test.dart`, `code/cli/test/ape_transition_test.dart`, `code/cli/test/fsm_state_test.dart`, and `code/cli/test/fsm_contract_test.dart` so the IDLE/DEWEY ownership boundary is protected.
+- [ ] Run `dart test test/ape_prompt_test.dart test/ape_transition_test.dart test/fsm_state_test.dart test/fsm_contract_test.dart test/firmware_agent_test.dart` and the `rg` verification above until the DEWEY boundary is GREEN.
+- [ ] Commit: "refactor(cli): externalize idle routing from dewey for #154"
+
+## Phase 5 — Bound DARWIN's abstract-process exception and externalize repository procedure (P5)
+
+**Entry:** Phase 4 is GREEN; the standard and IDLE-specific migrations are validated, but DARWIN still mixes evaluation method, GitHub issue procedure, and metrics-generation mechanics in the APE YAML.
+**Depends on:** Phase 4.
+**Risk:** High — if the abstract evolution standard is not made explicit outside the DARWIN YAML, repository procedure will creep back; if repository procedure is removed too early, EVOLUTION loses required behavior.
+**Produces:** An explicit evolution-owned abstract process contract outside the DARWIN YAML, plus CLI-delivered repository procedure for issue search/comment/create and metrics collection; DARWIN keeps only the methodological exception.
+**Why after P4:** DARWIN is the only justified exception, so it should be constrained only after the non-exception and IDLE-specific migration paths have already stabilized the carrier and prompt-helper shape.
+
+**Test definitions (pseudocode):**
+
+```text
+darwin := assembled prompt in EVOLUTION
+when the prompt is rendered after separation
+then the ideal-cycle comparison standard is still present
+and repository-specific gh issue / metrics.yaml / .inquiry mechanics come from the CLI/FSM-owned operational contract
+and darwin.yaml no longer primarily owns concrete repository procedure
+and the only retained DARWIN-specific exception is abstract-process methodology visible in the assembled prompt
+
+evolution := evolution-owned runtime contract
+when the source is inspected
+then the abstract process expectations are explicit outside darwin.yaml
+and iq ape prompt still shows the full assembled prompt including that contract
+```
+
+**Verification gate (pseudocode):**
+
+```text
+run dart test test/ape_prompt_test.dart test/ape_definition_test.dart test/fsm_state_test.dart test/assets_test.dart test/firmware_agent_test.dart
+expect exit 0
+expect DARWIN to retain only the bounded abstract-process exception while repository procedure stays externalized and inspectable
+
+run rg "gh issue|metrics.yaml|\.inquiry|issue comment|issue create" assets/apes/darwin.yaml assets/fsm/states/evolution.yaml lib/modules/ape/commands/prompt.dart
+expect repository procedure to move out of darwin.yaml while the abstract process standard remains available through runtime-owned surfaces
+```
+
+**TDD:** Yes. RED first: protect the allowed DARWIN exception and forbid the procedural one. GREEN second: move the procedure until the gate passes.
+
+- [ ] Extend `code/cli/assets/fsm/states/evolution.yaml` and `code/cli/build/assets/fsm/states/evolution.yaml` with the abstract-process contract that DARWIN may legitimately consume outside its own YAML.
+- [ ] Edit `code/cli/assets/apes/darwin.yaml` and `code/cli/build/assets/apes/darwin.yaml` so DARWIN keeps evaluation identity but stops owning the primary repository procedure.
+- [ ] Update `code/cli/lib/modules/ape/commands/prompt.dart` and nearby prompt-contract helpers so EVOLUTION injects repository procedure and metrics mechanics explicitly at assembly time.
+- [ ] Update `code/cli/test/ape_prompt_test.dart`, `code/cli/test/ape_definition_test.dart`, `code/cli/test/fsm_state_test.dart`, and `code/cli/test/assets_test.dart` so the DARWIN exception is bounded by executable tests.
+- [ ] Run `dart test test/ape_prompt_test.dart test/ape_definition_test.dart test/fsm_state_test.dart test/assets_test.dart test/firmware_agent_test.dart` and the `rg` verification above until the DARWIN boundary is GREEN.
+- [ ] Commit: "refactor(cli): bound darwin exception for #154"
+
+## Phase 6 — Align doctrine, release surfaces, and final validation (P6)
+
+**Entry:** Phase 5 is GREEN; the runtime now expresses the intended ownership boundary end to end, but explanatory docs and release metadata may still describe the old mixed model.
+**Depends on:** Phase 5.
+**Risk:** Medium — stale docs or unsynchronized release metadata would leave the repository teaching the wrong architecture or shipping inconsistent version surfaces.
+**Produces:** Documentation, firmware wording, version metadata, and changelog aligned to the validated ownership boundary.
+**Why last:** Explanatory and release surfaces should describe the runtime that already passes tests, not predict a contract that still exists only in planning.
+
+**Test definitions (pseudocode):**
+
+```text
+docs := architecture and spec surfaces
+when prompt-boundary sections are read
+then they describe FSM state assets as phase-owned mission/contract sources
+and they describe APE YAMLs as thinking-tool identity surfaces
+and they describe Inquiry CLI as the explicit prompt assembler
+and they keep iq ape prompt as the inspectable effective-prompt surface
+and DARWIN is documented as an abstract-process exception only
+and they do not reintroduce mixed ownership language that would imply hidden prompt glue or repository procedure inside standard APE YAMLs
+
+release := pubspec.yaml + version.dart + site index badge + cli changelog
+when version sync and final validation run
+then all version surfaces agree
+and the changelog records the prompt-boundary refactor
+```
+
+**Verification gate (pseudocode):**
+
+```text
+run dart analyze
+expect exit 0
+
+run dart test
+expect exit 0
+
+run dart test test/version_sync_test.dart
+expect exit 0
+
+run rg "thinking tool|operational contract|iq ape prompt|DARWIN|prompt assembly" ..\docs ..\code\cli\assets\agents
+expect docs and firmware to describe the final validated ownership boundary, preserve prompt inspectability, and bound DARWIN to the abstract-process exception without stale mixed-ownership language
+```
+
+**TDD:** No. This phase aligns explanation and release surfaces after the executable contract is already green.
+
+- [ ] Update the explanatory documentation in `docs/architecture.md`, `docs/thinking-tools.md`, `docs/spec/agent-lifecycle.md`, `docs/spec/finite-ape-machine.md`, and `docs/spec/target-specific-agents.md` so they describe the validated ownership boundary and the bounded DARWIN exception.
+- [ ] Reconcile `code/cli/assets/agents/inquiry.agent.md` with the final runtime wording if earlier phases left any temporary wording behind.
+- [ ] Update `code/cli/CHANGELOG.md` with the prompt-boundary refactor.
+- [ ] Bump the release surfaces in `code/cli/pubspec.yaml`, `code/cli/lib/src/version.dart`, and `code/site/index.html`.
+- [ ] Run `dart analyze`, `dart test`, `dart test test/version_sync_test.dart`, and the `rg` verification above until the repository is release-ready.
+- [ ] Commit: "release(cli): finalize prompt-boundary separation for #154"

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/retrospective.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/retrospective.md
@@ -13,16 +13,17 @@ created: 2026-05-09
 ### What Was Implemented
 
 1. Prompt-boundary doctrine was aligned across `docs/architecture.md`, `docs/thinking-tools.md`, `docs/spec/agent-lifecycle.md`, `docs/spec/finite-ape-machine.md`, and `docs/spec/target-specific-agents.md` so those surfaces now describe APE YAMLs as identity surfaces, FSM state assets as phase-owned operational-contract sources, `iq ape prompt` as the explicit assembler, and DARWIN as the bounded abstract-process exception.
-2. `code/cli/assets/agents/inquiry.agent.md` and `code/cli/CHANGELOG.md` now reflect the final runtime wording, and the release metadata was bumped to `0.3.7` across `code/cli/pubspec.yaml`, `code/cli/lib/src/version.dart`, and `code/site/index.html`.
-3. Final P6 validation passed on 2026-05-09: `dart analyze` reported no issues after a non-behavioral cleanup in `code/cli/lib/modules/ape/operational_contract.dart`; `dart test` passed 336 tests; `dart test test/version_sync_test.dart` passed 5 tests; and the required `rg` verification surfaced the updated prompt-boundary wording in the targeted docs and firmware.
+2. The final release/doc delta now records the shipped state as `0.4.0`: `code/cli/assets/agents/inquiry.agent.md`, `code/cli/CHANGELOG.md`, and `docs/timeline.md` reflect the final runtime wording, and the release metadata was bumped across `code/cli/pubspec.yaml`, `code/cli/lib/src/version.dart`, and `code/site/index.html`.
+3. Final delta validation passed on 2026-05-09: targeted `test/version_sync_test.dart` plus `test/firmware_agent_test.dart` passed 21 tests, `dart analyze` reported no issues, `dart test` passed 329 tests, and the required `rg` verification surfaced the updated prompt-boundary wording in the targeted docs, timeline, and firmware.
 
 ### How to Verify
 
 1. From `code/cli`, run `dart analyze`.
 2. From `code/cli`, run `dart test`.
 3. From `code/cli`, run `dart test test/version_sync_test.dart`.
-4. From `code/cli`, run `rg "thinking tool|operational contract|iq ape prompt|DARWIN|prompt assembly" ..\..\docs assets\agents`.
-5. Review `docs/architecture.md`, `docs/thinking-tools.md`, `docs/spec/agent-lifecycle.md`, `docs/spec/finite-ape-machine.md`, `docs/spec/target-specific-agents.md`, `code/cli/assets/agents/inquiry.agent.md`, and the `0.3.7` release entry in `code/cli/CHANGELOG.md`.
+4. From `code/cli`, run `dart test test/firmware_agent_test.dart`.
+5. From `code/cli`, run `rg "thinking-tool identity|phase-owned operational contract|iq ape prompt|inquiry-context|v0.4.0" ..\..\docs assets\agents`.
+6. Review `docs/architecture.md`, `docs/thinking-tools.md`, `docs/spec/agent-lifecycle.md`, `docs/spec/finite-ape-machine.md`, `docs/spec/target-specific-agents.md`, `docs/timeline.md`, `code/cli/assets/agents/inquiry.agent.md`, and the `0.4.0` release entry in `code/cli/CHANGELOG.md`.
 
 ### Known Limitations
 
@@ -30,7 +31,7 @@ created: 2026-05-09
 
 ## What Went Well
 
-- The validated runtime boundary was already stable, so P6 stayed confined to doctrine, firmware wording, release metadata, and final verification.
+- The validated runtime boundary was already stable, so the final delta stayed confined to doctrine, firmware wording, release metadata, one historical doc sync, and verification.
 - The version-sync test continued to enforce all three release surfaces and caught the necessary metadata alignment immediately.
 
 ## What Deviated from the Plan

--- a/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/retrospective.md
+++ b/cleanrooms/154-separate-thinking-tool-identity-from-operational-c/retrospective.md
@@ -1,0 +1,47 @@
+---
+type: retrospective
+scope: issue
+issue: 154
+title: Separate Thinking-Tool Identity from Operational Contract
+created: 2026-05-09
+---
+
+# Retrospective - Issue #154
+
+## Validation Report
+
+### What Was Implemented
+
+1. Prompt-boundary doctrine was aligned across `docs/architecture.md`, `docs/thinking-tools.md`, `docs/spec/agent-lifecycle.md`, `docs/spec/finite-ape-machine.md`, and `docs/spec/target-specific-agents.md` so those surfaces now describe APE YAMLs as identity surfaces, FSM state assets as phase-owned operational-contract sources, `iq ape prompt` as the explicit assembler, and DARWIN as the bounded abstract-process exception.
+2. `code/cli/assets/agents/inquiry.agent.md` and `code/cli/CHANGELOG.md` now reflect the final runtime wording, and the release metadata was bumped to `0.3.7` across `code/cli/pubspec.yaml`, `code/cli/lib/src/version.dart`, and `code/site/index.html`.
+3. Final P6 validation passed on 2026-05-09: `dart analyze` reported no issues after a non-behavioral cleanup in `code/cli/lib/modules/ape/operational_contract.dart`; `dart test` passed 336 tests; `dart test test/version_sync_test.dart` passed 5 tests; and the required `rg` verification surfaced the updated prompt-boundary wording in the targeted docs and firmware.
+
+### How to Verify
+
+1. From `code/cli`, run `dart analyze`.
+2. From `code/cli`, run `dart test`.
+3. From `code/cli`, run `dart test test/version_sync_test.dart`.
+4. From `code/cli`, run `rg "thinking tool|operational contract|iq ape prompt|DARWIN|prompt assembly" ..\..\docs assets\agents`.
+5. Review `docs/architecture.md`, `docs/thinking-tools.md`, `docs/spec/agent-lifecycle.md`, `docs/spec/finite-ape-machine.md`, `docs/spec/target-specific-agents.md`, `code/cli/assets/agents/inquiry.agent.md`, and the `0.3.7` release entry in `code/cli/CHANGELOG.md`.
+
+### Known Limitations
+
+- This final validation reran the approved P6 gate only. It did not rebuild installer artifacts or compile a fresh release binary because the approved phase did not require packaging smoke.
+
+## What Went Well
+
+- The validated runtime boundary was already stable, so P6 stayed confined to doctrine, firmware wording, release metadata, and final verification.
+- The version-sync test continued to enforce all three release surfaces and caught the necessary metadata alignment immediately.
+
+## What Deviated from the Plan
+
+- `dart analyze` exposed a preexisting unused import in `code/cli/lib/modules/ape/operational_contract.dart`; removing it was necessary to satisfy the approved release-readiness gate.
+- The approved P6 checklist did not enumerate the final retrospective artifact, so the validation record is captured here without widening the release scope.
+
+## What Surprised
+
+- The full 336-test suite stayed GREEN after the doctrine and release-surface edits, which confirmed that the remaining drift was documentary rather than behavioral.
+
+## Spawn Issues
+
+None identified.

--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
-## [0.3.7]
+## [0.4.0]
 ### Changed
 - **Prompt-boundary doctrine**: architecture, thinking-tool, lifecycle, finite-state, and target-wrapper docs now describe the validated runtime boundary: APE YAMLs provide thinking-tool identity, FSM state assets provide the phase-owned operational contract, and `iq ape prompt` remains the inspectable assembler (#154)
 - **DARWIN exception wording**: docs and firmware now bound DARWIN to abstract-process methodology while EVOLUTION owns issue/metrics repository procedure (#154)

--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.3.7]
+### Changed
+- **Prompt-boundary doctrine**: architecture, thinking-tool, lifecycle, finite-state, and target-wrapper docs now describe the validated runtime boundary: APE YAMLs provide thinking-tool identity, FSM state assets provide the phase-owned operational contract, and `iq ape prompt` remains the inspectable assembler (#154)
+- **DARWIN exception wording**: docs and firmware now bound DARWIN to abstract-process methodology while EVOLUTION owns issue/metrics repository procedure (#154)
+
 ## [0.3.6]
 ### Added
 - **TRIAGE issue creation**: IDLE now uses a dedicated `issue-create` skill for deterministic issue creation or confirmation before operational handoff (#175)

--- a/code/cli/assets/agents/inquiry.agent.md
+++ b/code/cli/assets/agents/inquiry.agent.md
@@ -74,7 +74,7 @@ iq fsm transition --event <event>
 
 Dispatch is **unconditional and immediate**. When you enter the Inner Loop, execute steps 1–2 without asking, narrating, or confirming.
 
-1. Run `iq ape prompt --name <ape.name>` to get the sub-agent prompt
+1. Run `iq ape prompt --name <ape.name>` to inspect the exact effective sub-agent prompt
 2. **Dispatch** that sub-agent: use the `agent` tool to invoke `@<ape.name>` with the prompt as context. Do NOT perform the sub-agent's work yourself. Do NOT render its output in chat. Do NOT announce what the sub-agent will do.
 3. Wait for the sub-agent to signal completion (it will announce its sub-phase is done).
 4. When signaled: `iq ape transition --event <event>` to advance the sub-FSM.

--- a/code/cli/assets/agents/inquiry.agent.md
+++ b/code/cli/assets/agents/inquiry.agent.md
@@ -74,7 +74,7 @@ iq fsm transition --event <event>
 
 Dispatch is **unconditional and immediate**. When you enter the Inner Loop, execute steps 1–2 without asking, narrating, or confirming.
 
-1. Run `iq ape prompt --name <ape.name>` to inspect the exact effective sub-agent prompt
+1. Run `iq ape prompt --name <ape.name>` to inspect the exact effective sub-agent prompt (APE identity + phase-owned operational contract + inquiry-context)
 2. **Dispatch** that sub-agent: use the `agent` tool to invoke `@<ape.name>` with the prompt as context. Do NOT perform the sub-agent's work yourself. Do NOT render its output in chat. Do NOT announce what the sub-agent will do.
 3. Wait for the sub-agent to signal completion (it will announce its sub-phase is done).
 4. When signaled: `iq ape transition --event <event>` to advance the sub-FSM.

--- a/code/cli/assets/agents/inquiry.agent.md
+++ b/code/cli/assets/agents/inquiry.agent.md
@@ -4,7 +4,7 @@ description: 'Inquiry — a strict FSM scheduler for structured task delivery. D
 tools: [vscode, execute, read, agent, edit, search, web, browser, todo]
 ---
 
-# Inquiry Scheduler — Firmware v0.3.7
+# Inquiry Scheduler — Firmware v0.4.0
 
 You are a **scheduler**. You operate a dual FSM (main + per-APE). You never think, analyze, plan, or implement yourself — sub-agents do that. You orchestrate via CLI commands only.
 

--- a/code/cli/assets/agents/inquiry.agent.md
+++ b/code/cli/assets/agents/inquiry.agent.md
@@ -4,7 +4,7 @@ description: 'Inquiry — a strict FSM scheduler for structured task delivery. D
 tools: [vscode, execute, read, agent, edit, search, web, browser, todo]
 ---
 
-# Inquiry Scheduler — Firmware v0.3.3
+# Inquiry Scheduler — Firmware v0.3.7
 
 You are a **scheduler**. You operate a dual FSM (main + per-APE). You never think, analyze, plan, or implement yourself — sub-agents do that. You orchestrate via CLI commands only.
 
@@ -74,7 +74,7 @@ iq fsm transition --event <event>
 
 Dispatch is **unconditional and immediate**. When you enter the Inner Loop, execute steps 1–2 without asking, narrating, or confirming.
 
-1. Run `iq ape prompt --name <ape.name>` to inspect the exact effective sub-agent prompt (APE identity + phase-owned operational contract + inquiry-context)
+1. Run `iq ape prompt --name <ape.name>` to inspect the exact effective sub-agent prompt (APE identity + phase-owned operational contract + inquiry-context). Treat that output as the complete runtime prompt surface; do not invent hidden glue or recover missing procedure from the APE YAML.
 2. **Dispatch** that sub-agent: use the `agent` tool to invoke `@<ape.name>` with the prompt as context. Do NOT perform the sub-agent's work yourself. Do NOT render its output in chat. Do NOT announce what the sub-agent will do.
 3. Wait for the sub-agent to signal completion (it will announce its sub-phase is done).
 4. When signaled: `iq ape transition --event <event>` to advance the sub-FSM.

--- a/code/cli/assets/apes/basho.yaml
+++ b/code/cli/assets/apes/basho.yaml
@@ -17,7 +17,7 @@ base_prompt: |
 
   - NOTHING WASTED: No over-engineering, no speculative code, no dead paths
   - CONSTRAINTS REVEAL: The plan's restrictions are your 5-7-5 — create within them
-  - THE JOURNEY IS THE WORK: Each phase is a stop on the narrow road; each produces a commit
+  - THE JOURNEY IS THE WORK: Each phase is a stop on the narrow road; let each leave the code clearer than it was
   - SEPARATION OF CONCERNS: Like the kireji (cutting word) in haiku, interfaces separate domains
 
   ## Input
@@ -27,22 +27,14 @@ base_prompt: |
   - Relevant codebase context
   - Domain-specific skills as applicable (TDD, API design, DB-as-code, etc.)
 
-  ## Output
+  ## Practice
 
-  For each phase:
-  1. Implement exactly what the plan specifies
-  2. Run tests, lint, build
-  3. Report results: what was done, what passed, what failed
-  4. If all steps pass, the phase is complete (ready for commit)
+  Work one sub-phase at a time:
+  - Shape the smallest correct change that satisfies the current phase
+  - Keep the implementation elegant, readable, and easy to validate
+  - Let the active phase contract define the validation and closure obligations around this code work
 
-  For the final phase:
-  1. Produce a validation report: what was implemented, how to verify, known limitations
-  2. List steps the user can take to validate independently
-  3. Produce `retrospective.md`:
-     - What went well
-     - What deviated from the plan
-     - What surprised
-     - Spawn issues identified
+  When you report, describe the concrete change and whether the phase constraint was satisfied.
 
   ## Rules
 

--- a/code/cli/assets/apes/darwin.yaml
+++ b/code/cli/assets/apes/darwin.yaml
@@ -11,82 +11,41 @@ base_prompt: |
 
   You observe, compare, and select. You do not design improvements — you identify what worked, what failed, and what mutated, then propose adaptations.
 
-  ## Input
+  Treat each completed cycle as evidence about process fitness. Preserve strong adaptations, expose weak ones, and surface the smallest evidence-backed mutation worth carrying forward.
 
-  You receive the complete cycle artifacts:
-  - diagnosis.md (what was analyzed)
-  - plan.md (what was planned, with checkbox state and deviation annotations)
-  - retrospective.md (what went well, what deviated, what surprised, spawn issues)
-  - .inquiry/mutations.md (human observations about APE's process performance during this cycle)
-  - Commit history (what was actually built)
-  - Any deviation notes
+  ## Methodological Exception
 
-  ## Process
-
-  1. Compare plan vs. actual: What deviated? Why?
-  2. Evaluate process: Was the analysis sufficient? Was the plan detailed enough? Did execution flow smoothly?
-  3. Identify patterns: Are there recurring issues across cycles?
-  4. Search for existing issues: `gh issue list --repo ccisnedev/inquiry --search "keyword"`
-  5. If match found: `gh issue comment <NNN> --body "Observation from cycle..."`
-  6. If no match: `gh issue create --repo ccisnedev/inquiry --title "..." --body "..."`
-
-  ## Metrics Collection
-
-  After evaluating the cycle, generate `.inquiry/metrics.yaml` with these fields:
-
-  | Field | Source |
-  |-------|--------|
-  | `issue` | `.inquiry/state.yaml` → `issue` |
-  | `version` | `pubspec.yaml` → `version` |
-  | `model` | Self-report |
-  | `agent` | Context (copilot, crush, local) |
-  | `cycle.completed` | `true` (you are in EVOLUTION) |
-  | `cycle.darwin_activated` | `true` (you are DARWIN) |
-  | `cycle.darwin_issue` | Issue # you created/commented |
-  | `timing.branch_created` | `.inquiry/metrics_snapshot.yaml` |
-  | `timing.pr_merged` | `gh pr view --json mergedAt` |
-  | `plan.total_phases` | Count phases in plan.md |
-  | `plan.completed_phases` | Count `[x]` in plan.md |
-  | `plan.deviations` | Count deviation annotations |
-  | `tests.before` | `.inquiry/metrics_snapshot.yaml` |
-  | `tests.after` | Current test count |
-  | `tests.delta` | `tests.after - tests.before` |
-  | `observations` | Freeform notable observations |
-
-  Omit any field you cannot reliably determine — do not fabricate data.
-
-  ## Rules
-
-  - Never modify the project's code or documentation. Exception: write `.inquiry/metrics.yaml`.
-  - Only create issues/comments in the inquiry repository.
-  - Be specific and actionable in observations.
-  - Reference concrete examples from the cycle.
+  Your exception is abstract process metaknowledge only:
+  - evaluate workflow fitness rather than product design
+  - compare recurring patterns across completed cycles
+  - prefer falsifiable observations over broad opinion
+  - surface concrete adaptations without taking ownership of repository procedure
 
 states:
   observe:
-    description: "Read cycle artifacts — diagnosis, plan, retrospective, mutations"
+    description: "Read the completed cycle evidence trail"
     transitions:
       - event: next
         to: compare
     prompt: |
-      FOCUS: Observation. Read all cycle artifacts systematically.
-      Note deviations between plan and actual execution.
-      Note human observations from mutations.md.
+      FOCUS: Observation. Read the completed cycle evidence trail systematically.
+      Note deviations between expected and actual execution.
+      Note which observations recur strongly enough to survive comparison.
 
   compare:
-    description: "Compare plan vs actual — identify deviations and patterns"
+    description: "Compare expected and actual process fitness"
     transitions:
       - event: next
         to: select
       - event: back
         to: observe
     prompt: |
-      FOCUS: Comparison. Analyze plan vs. actual execution.
-      What deviated? Why? Are there recurring patterns across cycles?
-      Was the analysis sufficient? Was the plan detailed enough?
+      FOCUS: Comparison. Analyze the gap between the intended workflow and the observed cycle.
+      What deviated? Why? Which patterns look stable across cycles?
+      Was the process fit for purpose at each stage?
 
   select:
-    description: "Select adaptations — create/comment issues"
+    description: "Select the strongest evidence-backed adaptations"
     transitions:
       - event: next
         to: report
@@ -94,15 +53,14 @@ states:
         to: compare
     prompt: |
       FOCUS: Selection. Propose concrete adaptations.
-      Search for existing issues before creating new ones.
+      Prefer the smallest change that addresses the strongest recurring signal.
       Each observation should be actionable and specific.
 
   report:
-    description: "Generate metrics.yaml and final evaluation"
+    description: "Summarize the cycle evaluation"
     transitions:
       - event: complete
         to: _DONE
     prompt: |
-      FOCUS: Reporting. Generate .inquiry/metrics.yaml.
-      Summarize the cycle evaluation.
-      Omit fields you cannot reliably determine.
+      FOCUS: Reporting. Summarize the cycle evaluation and selected adaptations.
+      Keep the report evidence-backed and precise.

--- a/code/cli/assets/apes/descartes.yaml
+++ b/code/cli/assets/apes/descartes.yaml
@@ -22,19 +22,17 @@ base_prompt: |
 
   ## Input
 
-  Your primary input is the diagnosis document at the path specified in `analysis_input` from the inquiry-context block at the end of this prompt. You may reference other documents in the same analyze/ directory for deeper context, but the diagnosis should be sufficient.
+  Ground the plan in the approved diagnosis and any adjacent evidence that materially sharpens it.
 
   ## Output
 
-  Produce the plan at the path specified in `plan_file` from the inquiry-context block. Structure:
+  Produce a phased plan that is detailed enough to execute mechanically. Structure:
 
   - Phases with checkable sub-steps (`- [ ]`)
   - Test definitions in pseudocode for each phase
   - Risk notes where applicable
   - Dependencies between phases
-  - The plan must be detailed enough that execution is mechanical
-  - Every phase MUST end with: `- [ ] Commit: "<descriptive message referencing issue>"`
-  - The final phase MUST include version bump + CHANGELOG update + commit
+  - Explicit entry criteria, execution steps, and verification for every phase
 
   The plan's structure is immutable after approval. Only checkboxes and deviation annotations change during execution.
 

--- a/code/cli/assets/apes/dewey.yaml
+++ b/code/cli/assets/apes/dewey.yaml
@@ -56,7 +56,7 @@ states:
         to: evaluate_scope
     prompt: |
       FOCUS: Deduplication. Search before creating.
-      Use: `gh issue list --search "<keywords>"` to find existing issues.
+      Use the active IDLE contract and allowed command surface to search for existing issues.
       Ask: "Does any existing issue cover this?", "Should we extend an existing issue or create new?"
 
   create_or_select:
@@ -68,7 +68,7 @@ states:
         to: search_existing
     prompt: |
       FOCUS: Issue formulation. Create or select.
-      Use the injected inquiry-context to respect IDLE's TRIAGE objective, deterministic skill, and allowed command surface.
+      Use the injected inquiry-context to respect the active IDLE routing contract.
       If creating: help write a clear title and description. One problem, one reason.
       If selecting: confirm the existing issue matches the user's intent.
 
@@ -83,6 +83,5 @@ states:
         to: create_or_select
     prompt: |
       FOCUS: Confirmation. Verify readiness.
-      If the issue is ready to be tracked, record issue readiness and return to TRIAGE.
-      If the user explicitly wants to begin resolving the issue now, signal start.
+      Confirm whether the issue is well-scoped, clearly titled, and ready for IDLE's next action.
       Ask: "Is this issue well-scoped?", "Is the title clear?", "Should we track this issue now?"

--- a/code/cli/assets/apes/socrates.yaml
+++ b/code/cli/assets/apes/socrates.yaml
@@ -38,7 +38,7 @@ base_prompt: |
   3. Ask 2-3 Socratic questions of different types
   4. Close by inviting deeper exploration, NEVER by suggesting a next step
 
-  ## Final Deliverable: diagnosis.md
+  ## Synthesis
 
   When the analysis is sufficiently deep, produce `diagnosis.md` — a rigorous technical document:
 
@@ -48,26 +48,8 @@ base_prompt: |
   - **Scope** (what enters, what does not)
   - **References** (links to other analysis documents)
 
-  This document must be written like a paper: rigorous, well-documented, with references. It is the sole required input for the planning phase.
-
-  ## Documentation Protocol
-
-  Your output directory is specified in `output_dir` from the inquiry-context block at the end of this prompt.
-
-  ### Mandatory: confirmed.md
-  - You MUST update `confirmed_doc` (from inquiry-context) with every confirmed finding
-  - Each finding uses format: `## F<N>: <title> — CONFIRMED|REVISED|INVALIDATED`
-  - NEVER produce diagnosis.md without at least one finding in confirmed.md
-
-  ### Additional documents
-  - Create one file per distinct investigation topic (e.g., `root-cause.md`, `code-inventory.md`)
-  - Use the doc-write skill protocol for all writes
-  - Use the doc-read skill protocol before creating new files (avoid duplicates)
-
-  ### Rules
-  - All files go in `output_dir`
-  - Update `index_file` (from inquiry-context) after every write
-  - One topic per document — split if covering two themes
+  Treat the diagnosis like a paper: rigorous, well-documented, and grounded in references.
+  Keep each contribution focused on clarifying the problem rather than prescribing implementation.
 
 states:
   clarification:

--- a/code/cli/assets/fsm/states/evolution.yaml
+++ b/code/cli/assets/fsm/states/evolution.yaml
@@ -3,16 +3,53 @@ version: "1.0.0"
 description: "Cycle evaluation and process improvement"
 
 instructions: |
-  Evaluate the completed cycle. Observe what worked,
-  what deviated, what can improve. Create improvement issues.
+  Evaluate the completed cycle against the ideal Analyze -> Plan -> Execute -> End loop.
+  EVOLUTION owns the repository procedure for issue search/comment/create and metrics collection.
+  DARWIN keeps only the abstract process methodology: observe, compare, select, report.
+
+  Review the complete cycle artifacts:
+  - diagnosis.md (what was analyzed)
+  - plan.md (what was planned, with checkbox state and deviation annotations)
+  - retrospective.md (what went well, what deviated, what surprised, spawn issues)
+  - .inquiry/mutations.md (human observations about APE's process performance during this cycle)
+  - Commit history (what was actually built)
+  - Any deviation notes
+
+  Search for existing issues: `gh issue list --repo ccisnedev/inquiry --search "keyword"`
+  If a match exists: `gh issue comment <NNN> --body "Observation from cycle..."`
+  If no match exists: `gh issue create --repo ccisnedev/inquiry --title "..." --body "..."`
+
+  After evaluating the cycle, generate `.inquiry/metrics.yaml` with these fields:
+
+  | Field | Source |
+  |-------|--------|
+  | `issue` | `.inquiry/state.yaml` -> `issue` |
+  | `version` | `pubspec.yaml` -> `version` |
+  | `model` | Self-report |
+  | `agent` | Context (copilot, crush, local) |
+  | `cycle.completed` | `true` (you are in EVOLUTION) |
+  | `cycle.darwin_activated` | `true` (you are DARWIN) |
+  | `cycle.darwin_issue` | Issue # you created/commented |
+  | `timing.branch_created` | `.inquiry/metrics_snapshot.yaml` |
+  | `timing.pr_merged` | `gh pr view --json mergedAt` |
+  | `plan.total_phases` | Count phases in plan.md |
+  | `plan.completed_phases` | Count `[x]` in plan.md |
+  | `plan.deviations` | Count deviation annotations |
+  | `tests.before` | `.inquiry/metrics_snapshot.yaml` |
+  | `tests.after` | Current test count |
+  | `tests.delta` | `tests.after - tests.before` |
+  | `observations` | Freeform notable observations |
 
 constraints:
-  - No code edits (cycle is closed)
-  - Observations must be evidence-based
+  - No project code or documentation edits; only GitHub issue operations and `.inquiry/metrics.yaml`
+  - Observations must be evidence-based and tied to the ideal cycle
   - Improvement issues must be atomic and actionable
+  - Only create issues/comments in the inquiry repository
+  - Omit any metric field you cannot reliably determine
 
 allowed_actions:
-  - Review cycle artifacts (diagnosis, plan, commits, PR)
-  - Document observations in mutations.md
-  - Create improvement issues on GitHub
-  - Collect metrics
+  - Review cycle artifacts (diagnosis.md, plan.md, retrospective.md, commit history, .inquiry/mutations.md)
+  - Search existing issues with gh issue list
+  - Comment on matching issues with gh issue comment
+  - Create new issues with gh issue create
+  - Write .inquiry/metrics.yaml from verified sources

--- a/code/cli/assets/fsm/states/idle.yaml
+++ b/code/cli/assets/fsm/states/idle.yaml
@@ -6,7 +6,8 @@ instructions: |
   IDLE has two internal modes: TRIAGE and DONE.
   TRIAGE is the default: DEWEY clarifies scope, searches, and uses issue-create to create or confirm the GitHub issue.
   If the user's intent is already explicit enough to create or select an issue, IDLE may route TRIAGE directly to create_or_select.
-  Inquiry CLI delivers the TRIAGE objective, deterministic skill, and allowed command surface for that fast path.
+  IDLE owns that fast-path routing contract: triage_objective=create_or_select, deterministic_skill=issue-create, allowed_commands=gh issue list, gh issue view, gh issue create, gh issue edit.
+  Inquiry CLI injects that routing contract into the assembled prompt as explicit inquiry-context.
   When issue readiness is reached, produce issue_selected_or_created, reset DEWEY, and remain in IDLE.
   DONE is reached only on explicit start intent; DONE consumes issue-start to prepare feature_branch_selected.
   Only after that handoff may IDLE fire start_analyze.
@@ -26,3 +27,10 @@ allowed_actions:
   - Search codebase (read-only)
   - Discuss and clarify with user
   - Run iq doctor
+
+inquiry_context:
+  dewey:
+    create_or_select:
+      triage_objective: create_or_select
+      deterministic_skill: issue-create
+      allowed_commands: gh issue list, gh issue view, gh issue create, gh issue edit

--- a/code/cli/lib/modules/ape/ape_definition.dart
+++ b/code/cli/lib/modules/ape/ape_definition.dart
@@ -51,10 +51,16 @@ class ApeDefinition {
 
   /// Assemble the full prompt for a given sub-state.
   ///
-  /// Returns `basePrompt + "\n\n" + state.prompt`.
+  /// Returns APE identity, then an optional operational-contract layer,
+  /// then an optional inquiry-context block.
   /// If [stateName] is null, returns only the base prompt.
+  /// If [operationalContract] is provided, appends it after the APE identity.
   /// If [context] is provided, appends a fenced YAML inquiry-context block.
-  String assemblePrompt({String? stateName, Map<String, String>? context}) {
+  String assemblePrompt({
+    String? stateName,
+    String? operationalContract,
+    Map<String, String>? context,
+  }) {
     final buffer = StringBuffer(basePrompt);
 
     if (stateName != null) {
@@ -63,6 +69,10 @@ class ApeDefinition {
         orElse: () => throw ArgumentError('Unknown state: $stateName for APE $name'),
       );
       buffer.write('\n\n${state.prompt}');
+    }
+
+    if (operationalContract != null && operationalContract.trim().isNotEmpty) {
+      buffer.write('\n\n$operationalContract');
     }
 
     if (context != null && context.isNotEmpty) {

--- a/code/cli/lib/modules/ape/commands/prompt.dart
+++ b/code/cli/lib/modules/ape/commands/prompt.dart
@@ -220,7 +220,13 @@ class ApePromptCommand implements Command<ApePromptInput, ApePromptOutput> {
       case 'darwin':
         return {
           'analyze_dir': analyzeDir,
+          'diagnosis_file': '${analyzeDir}diagnosis.md',
           'plan_file': 'cleanrooms/$branch/plan.md',
+          'retrospective_file': 'cleanrooms/$branch/retrospective.md',
+          'mutations_file': '.inquiry/mutations.md',
+          'state_file': '.inquiry/state.yaml',
+          'metrics_snapshot_file': '.inquiry/metrics_snapshot.yaml',
+          'metrics_file': '.inquiry/metrics.yaml',
           'output_dir': 'cleanrooms/$branch/',
         };
       default:

--- a/code/cli/lib/modules/ape/commands/prompt.dart
+++ b/code/cli/lib/modules/ape/commands/prompt.dart
@@ -16,6 +16,7 @@ import '../../../fsm_contract.dart';
 import '../../../src/git_utils.dart';
 import '../ape_definition.dart';
 import '../inquiry_state.dart';
+import '../operational_contract.dart';
 
 // ─── Input ──────────────────────────────────────────────────────────────────
 
@@ -144,11 +145,16 @@ class ApePromptCommand implements Command<ApePromptInput, ApePromptOutput> {
       currentState,
       resolvedSubState,
     );
+    final operationalContract = OperationalContractLoader(
+      workingDirectory: input.workingDirectory,
+      assets: _assets,
+    ).load(currentState);
 
     // Parse and assemble
     final definition = ApeDefinition.parse(yamlFile.readAsStringSync());
     final prompt = definition.assemblePrompt(
       stateName: resolvedSubState,
+      operationalContract: operationalContract.render(),
       context: context,
     );
 

--- a/code/cli/lib/modules/ape/commands/prompt.dart
+++ b/code/cli/lib/modules/ape/commands/prompt.dart
@@ -139,16 +139,15 @@ class ApePromptCommand implements Command<ApePromptInput, ApePromptOutput> {
     // Resolve sub-state: explicit flag > state.yaml > null
     final resolvedSubState = input.subState ?? inquiry.apeState;
 
-    // Resolve dynamic context for injection
-    final context = _resolveContext(
-      input.name!,
-      currentState,
-      resolvedSubState,
-    );
     final operationalContract = OperationalContractLoader(
       workingDirectory: input.workingDirectory,
       assets: _assets,
     ).load(currentState);
+    final context = _resolveContext(
+      input.name!,
+      resolvedSubState,
+      operationalContract: operationalContract,
+    );
 
     // Parse and assemble
     final definition = ApeDefinition.parse(yamlFile.readAsStringSync());
@@ -169,20 +168,29 @@ class ApePromptCommand implements Command<ApePromptInput, ApePromptOutput> {
   /// Resolves dynamic context paths per APE and FSM state.
   Map<String, String>? _resolveContext(
     String apeName,
-    FsmState state,
     String? subState,
-  ) {
-    if (apeName == 'dewey' &&
-        state == FsmState.idle &&
-        subState == 'create_or_select') {
-      return const {
-        'triage_objective': 'create_or_select',
-        'deterministic_skill': 'issue-create',
-        'allowed_commands':
-            'gh issue list, gh issue view, gh issue create, gh issue edit',
-      };
+    {
+    required OperationalContract operationalContract,
+  }) {
+    final context = <String, String>{};
+
+    final stateOwnedContext = operationalContract.inquiryContextFor(
+      apeName: apeName,
+      subState: subState,
+    );
+    if (stateOwnedContext != null) {
+      context.addAll(stateOwnedContext);
     }
 
+    final runtimeContext = _resolveRuntimeContext(apeName);
+    if (runtimeContext != null) {
+      context.addAll(runtimeContext);
+    }
+
+    return context.isEmpty ? null : context;
+  }
+
+  Map<String, String>? _resolveRuntimeContext(String apeName) {
     final branch = getCurrentBranch(input.workingDirectory);
     if (branch.isEmpty) return null;
 

--- a/code/cli/lib/modules/ape/operational_contract.dart
+++ b/code/cli/lib/modules/ape/operational_contract.dart
@@ -1,0 +1,156 @@
+library;
+
+import 'dart:io';
+
+import 'package:cli_router/cli_router.dart';
+import 'package:modular_cli_sdk/modular_cli_sdk.dart';
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+
+import '../../assets.dart';
+import '../../fsm_contract.dart';
+
+class OperationalContract {
+  final FsmState state;
+  final String instructions;
+  final List<String> constraints;
+  final List<String> allowedActions;
+
+  const OperationalContract({
+    required this.state,
+    required this.instructions,
+    required this.constraints,
+    required this.allowedActions,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'state': state.value,
+    'instructions': instructions,
+    'constraints': constraints,
+    'allowed_actions': allowedActions,
+  };
+
+  String render() {
+    final buffer = StringBuffer()
+      ..writeln('## Phase-Owned Operational Contract')
+      ..writeln('State: ${state.value}')
+      ..writeln()
+      ..writeln('Mission:')
+      ..writeln(instructions.trim());
+
+    if (constraints.isNotEmpty) {
+      buffer
+        ..writeln()
+        ..writeln('Constraints:');
+      for (final constraint in constraints) {
+        buffer.writeln('- $constraint');
+      }
+    }
+
+    if (allowedActions.isNotEmpty) {
+      buffer
+        ..writeln()
+        ..writeln('Allowed actions:');
+      for (final action in allowedActions) {
+        buffer.writeln('- $action');
+      }
+    }
+
+    return buffer.toString().trimRight();
+  }
+}
+
+class OperationalContractLoader {
+  final String workingDirectory;
+  final Assets? assets;
+
+  const OperationalContractLoader({
+    required this.workingDirectory,
+    this.assets,
+  });
+
+  OperationalContract load(FsmState state) {
+    final stateName = state.value.toLowerCase();
+    final yamlPath = assets != null
+        ? assets!.path('fsm/states/$stateName.yaml')
+        : p.join(workingDirectory, 'assets', 'fsm', 'states', '$stateName.yaml');
+
+    final yaml = _readYamlMap(yamlPath, stateName);
+    final instructions = _readStringField(
+      yaml,
+      fieldName: 'instructions',
+      stateName: stateName,
+    );
+    final constraints = _readStringListField(
+      yaml,
+      fieldName: 'constraints',
+      stateName: stateName,
+    );
+    final allowedActions = _readStringListField(
+      yaml,
+      fieldName: 'allowed_actions',
+      stateName: stateName,
+    );
+
+    return OperationalContract(
+      state: state,
+      instructions: instructions.trim(),
+      constraints: constraints,
+      allowedActions: allowedActions,
+    );
+  }
+
+  YamlMap _readYamlMap(String yamlPath, String stateName) {
+    try {
+      final yaml = loadYaml(File(yamlPath).readAsStringSync());
+      if (yaml is YamlMap) {
+        return yaml;
+      }
+      throw _malformedStateYaml(stateName, 'root mapping');
+    } on PathNotFoundException {
+      throw _missingStateYaml(stateName);
+    } on FileSystemException {
+      throw _missingStateYaml(stateName);
+    }
+  }
+
+  String _readStringField(
+    YamlMap yaml, {
+    required String fieldName,
+    required String stateName,
+  }) {
+    final value = yaml[fieldName];
+    if (value is String && value.trim().isNotEmpty) {
+      return value;
+    }
+    throw _malformedStateYaml(stateName, fieldName);
+  }
+
+  List<String> _readStringListField(
+    YamlMap yaml, {
+    required String fieldName,
+    required String stateName,
+  }) {
+    final value = yaml[fieldName];
+    if (value is YamlList) {
+      return value.cast<String>().toList(growable: false);
+    }
+    throw _malformedStateYaml(stateName, fieldName);
+  }
+
+  CommandException _missingStateYaml(String stateName) {
+    return CommandException(
+      code: 'MISSING_STATE_YAML',
+      message: "State instructions missing for '$stateName'. Run 'iq doctor --fix' to repair.",
+      exitCode: ExitCode.genericError,
+    );
+  }
+
+  CommandException _malformedStateYaml(String stateName, String fieldName) {
+    return CommandException(
+      code: 'MALFORMED_STATE_YAML',
+      message: "State file for '$stateName' is missing '$fieldName' field. Run 'iq doctor --fix' to repair.",
+      exitCode: ExitCode.genericError,
+    );
+  }
+}

--- a/code/cli/lib/modules/ape/operational_contract.dart
+++ b/code/cli/lib/modules/ape/operational_contract.dart
@@ -2,7 +2,6 @@ library;
 
 import 'dart:io';
 
-import 'package:cli_router/cli_router.dart';
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';

--- a/code/cli/lib/modules/ape/operational_contract.dart
+++ b/code/cli/lib/modules/ape/operational_contract.dart
@@ -15,12 +15,14 @@ class OperationalContract {
   final String instructions;
   final List<String> constraints;
   final List<String> allowedActions;
+  final Map<String, Map<String, Map<String, String>>> inquiryContext;
 
   const OperationalContract({
     required this.state,
     required this.instructions,
     required this.constraints,
     required this.allowedActions,
+    this.inquiryContext = const {},
   });
 
   Map<String, dynamic> toJson() => {
@@ -28,7 +30,25 @@ class OperationalContract {
     'instructions': instructions,
     'constraints': constraints,
     'allowed_actions': allowedActions,
+    if (inquiryContext.isNotEmpty) 'inquiry_context': inquiryContext,
   };
+
+  Map<String, String>? inquiryContextFor({
+    required String apeName,
+    String? subState,
+  }) {
+    if (subState == null) return null;
+
+    final apeContext = inquiryContext[apeName];
+    if (apeContext == null) return null;
+
+    final subStateContext = apeContext[subState];
+    if (subStateContext == null || subStateContext.isEmpty) {
+      return null;
+    }
+
+    return subStateContext;
+  }
 
   String render() {
     final buffer = StringBuffer()
@@ -91,12 +111,17 @@ class OperationalContractLoader {
       fieldName: 'allowed_actions',
       stateName: stateName,
     );
+    final inquiryContext = _readInquiryContextField(
+      yaml,
+      stateName: stateName,
+    );
 
     return OperationalContract(
       state: state,
       instructions: instructions.trim(),
       constraints: constraints,
       allowedActions: allowedActions,
+      inquiryContext: inquiryContext,
     );
   }
 
@@ -136,6 +161,55 @@ class OperationalContractLoader {
       return value.cast<String>().toList(growable: false);
     }
     throw _malformedStateYaml(stateName, fieldName);
+  }
+
+  Map<String, Map<String, Map<String, String>>> _readInquiryContextField(
+    YamlMap yaml, {
+    required String stateName,
+  }) {
+    final value = yaml['inquiry_context'];
+    if (value == null) {
+      return const {};
+    }
+    if (value is! YamlMap) {
+      throw _malformedStateYaml(stateName, 'inquiry_context');
+    }
+
+    final inquiryContext = <String, Map<String, Map<String, String>>>{};
+    for (final apeEntry in value.entries) {
+      final apeName = apeEntry.key;
+      final apeValue = apeEntry.value;
+      if (apeName is! String || apeValue is! YamlMap) {
+        throw _malformedStateYaml(stateName, 'inquiry_context');
+      }
+
+      final subStateContext = <String, Map<String, String>>{};
+      for (final subStateEntry in apeValue.entries) {
+        final subStateName = subStateEntry.key;
+        final subStateValue = subStateEntry.value;
+        if (subStateName is! String || subStateValue is! YamlMap) {
+          throw _malformedStateYaml(stateName, 'inquiry_context');
+        }
+
+        final contextFields = <String, String>{};
+        for (final contextEntry in subStateValue.entries) {
+          final contextKey = contextEntry.key;
+          final contextValue = contextEntry.value;
+          if (contextKey is! String ||
+              contextValue is! String ||
+              contextValue.trim().isEmpty) {
+            throw _malformedStateYaml(stateName, 'inquiry_context');
+          }
+          contextFields[contextKey] = contextValue;
+        }
+
+        subStateContext[subStateName] = contextFields;
+      }
+
+      inquiryContext[apeName] = subStateContext;
+    }
+
+    return inquiryContext;
   }
 
   CommandException _missingStateYaml(String stateName) {

--- a/code/cli/lib/modules/fsm/commands/state.dart
+++ b/code/cli/lib/modules/fsm/commands/state.dart
@@ -12,6 +12,7 @@ import '../../../assets.dart';
 import '../../../fsm_contract.dart';
 import '../../ape/ape_definition.dart';
 import '../../ape/inquiry_state.dart';
+import '../../ape/operational_contract.dart';
 
 class FsmStateInput extends Input {
   final String workingDirectory;
@@ -32,6 +33,7 @@ class FsmStateOutput extends Output {
   final List<Map<String, String>> transitions;
   final List<Map<String, String>> apes;
   final String instructions;
+  final Map<String, dynamic> operationalContract;
   final Map<String, dynamic>? ape;
   final String completionAuthority;
 
@@ -41,6 +43,7 @@ class FsmStateOutput extends Output {
     required this.transitions,
     required this.apes,
     required this.instructions,
+    required this.operationalContract,
     this.ape,
     required this.completionAuthority,
   });
@@ -53,6 +56,7 @@ class FsmStateOutput extends Output {
     'transitions': transitions,
     'apes': apes,
     'instructions': instructions,
+    'operational_contract': operationalContract,
     if (ape != null) 'ape': ape,
   };
 
@@ -106,7 +110,8 @@ class FsmStateCommand implements Command<FsmStateInput, FsmStateOutput> {
     final validTransitions = _computeTransitions(
       contract, currentState, input.workingDirectory);
     final activeApes = _computeApes(currentState);
-    final instructions = _computeInstructions(currentState);
+    final operationalContract = _loadOperationalContract(currentState);
+    final instructions = operationalContract.instructions;
     final apeInfo = _computeApeInfo(inquiry);
     final completionAuthority =
         contract.completionAuthority[currentState] ?? 'user';
@@ -117,6 +122,7 @@ class FsmStateCommand implements Command<FsmStateInput, FsmStateOutput> {
       transitions: validTransitions,
       apes: activeApes,
       instructions: instructions,
+      operationalContract: operationalContract.toJson(),
       ape: apeInfo,
       completionAuthority: completionAuthority,
     );
@@ -180,38 +186,11 @@ class FsmStateCommand implements Command<FsmStateInput, FsmStateOutput> {
     return _stateApes[state] ?? [];
   }
 
-  String _computeInstructions(FsmState state) {
-    final stateName = state.value.toLowerCase();
-    try {
-      final yamlPath = _assets != null
-          ? _assets.path('fsm/states/$stateName.yaml')
-          : p.join(input.workingDirectory, 'assets', 'fsm', 'states', '$stateName.yaml');
-      final content = File(yamlPath).readAsStringSync();
-      final yaml = loadYaml(content);
-      if (yaml is YamlMap && yaml['instructions'] is String) {
-        return (yaml['instructions'] as String).trim();
-      }
-      throw CommandException(
-        code: 'MALFORMED_STATE_YAML',
-        message: "State file for '$stateName' is missing 'instructions' field. "
-            "Run 'iq doctor --fix' to repair.",
-        exitCode: ExitCode.genericError,
-      );
-    } on PathNotFoundException {
-      throw CommandException(
-        code: 'MISSING_STATE_YAML',
-        message: "State instructions missing for '$stateName'. "
-            "Run 'iq doctor --fix' to repair.",
-        exitCode: ExitCode.genericError,
-      );
-    } on FileSystemException {
-      throw CommandException(
-        code: 'MISSING_STATE_YAML',
-        message: "State instructions missing for '$stateName'. "
-            "Run 'iq doctor --fix' to repair.",
-        exitCode: ExitCode.genericError,
-      );
-    }
+  OperationalContract _loadOperationalContract(FsmState state) {
+    return OperationalContractLoader(
+      workingDirectory: input.workingDirectory,
+      assets: _assets,
+    ).load(state);
   }
 
   /// Build `ape` info from InquiryState + APE YAML definition.

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.3.7';
+const String inquiryVersion = '0.4.0';

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.3.6';
+const String inquiryVersion = '0.3.7';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.3.7
+version: 0.4.0
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.3.6
+version: 0.3.7
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/ape_definition_test.dart
+++ b/code/cli/test/ape_definition_test.dart
@@ -122,6 +122,10 @@ void main() {
         expect(def.basePrompt, contains('Socratic method'));
         expect(def.basePrompt, contains('EPISTEMIC HUMILITY'));
         expect(def.basePrompt, contains('diagnosis.md'));
+        expect(def.basePrompt, isNot(contains('output_dir')));
+        expect(def.basePrompt, isNot(contains('confirmed_doc')));
+        expect(def.basePrompt, isNot(contains('index_file')));
+        expect(def.basePrompt, isNot(contains('doc-write')));
       });
 
       test('descartes base_prompt contains Cartesian method keywords', () {
@@ -131,7 +135,10 @@ void main() {
         expect(def.basePrompt, contains('DESCARTES'));
         expect(def.basePrompt, contains('scientific method'));
         expect(def.basePrompt, contains('EVIDENCE'));
-        expect(def.basePrompt, contains('plan_file'));
+        expect(def.basePrompt, contains('experimental design'));
+        expect(def.basePrompt, isNot(contains('analysis_input')));
+        expect(def.basePrompt, isNot(contains('plan_file')));
+        expect(def.basePrompt, isNot(contains('Commit:')));
       });
 
       test('basho base_prompt contains implementation keywords', () {
@@ -141,7 +148,9 @@ void main() {
         expect(def.basePrompt, contains('BASHŌ'));
         expect(def.basePrompt, contains('用の美'));
         expect(def.basePrompt, contains('NOTHING WASTED'));
-        expect(def.basePrompt, contains('retrospective.md'));
+        expect(def.basePrompt, contains('functional art'));
+        expect(def.basePrompt, isNot(contains('Run tests, lint, build')));
+        expect(def.basePrompt, isNot(contains('retrospective.md')));
       });
 
       test('darwin base_prompt contains evolution keywords', () {

--- a/code/cli/test/ape_definition_test.dart
+++ b/code/cli/test/ape_definition_test.dart
@@ -159,8 +159,15 @@ void main() {
         );
         expect(def.basePrompt, contains('DARWIN'));
         expect(def.basePrompt, contains('natural selection'));
-        expect(def.basePrompt, contains('mutations.md'));
-        expect(def.basePrompt, contains('metrics.yaml'));
+        expect(def.basePrompt, contains('observe, compare, and select'));
+        expect(def.basePrompt, isNot(contains('gh issue list')));
+        expect(def.basePrompt, isNot(contains('gh issue create')));
+        expect(def.basePrompt, isNot(contains('gh issue comment')));
+        expect(def.basePrompt, isNot(contains('diagnosis.md')));
+        expect(def.basePrompt, isNot(contains('plan.md')));
+        expect(def.basePrompt, isNot(contains('retrospective.md')));
+        expect(def.basePrompt, isNot(contains('.inquiry/')));
+        expect(def.basePrompt, isNot(contains('metrics.yaml')));
       });
     });
 

--- a/code/cli/test/ape_prompt_test.dart
+++ b/code/cli/test/ape_prompt_test.dart
@@ -413,7 +413,14 @@ void main() {
         final result = await cmd.execute();
 
         expect(result.prompt, contains('natural selection'));
-        expect(result.prompt, contains('mutations.md'));
+        expect(
+          result.prompt,
+          contains('ideal Analyze -> Plan -> Execute -> End loop'),
+        );
+        expect(
+          result.prompt,
+          contains('EVOLUTION owns the repository procedure for issue search/comment/create and metrics collection.'),
+        );
         expect(result.prompt, contains('Observation'));
       });
     });
@@ -775,12 +782,25 @@ void main() {
         final result = await cmd.execute();
 
         expect(result.prompt, contains('diagnosis.md'));
-        expect(result.prompt, contains('.inquiry/mutations.md'));
         expect(result.prompt, contains('FOCUS: Observation.'));
-        expect(result.prompt, contains('metrics.yaml'));
+        expect(
+          result.prompt,
+          contains('EVOLUTION owns the repository procedure for issue search/comment/create and metrics collection.'),
+        );
         expect(result.prompt, contains('# --- inquiry-context ---'));
         expect(result.prompt, contains('analyze_dir: cleanrooms/152-test-branch/analyze/'));
         expect(result.prompt, contains('plan_file: cleanrooms/152-test-branch/plan.md'));
+        expect(
+          result.prompt,
+          contains('retrospective_file: cleanrooms/152-test-branch/retrospective.md'),
+        );
+        expect(result.prompt, contains('mutations_file: .inquiry/mutations.md'));
+        expect(result.prompt, contains('state_file: .inquiry/state.yaml'));
+        expect(
+          result.prompt,
+          contains('metrics_snapshot_file: .inquiry/metrics_snapshot.yaml'),
+        );
+        expect(result.prompt, contains('metrics_file: .inquiry/metrics.yaml'));
         expect(result.prompt, contains('output_dir: cleanrooms/152-test-branch/'));
         expectExplicitContextAfter(result.prompt, 'FOCUS: Observation.');
       });

--- a/code/cli/test/ape_prompt_test.dart
+++ b/code/cli/test/ape_prompt_test.dart
@@ -700,16 +700,65 @@ void main() {
         expect(result.subState, equals('create_or_select'));
         expect(result.prompt, contains('FOCUS: Issue formulation. Create or select.'));
         expect(result.prompt, contains('# --- inquiry-context ---'));
+        expect(
+          result.prompt,
+          contains('IDLE owns that fast-path routing contract: triage_objective=create_or_select, deterministic_skill=issue-create, allowed_commands=gh issue list, gh issue view, gh issue create, gh issue edit.'),
+        );
         expect(result.prompt, contains('triage_objective: create_or_select'));
         expect(result.prompt, contains('deterministic_skill: issue-create'));
         expect(
           result.prompt,
           contains('allowed_commands: gh issue list, gh issue view, gh issue create, gh issue edit'),
         );
+        expectOperationalContractBetween(
+          result.prompt,
+          identityFragment: 'FOCUS: Issue formulation. Create or select.',
+          contractFragment: 'IDLE owns that fast-path routing contract: triage_objective=create_or_select',
+        );
         expectExplicitContextAfter(
           result.prompt,
           'FOCUS: Issue formulation. Create or select.',
         );
+      });
+
+      test('dewey search_existing prompt keeps GitHub procedure in the IDLE contract', () async {
+        File(p.join(gitTmpDir.path, '.inquiry', 'state.yaml'))
+            .writeAsStringSync(
+              'state: IDLE\n'
+              'issue: null\n'
+              'ape:\n'
+              '  name: dewey\n'
+              '  state: search_existing\n',
+            );
+
+        final cmd = ApePromptCommand(
+          ApePromptInput(name: 'dewey', workingDirectory: gitTmpDir.path),
+        );
+        final result = await cmd.execute();
+
+        expect(result.subState, equals('search_existing'));
+        expect(result.prompt, contains('FOCUS: Deduplication. Search before creating.'));
+        expect(
+          result.prompt,
+          isNot(contains('Use: `gh issue list --search "<keywords>"` to find existing issues.')),
+        );
+        expect(
+          result.prompt,
+          contains('IDLE owns that fast-path routing contract: triage_objective=create_or_select, deterministic_skill=issue-create, allowed_commands=gh issue list, gh issue view, gh issue create, gh issue edit.'),
+        );
+        final promptIndex = result.prompt.indexOf(
+          'FOCUS: Deduplication. Search before creating.',
+        );
+        final contractIndex = result.prompt.indexOf(
+          '## Phase-Owned Operational Contract',
+        );
+        final detailIndex = result.prompt.indexOf(
+          'IDLE owns that fast-path routing contract: triage_objective=create_or_select',
+        );
+
+        expect(promptIndex, greaterThanOrEqualTo(0));
+        expect(contractIndex, greaterThan(promptIndex));
+        expect(detailIndex, greaterThan(contractIndex));
       });
 
       test('darwin prompt includes cycle artifact contract in assembled prompt', () async {

--- a/code/cli/test/ape_prompt_test.dart
+++ b/code/cli/test/ape_prompt_test.dart
@@ -468,6 +468,16 @@ void main() {
     group('inquiry-context injection', () {
       late Directory gitTmpDir;
 
+      void expectExplicitContextAfter(String prompt, String promptFragment) {
+        final promptIndex = prompt.indexOf(promptFragment);
+        final contextIndex = prompt.indexOf('# --- inquiry-context ---');
+
+        expect(promptIndex, greaterThanOrEqualTo(0),
+            reason: 'Missing assembled prompt fragment: $promptFragment');
+        expect(contextIndex, greaterThan(promptIndex),
+            reason: 'inquiry-context should stay explicit after the prompt body');
+      }
+
       setUp(() {
         gitTmpDir = Directory.systemTemp.createTempSync('ape_ctx_test_');
         Directory(p.join(gitTmpDir.path, '.inquiry')).createSync();
@@ -503,14 +513,22 @@ void main() {
             .writeAsStringSync('state: ANALYZE\nissue: "152"\n');
 
         final cmd = ApePromptCommand(
-          ApePromptInput(name: 'socrates', workingDirectory: gitTmpDir.path),
+          ApePromptInput(
+            name: 'socrates',
+            subState: 'clarification',
+            workingDirectory: gitTmpDir.path,
+          ),
         );
         final result = await cmd.execute();
 
+        expect(result.prompt, contains('diagnosis.md'));
+        expect(result.prompt, contains('Clarification questions'));
         expect(result.prompt, contains('# --- inquiry-context ---'));
         expect(result.prompt, contains('output_dir: cleanrooms/152-test-branch/analyze/'));
         expect(result.prompt, contains('confirmed_doc: cleanrooms/152-test-branch/analyze/confirmed.md'));
         expect(result.prompt, contains('index_file: cleanrooms/152-test-branch/analyze/index.md'));
+        expect(result.prompt, contains('doc_protocol: doc-write'));
+        expectExplicitContextAfter(result.prompt, 'Clarification questions');
       });
 
       test('descartes prompt includes analysis_input path', () async {
@@ -518,13 +536,49 @@ void main() {
             .writeAsStringSync('state: PLAN\nissue: "152"\n');
 
         final cmd = ApePromptCommand(
-          ApePromptInput(name: 'descartes', workingDirectory: gitTmpDir.path),
+          ApePromptInput(
+            name: 'descartes',
+            subState: 'decomposition',
+            workingDirectory: gitTmpDir.path,
+          ),
         );
         final result = await cmd.execute();
 
+        expect(result.prompt, contains('EVIDENCE'));
+        expect(result.prompt, contains('FOCUS: Division.'));
         expect(result.prompt, contains('# --- inquiry-context ---'));
         expect(result.prompt, contains('analysis_input: cleanrooms/152-test-branch/analyze/diagnosis.md'));
         expect(result.prompt, contains('plan_file: cleanrooms/152-test-branch/plan.md'));
+        expect(result.prompt, contains('doc_protocol: doc-read'));
+        expectExplicitContextAfter(result.prompt, 'FOCUS: Division.');
+      });
+
+      test('basho prompt includes plan contract in assembled prompt', () async {
+        File(p.join(gitTmpDir.path, '.inquiry', 'state.yaml'))
+            .writeAsStringSync('state: EXECUTE\nissue: "152"\n');
+
+        final cmd = ApePromptCommand(
+          ApePromptInput(
+            name: 'basho',
+            subState: 'implement',
+            workingDirectory: gitTmpDir.path,
+          ),
+        );
+        final result = await cmd.execute();
+
+        expect(result.prompt, contains('NOTHING WASTED'));
+        expect(
+          result.prompt,
+          contains('Implement exactly what the plan says. No more, no less.'),
+        );
+        expect(result.prompt, contains('# --- inquiry-context ---'));
+        expect(result.prompt, contains('plan_file: cleanrooms/152-test-branch/plan.md'));
+        expect(result.prompt, contains('output_dir: cleanrooms/152-test-branch/'));
+        expect(result.prompt, contains('doc_protocol: doc-read'));
+        expectExplicitContextAfter(
+          result.prompt,
+          'Implement exactly what the plan says. No more, no less.',
+        );
       });
 
       test('dewey create_or_select prompt includes IDLE-owned routing context', () async {
@@ -543,6 +597,7 @@ void main() {
         final result = await cmd.execute();
 
         expect(result.subState, equals('create_or_select'));
+        expect(result.prompt, contains('FOCUS: Issue formulation. Create or select.'));
         expect(result.prompt, contains('# --- inquiry-context ---'));
         expect(result.prompt, contains('triage_objective: create_or_select'));
         expect(result.prompt, contains('deterministic_skill: issue-create'));
@@ -550,6 +605,34 @@ void main() {
           result.prompt,
           contains('allowed_commands: gh issue list, gh issue view, gh issue create, gh issue edit'),
         );
+        expectExplicitContextAfter(
+          result.prompt,
+          'FOCUS: Issue formulation. Create or select.',
+        );
+      });
+
+      test('darwin prompt includes cycle artifact contract in assembled prompt', () async {
+        File(p.join(gitTmpDir.path, '.inquiry', 'state.yaml'))
+            .writeAsStringSync('state: EVOLUTION\nissue: "152"\n');
+
+        final cmd = ApePromptCommand(
+          ApePromptInput(
+            name: 'darwin',
+            subState: 'observe',
+            workingDirectory: gitTmpDir.path,
+          ),
+        );
+        final result = await cmd.execute();
+
+        expect(result.prompt, contains('diagnosis.md'));
+        expect(result.prompt, contains('.inquiry/mutations.md'));
+        expect(result.prompt, contains('FOCUS: Observation.'));
+        expect(result.prompt, contains('metrics.yaml'));
+        expect(result.prompt, contains('# --- inquiry-context ---'));
+        expect(result.prompt, contains('analyze_dir: cleanrooms/152-test-branch/analyze/'));
+        expect(result.prompt, contains('plan_file: cleanrooms/152-test-branch/plan.md'));
+        expect(result.prompt, contains('output_dir: cleanrooms/152-test-branch/'));
+        expectExplicitContextAfter(result.prompt, 'FOCUS: Observation.');
       });
 
       test('no context injected when not in a git repo', () async {

--- a/code/cli/test/ape_prompt_test.dart
+++ b/code/cli/test/ape_prompt_test.dart
@@ -21,6 +21,13 @@ void main() {
       File('assets/apes/$name.yaml')
           .copySync(p.join(apesDir.path, '$name.yaml'));
     }
+
+    final statesDir = Directory(p.join(tmpDir.path, 'assets', 'fsm', 'states'));
+    statesDir.createSync(recursive: true);
+    for (final name in ['idle', 'analyze', 'plan', 'execute', 'end', 'evolution']) {
+      File('assets/fsm/states/$name.yaml')
+          .copySync(p.join(statesDir.path, '$name.yaml'));
+    }
   });
 
   tearDown(() {
@@ -478,6 +485,26 @@ void main() {
             reason: 'inquiry-context should stay explicit after the prompt body');
       }
 
+      void expectOperationalContractBetween(
+        String prompt, {
+        required String identityFragment,
+        required String contractFragment,
+      }) {
+        final identityIndex = prompt.indexOf(identityFragment);
+        final contractIndex = prompt.indexOf('## Phase-Owned Operational Contract');
+        final detailIndex = prompt.indexOf(contractFragment);
+        final contextIndex = prompt.indexOf('# --- inquiry-context ---');
+
+        expect(identityIndex, greaterThanOrEqualTo(0),
+            reason: 'Missing assembled prompt identity fragment: $identityFragment');
+        expect(contractIndex, greaterThan(identityIndex),
+            reason: 'Operational contract should come after the APE identity');
+        expect(detailIndex, greaterThan(contractIndex),
+            reason: 'Operational contract should expose the phase-owned details');
+        expect(contextIndex, greaterThan(detailIndex),
+            reason: 'inquiry-context should stay explicit after the operational contract');
+      }
+
       setUp(() {
         gitTmpDir = Directory.systemTemp.createTempSync('ape_ctx_test_');
         Directory(p.join(gitTmpDir.path, '.inquiry')).createSync();
@@ -501,6 +528,13 @@ void main() {
         for (final name in ['socrates', 'dewey', 'descartes', 'basho', 'darwin']) {
           File('assets/apes/$name.yaml')
               .copySync(p.join(apesDir.path, '$name.yaml'));
+        }
+
+        final statesDir = Directory(p.join(gitTmpDir.path, 'assets', 'fsm', 'states'));
+        statesDir.createSync(recursive: true);
+        for (final name in ['idle', 'analyze', 'plan', 'execute', 'end', 'evolution']) {
+          File('assets/fsm/states/$name.yaml')
+              .copySync(p.join(statesDir.path, '$name.yaml'));
         }
       });
 
@@ -571,13 +605,25 @@ void main() {
           result.prompt,
           contains('Implement exactly what the plan says. No more, no less.'),
         );
+        expect(result.prompt, contains('## Phase-Owned Operational Contract'));
+        expect(
+          result.prompt,
+          contains('Implement the plan phase by phase under its formal constraints.'),
+        );
+        expect(
+          result.prompt,
+          contains('Follow plan.md phases in order'),
+        );
+        expect(result.prompt, contains('Allowed actions:'));
+        expect(result.prompt, contains('Edit code files'));
         expect(result.prompt, contains('# --- inquiry-context ---'));
         expect(result.prompt, contains('plan_file: cleanrooms/152-test-branch/plan.md'));
         expect(result.prompt, contains('output_dir: cleanrooms/152-test-branch/'));
         expect(result.prompt, contains('doc_protocol: doc-read'));
-        expectExplicitContextAfter(
+        expectOperationalContractBetween(
           result.prompt,
-          'Implement exactly what the plan says. No more, no less.',
+          identityFragment: 'Implement exactly what the plan says. No more, no less.',
+          contractFragment: 'Implement the plan phase by phase under its formal constraints.',
         );
       });
 

--- a/code/cli/test/ape_prompt_test.dart
+++ b/code/cli/test/ape_prompt_test.dart
@@ -381,7 +381,7 @@ void main() {
 
         expect(result.prompt, contains('EVIDENCE'));
         expect(result.prompt, contains('DIVISION'));
-        expect(result.prompt, contains('plan_file'));
+        expect(result.prompt, contains('experimental plan'));
         expect(result.prompt, contains('Division'));
       });
 
@@ -505,6 +505,18 @@ void main() {
             reason: 'inquiry-context should stay explicit after the operational contract');
       }
 
+        void expectContextKeyOnlyInInquiryContext(String prompt, String key) {
+        final contextIndex = prompt.indexOf('# --- inquiry-context ---');
+        final keyIndex = prompt.indexOf(key);
+
+        expect(contextIndex, greaterThanOrEqualTo(0),
+          reason: 'Missing inquiry-context block for key: $key');
+        expect(keyIndex, greaterThan(contextIndex),
+          reason: '$key should be owned by inquiry-context, not the APE identity');
+        expect(prompt.indexOf(key, keyIndex + key.length), equals(-1),
+          reason: '$key should appear only once in the assembled prompt');
+        }
+
       setUp(() {
         gitTmpDir = Directory.systemTemp.createTempSync('ape_ctx_test_');
         Directory(p.join(gitTmpDir.path, '.inquiry')).createSync();
@@ -562,6 +574,22 @@ void main() {
         expect(result.prompt, contains('confirmed_doc: cleanrooms/152-test-branch/analyze/confirmed.md'));
         expect(result.prompt, contains('index_file: cleanrooms/152-test-branch/analyze/index.md'));
         expect(result.prompt, contains('doc_protocol: doc-write'));
+        expectContextKeyOnlyInInquiryContext(
+          result.prompt,
+          'output_dir: cleanrooms/152-test-branch/analyze/',
+        );
+        expectContextKeyOnlyInInquiryContext(
+          result.prompt,
+          'confirmed_doc: cleanrooms/152-test-branch/analyze/confirmed.md',
+        );
+        expectContextKeyOnlyInInquiryContext(
+          result.prompt,
+          'index_file: cleanrooms/152-test-branch/analyze/index.md',
+        );
+        expectContextKeyOnlyInInquiryContext(
+          result.prompt,
+          'doc_protocol: doc-write',
+        );
         expectExplicitContextAfter(result.prompt, 'Clarification questions');
       });
 
@@ -584,6 +612,19 @@ void main() {
         expect(result.prompt, contains('analysis_input: cleanrooms/152-test-branch/analyze/diagnosis.md'));
         expect(result.prompt, contains('plan_file: cleanrooms/152-test-branch/plan.md'));
         expect(result.prompt, contains('doc_protocol: doc-read'));
+        expect(result.prompt, isNot(contains('Commit:')));
+        expectContextKeyOnlyInInquiryContext(
+          result.prompt,
+          'analysis_input: cleanrooms/152-test-branch/analyze/diagnosis.md',
+        );
+        expectContextKeyOnlyInInquiryContext(
+          result.prompt,
+          'plan_file: cleanrooms/152-test-branch/plan.md',
+        );
+        expectContextKeyOnlyInInquiryContext(
+          result.prompt,
+          'doc_protocol: doc-read',
+        );
         expectExplicitContextAfter(result.prompt, 'FOCUS: Division.');
       });
 
@@ -620,6 +661,20 @@ void main() {
         expect(result.prompt, contains('plan_file: cleanrooms/152-test-branch/plan.md'));
         expect(result.prompt, contains('output_dir: cleanrooms/152-test-branch/'));
         expect(result.prompt, contains('doc_protocol: doc-read'));
+        expect(result.prompt, isNot(contains('Run tests, lint, build')));
+        expect(result.prompt, isNot(contains('retrospective.md')));
+        expectContextKeyOnlyInInquiryContext(
+          result.prompt,
+          'plan_file: cleanrooms/152-test-branch/plan.md',
+        );
+        expectContextKeyOnlyInInquiryContext(
+          result.prompt,
+          'output_dir: cleanrooms/152-test-branch/',
+        );
+        expectContextKeyOnlyInInquiryContext(
+          result.prompt,
+          'doc_protocol: doc-read',
+        );
         expectOperationalContractBetween(
           result.prompt,
           identityFragment: 'Implement exactly what the plan says. No more, no less.',

--- a/code/cli/test/ape_transition_test.dart
+++ b/code/cli/test/ape_transition_test.dart
@@ -140,6 +140,24 @@ void main() {
         expect(result.to, equals('evaluate_scope'));
       });
 
+      test('dewey search_existing --next--> create_or_select', () async {
+        writeState(
+          state: 'IDLE',
+          apeName: 'dewey',
+          apeState: 'search_existing',
+        );
+
+        final cmd = ApeTransitionCommand(
+          ApeTransitionInput(event: 'next', workingDirectory: tmpDir.path),
+        );
+        final result = await cmd.execute();
+
+        expect(result.apeName, equals('dewey'));
+        expect(result.from, equals('search_existing'));
+        expect(result.event, equals('next'));
+        expect(result.to, equals('create_or_select'));
+      });
+
       test('reaches _DONE sentinel', () async {
         writeState(
           state: 'ANALYZE',

--- a/code/cli/test/assets_test.dart
+++ b/code/cli/test/assets_test.dart
@@ -116,6 +116,26 @@ void main() {
       expect(content, isNotEmpty);
     });
 
+    test('standard APE identity assets do not own runtime contract markers', () {
+      final disallowedMarkers = {
+        'socrates': ['output_dir', 'confirmed_doc', 'index_file', 'doc-write'],
+        'descartes': ['analysis_input', 'plan_file', 'Commit:'],
+        'basho': ['retrospective.md'],
+      };
+
+      for (final entry in disallowedMarkers.entries) {
+        final content = assets.loadString('apes/${entry.key}.yaml');
+        for (final marker in entry.value) {
+          expect(
+            content,
+            isNot(contains(marker)),
+            reason:
+                '${entry.key}.yaml should leave "$marker" to runtime-owned prompt surfaces',
+          );
+        }
+      }
+    });
+
     test('listDirectory skills returns all skill directories', () {
       final dirs = assets.listDirectory('skills');
       expect(

--- a/code/cli/test/assets_test.dart
+++ b/code/cli/test/assets_test.dart
@@ -121,6 +121,16 @@ void main() {
         'socrates': ['output_dir', 'confirmed_doc', 'index_file', 'doc-write'],
         'descartes': ['analysis_input', 'plan_file', 'Commit:'],
         'basho': ['retrospective.md'],
+        'darwin': [
+          'gh issue list',
+          'gh issue comment',
+          'gh issue create',
+          'diagnosis.md',
+          'plan.md',
+          'retrospective.md',
+          '.inquiry/',
+          'metrics.yaml',
+        ],
       };
 
       for (final entry in disallowedMarkers.entries) {

--- a/code/cli/test/firmware_agent_test.dart
+++ b/code/cli/test/firmware_agent_test.dart
@@ -18,6 +18,10 @@ void main() {
       expect(content, contains('iq ape prompt'));
     });
 
+    test('documents iq ape prompt as the exact effective prompt surface', () {
+      expect(content, contains('inspect the exact effective sub-agent prompt'));
+    });
+
     test('references iq ape transition', () {
       expect(content, contains('iq ape transition'));
     });

--- a/code/cli/test/firmware_agent_test.dart
+++ b/code/cli/test/firmware_agent_test.dart
@@ -22,6 +22,13 @@ void main() {
       expect(content, contains('inspect the exact effective sub-agent prompt'));
     });
 
+    test('documents prompt assembly as identity plus operational contract plus inquiry-context', () {
+      expect(
+        content,
+        contains('APE identity + phase-owned operational contract + inquiry-context'),
+      );
+    });
+
     test('references iq ape transition', () {
       expect(content, contains('iq ape transition'));
     });

--- a/code/cli/test/fsm_contract_test.dart
+++ b/code/cli/test/fsm_contract_test.dart
@@ -66,6 +66,27 @@ void main() {
     }
   });
 
+  test('IDLE state asset exposes DEWEY create_or_select routing context', () {
+    final loader = OperationalContractLoader(
+      workingDirectory: Directory.current.path,
+    );
+
+    final idleContract = loader.load(FsmState.idle);
+
+    expect(
+      idleContract.inquiryContextFor(
+        apeName: 'dewey',
+        subState: 'create_or_select',
+      ),
+      equals({
+        'triage_objective': 'create_or_select',
+        'deterministic_skill': 'issue-create',
+        'allowed_commands':
+            'gh issue list, gh issue view, gh issue create, gh issue edit',
+      }),
+    );
+  });
+
   test('IDLE + go_execute is rejected as illegal transition', () {
     final transition = contract.transitionFor(FsmState.idle, FsmEvent.goExecute);
 

--- a/code/cli/test/fsm_contract_test.dart
+++ b/code/cli/test/fsm_contract_test.dart
@@ -4,6 +4,7 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'package:inquiry_cli/fsm_contract.dart';
+import 'package:inquiry_cli/modules/ape/operational_contract.dart';
 
 void main() {
   late FsmContract contract;
@@ -31,6 +32,37 @@ void main() {
           reason: 'Missing transition for ${state.value} + ${event.value}',
         );
       }
+    }
+  });
+
+  test('state assets expose phase-owned operational contract for every FSM state', () {
+    final loader = OperationalContractLoader(
+      workingDirectory: Directory.current.path,
+    );
+
+    for (final state in FsmState.values) {
+      final operationalContract = loader.load(state);
+
+      expect(
+        operationalContract.toJson()['state'],
+        equals(state.value),
+        reason: 'Operational contract should keep the owning FSM state visible',
+      );
+      expect(
+        operationalContract.instructions,
+        isNotEmpty,
+        reason: 'Operational contract for ${state.value} should expose instructions',
+      );
+      expect(
+        operationalContract.constraints,
+        isNotEmpty,
+        reason: 'Operational contract for ${state.value} should expose constraints',
+      );
+      expect(
+        operationalContract.allowedActions,
+        isNotEmpty,
+        reason: 'Operational contract for ${state.value} should expose allowed actions',
+      );
     }
   });
 

--- a/code/cli/test/fsm_state_test.dart
+++ b/code/cli/test/fsm_state_test.dart
@@ -265,6 +265,24 @@ void main() {
         expect(result.toJson()['instructions'], contains('issue-start'));
         expect(result.toJson()['instructions'], contains('start_analyze'));
       });
+
+      test('EVOLUTION instructions own darwin repository procedure', () async {
+        setupWorkspace(state: 'EVOLUTION', issue: '145');
+
+        final command = FsmStateCommand(FsmStateInput(
+          workingDirectory: tempDir.path,
+        ));
+        final result = await command.execute();
+
+        expect(
+          result.toJson()['instructions'],
+          contains('ideal Analyze -> Plan -> Execute -> End loop'),
+        );
+        expect(result.toJson()['instructions'], contains('gh issue list'));
+        expect(result.toJson()['instructions'], contains('gh issue comment'));
+        expect(result.toJson()['instructions'], contains('gh issue create'));
+        expect(result.toJson()['instructions'], contains('.inquiry/metrics.yaml'));
+      });
     });
 
     group('missing workspace', () {

--- a/code/cli/test/fsm_state_test.dart
+++ b/code/cli/test/fsm_state_test.dart
@@ -259,7 +259,9 @@ void main() {
 
         expect(result.toJson()['instructions'], contains('TRIAGE'));
         expect(result.toJson()['instructions'], contains('DONE'));
+        expect(result.toJson()['instructions'], contains('create_or_select'));
         expect(result.toJson()['instructions'], contains('issue-create'));
+        expect(result.toJson()['instructions'], contains('gh issue create'));
         expect(result.toJson()['instructions'], contains('issue-start'));
         expect(result.toJson()['instructions'], contains('start_analyze'));
       });

--- a/code/cli/test/fsm_state_test.dart
+++ b/code/cli/test/fsm_state_test.dart
@@ -82,6 +82,32 @@ void main() {
         expect(json['instructions'], isA<String>());
       });
 
+      test('returns operational contract sourced from state assets', () async {
+        setupWorkspace(state: 'EXECUTE', issue: '145');
+
+        final command = FsmStateCommand(FsmStateInput(
+          workingDirectory: tempDir.path,
+        ));
+        final result = await command.execute();
+        final json = result.toJson();
+        final operationalContract =
+            json['operational_contract'] as Map<String, dynamic>?;
+
+        expect(operationalContract, isNotNull);
+        expect(
+          operationalContract!['instructions'],
+          contains('Implement the plan phase by phase under its formal constraints.'),
+        );
+        expect(
+          operationalContract['constraints'],
+          contains('Follow plan.md phases in order'),
+        );
+        expect(
+          operationalContract['allowed_actions'],
+          contains('Edit code files'),
+        );
+      });
+
       test('IDLE state has no task', () async {
         setupWorkspace(state: 'IDLE');
 

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More targets coming soon.</p>
-      <span class="badge">v0.3.7</span>
+      <span class="badge">v0.4.0</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More targets coming soon.</p>
-      <span class="badge">v0.3.6</span>
+      <span class="badge">v0.3.7</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">

--- a/code/vscode/LICENSE
+++ b/code/vscode/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Silicon Brained Machines
+Copyright (c) 2026 @ccisnedev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,9 @@
 │  The agent has NO knowledge of other states' agents.                │
 │  It only sees: current state + transition contract + memory.        │
 └─────────────────────────────────────────────────────────────────────┘
+
+Sub-agent prompt delivery is explicit and inspectable. `iq ape prompt --name <ape>` prints the exact effective prompt as APE identity from `assets/apes/<name>.yaml`, phase-owned operational contract from `assets/fsm/states/<state>.yaml`, and runtime `inquiry-context` resolved by the CLI. Standard APE YAMLs no longer own the primary repository procedure. DARWIN is the bounded exception: EVOLUTION may provide the abstract observe/compare/select standard that DARWIN consumes, but issue search/comment/create and metrics procedure remain state-owned.
+
                                    │
                           reads/writes
                                    │
@@ -113,6 +116,8 @@ The CLI enforces this via `iq fsm transition --event <e>`: reads `.inquiry/state
 ## Agent architecture
 
 There is **one agent file** (`inquiry.agent.md`) that acts as orchestrator. It is NOT 4 separate agents — it is one prompt that **behaves differently depending on FSM state**:
+
+The scheduler does not inline each phase runbook itself. It reads state, inspects the exact assembled sub-agent prompt through `iq ape prompt`, and dispatches the active thinking tool against that inspectable runtime surface.
 
 ```
 inquiry.agent.md
@@ -194,4 +199,5 @@ A complete APE cycle from issue to merge:
 | **Skills are protocols** | Step-by-step markdown, not code | Portable across any LLM that reads markdown |
 | **Memory in repo** | .inquiry/ + docs/, no external DB | Version-controlled, survives any infrastructure change |
 | **Single target until MVP** | Copilot only (D20) | Prove methodology on one tool before fragmenting |
+| **Prompt delivery is explicit** | `iq ape prompt` prints identity + contract + context | The effective prompt stays inspectable; no hidden glue in standard APE YAMLs |
 | **EVOLUTION is opt-in** | config.yaml flag | Self-modification is powerful but must be conscious |

--- a/docs/spec/agent-lifecycle.md
+++ b/docs/spec/agent-lifecycle.md
@@ -34,11 +34,11 @@ IDLE → ANALYZE → PLAN → EXECUTE → END → EVOLUTION
 
 **PLAN** — DESCARTES applies the scientific method: the plan is an experimental design. Decomposes complexity into phases (WBS), defines tests in pseudocode, sequences by dependencies. Produces `plan.md` as an immutable checklist. The plan must be detailed enough that EXECUTE is mechanical — following instructions, not inventing them. The user approves the plan before transitioning.
 
-**EXECUTE** — BASHŌ implements the plan phase by phase, like a haiku master working within formal constraints (the plan's restrictions = the 5-7-5 form). Each phase produces a commit. The final phase includes product retrospective: an implementation report with validation instructions for the user. If a deviation is detected, returns to ANALYZE (like falsifying a hypothesis in the scientific method). The user approves the execution report before transitioning to END.
+**EXECUTE** — This document is explanatory architecture, not the sole normative source. The canonical runtime contract for EXECUTE lives in `code/cli/assets/fsm/states/execute.yaml`. BASHŌ's YAML supplies implementation identity and sub-state modulation, while plan-path/output protocol reaches the operator through the phase-owned operational contract that `iq ape prompt` assembles and exposes. BASHŌ then implements the plan phase by phase, like a haiku master working within formal constraints (the plan's restrictions = the 5-7-5 form). Each phase produces a commit. The final phase includes product retrospective: an implementation report with validation instructions for the user. If a deviation is detected, returns to ANALYZE (like falsifying a hypothesis in the scientific method). The user approves the execution report before transitioning to END.
 
 **END** — APE presents the execution summary and waits for explicit authorization to create the PR and pass into EVOLUTION or return to IDLE if evolution is disabled. This keeps delivery and merge preparation as a distinct closure gate rather than an implicit side effect of EXECUTE.
 
-**EVOLUTION** — DARWIN reads the complete cycle (diagnosis, plan, commits, deviations) and evaluates APE's own process. Searches for existing issues in the Inquiry repository (`gh issue list --search`), comments on matches or creates new issues. Automatic, no user approval required. Opt-out via `.inquiry/config.yaml` (`evolution.enabled: false`).
+**EVOLUTION** — This document is explanatory architecture, not the sole normative source. The canonical runtime contract for EVOLUTION lives in `code/cli/assets/fsm/states/evolution.yaml`. EVOLUTION owns repository procedure for issue search/comment/create and metrics collection, while DARWIN retains only the abstract process methodology of observe, compare, select, and report. `iq ape prompt --name darwin` exposes that full assembled prompt without hidden glue. Automatic, no user approval required. Opt-out via `.inquiry/config.yaml` (`evolution.enabled: false`).
 
 ## Agent Registry
 
@@ -94,7 +94,7 @@ From the **agent's perspective**, only three states are visible: idle, working, 
 
 ### Key principle
 
-Agent intelligence lives in prompts, not in state machines. SOCRATES uses Socratic phases (CLARIFICATION → ASSUMPTIONS → EVIDENCE → PERSPECTIVES → IMPLICATIONS → META-REFLECTION) as conversation strategies, not scheduler-tracked states. DESCARTES applies the 4 rules of the Method internally. BASHŌ selects the appropriate domain skill per phase. These are opaque to the scheduler.
+Agent intelligence lives in prompts assembled explicitly by the CLI, not in state machines. SOCRATES uses Socratic phases (CLARIFICATION → ASSUMPTIONS → EVIDENCE → PERSPECTIVES → IMPLICATIONS → META-REFLECTION) as conversation strategies, not scheduler-tracked states. DESCARTES applies the 4 rules of the Method internally. BASHŌ selects the appropriate domain skill per phase. DARWIN keeps only its abstract-process exception. These methodology details remain opaque to the scheduler, while the phase-owned operational contract stays visible through `iq ape prompt` instead of being buried as repository procedure inside standard APE YAMLs.
 
 | Concept | Visible to scheduler | Visible to agent |
 |---------|---------------------|------------------|

--- a/docs/spec/finite-ape-machine.md
+++ b/docs/spec/finite-ape-machine.md
@@ -27,7 +27,7 @@ If evolution is disabled in `.inquiry/config.yaml`, the cycle returns directly f
 
 | State | Operator | Purpose | Primary artifact |
 |---|---|---|---|
-| IDLE | APE | Triage, readiness, and infrastructure preparation | `.inquiry/state.yaml` |
+| IDLE | DEWEY | Triage, issue readiness, and explicit start handoff | `.inquiry/state.yaml` |
 | ANALYZE | SOCRATES | Clarify the problem and produce a rigorous diagnosis | `cleanrooms/<issue>/analyze/diagnosis.md` |
 | PLAN | DESCARTES | Design the execution sequence and verification strategy | `cleanrooms/<issue>/plan.md` |
 | EXECUTE | BASHO | Implement phase by phase under the plan's constraints | code + commits |
@@ -44,16 +44,21 @@ APE is not a peer agent in the roster. It is the orchestrating methodology and d
 
 The current system uses one primary sub-agent per active work phase:
 
+- DEWEY in IDLE
 - SOCRATES in ANALYZE
 - DESCARTES in PLAN
 - BASHO in EXECUTE
 - DARWIN in EVOLUTION
 
-IDLE and END are orchestration-heavy states governed directly by APE plus explicit human authorization. Earlier multi-agent rosters remain historically relevant, but they are not the active architectural model. Their documentary home is [../lore.md](../lore.md), not this specification. [4][6]
+APE still orchestrates every state boundary, and END remains the explicit APE + human closure gate. Earlier multi-agent rosters remain historically relevant, but they are not the active architectural model. Their documentary home is [../lore.md](../lore.md), not this specification. [4][6]
 
 ### Transitions are explicit and CLI-governed
 
 The machine does not rely on implicit conversational drift to change phases. Transitions are checked against a declared contract and executed through the CLI, which is responsible for validating preconditions, applying effects, and updating persisted state. This makes the finite-state structure operational rather than metaphorical. [2][5]
+
+### Prompt assembly is explicit and inspectable
+
+The sub-agent prompt seen by the operator is not an opaque mixture of YAML prose. Inquiry CLI assembles it explicitly as APE identity from `assets/apes/<name>.yaml`, phase-owned operational contract from `assets/fsm/states/<state>.yaml`, and runtime inquiry-context. `iq ape prompt` prints that exact effective prompt. Standard APE YAMLs stay identity-first; DARWIN is the only bounded exception and keeps only abstract-process methodology while EVOLUTION owns repository procedure. [2][4][5]
 
 ### Artifacts are the coordination surface
 

--- a/docs/spec/target-specific-agents.md
+++ b/docs/spec/target-specific-agents.md
@@ -50,6 +50,8 @@ gentle-ai itself uses target-specific asset directories (`internal/assets/claude
 
 The prompt body (instructions, state machine, behavior rules) is the **shared core**. The frontmatter and file structure are **target-specific wrappers**.
 
+For Copilot, that wrapper surrounds the scheduler firmware, not the phase-specific repository procedure. At runtime Inquiry CLI assembles the inspectable sub-agent prompt as APE identity from `assets/apes/*.yaml`, phase-owned operational contract from `assets/fsm/states/*.yaml`, and runtime inquiry-context. `iq ape prompt` prints that effective prompt, so operational procedure is not duplicated inside target wrappers or standard APE YAMLs.
+
 ---
 
 ## 4. Architectural Decision
@@ -106,7 +108,8 @@ The prompt body (instructions, state machine, behavior rules) is the **shared co
 
 - Re-register adapters one at a time in the deploy list
 - Each adapter may define its own agent template or transformation
-- The deployer becomes a compiler: shared prompt + target-specific wrapper → target-specific file
+- The deployer becomes a compiler: shared scheduler firmware + target-specific wrapper → target-specific file
+- Sub-agent prompt assembly remains CLI-owned and inspectable via `iq ape prompt`
 - Skills continue to be copied verbatim
 
 ---

--- a/docs/thinking-tools.md
+++ b/docs/thinking-tools.md
@@ -27,6 +27,8 @@ The current model uses Thinking Tools through five active operators and one orch
 
 APE remains the scheduler and closure gate. DEWEY does not prepare branches or perform downstream phases; `issue-start` owns the explicit handoff into ANALYZE.
 
+At prompt-delivery time, Inquiry CLI assembles the effective sub-agent prompt as thinking-tool identity from the APE YAML, phase-owned operational contract from the active FSM state asset, and runtime inquiry-context. `iq ape prompt` remains the inspectable surface for that exact assembly. DARWIN is the only bounded exception: it keeps the abstract observe/compare/select methodology, while EVOLUTION owns repository procedure such as issue search/comment/create and metrics mechanics.
+
 This mapping matters because the system does not treat the named agents as arbitrary characters. Their names identify the method each phase is expected to embody. [2][3][4]
 
 ## Boundary Clarifications

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -100,11 +100,15 @@ APE wasn't just a workflow — it was an implementation of the oldest formal the
 **2026-04-25 to 2026-04-26.** The architecture underwent its most significant redesign: the monolithic 554-line agent prompt was replaced by a thin **firmware scheduler** (~35 lines) backed by a dual FSM (main + per-APE). Key innovations:
 
 - **`iq fsm state --json`** — structured output for agent consumption
-- **`iq ape prompt --name <name>`** — sub-agent prompts assembled from YAML + state
+- **`iq ape prompt --name <name>`** — sub-agent prompts assembled from APE identity YAML + phase-owned state contract + runtime inquiry-context
 - **`completion_authority`** — per-state field that tells the scheduler whether to ask the user or transition automatically
 - **Dispatch model** — the scheduler never performs sub-agent work; it delegates via the `agent` tool
 
 The design principle: **the CLI is the algorithm, the LLM is just the executor**. Version **v0.2.0** landed with the redesign, followed immediately by **v0.2.1** with smoke-test fixes.
+
+## Prompt-boundary consolidation
+
+**2026-05-09.** Issue #154 closed the remaining prompt-ownership ambiguity in the public architecture. The effective sub-agent prompt is now described consistently across the canonical docs and firmware as: APE YAMLs provide thinking-tool identity, FSM state assets provide the phase-owned operational contract, and Inquiry CLI assembles the runtime `inquiry-context`. Standard APE YAMLs no longer carry the primary repository procedure. DARWIN remains the bounded exception: it keeps the abstract observe/compare/select methodology, while EVOLUTION owns the concrete issue and metrics procedure. This release line ships as **v0.4.0**.
 
 ## What emerged
 


### PR DESCRIPTION
Closes #154