### PR TITLE
fix(#186): add Invoke-ExpertCouncil to assets_test skill list

### DIFF
--- a/code/cli/test/assets_test.dart
+++ b/code/cli/test/assets_test.dart
@@ -151,6 +151,7 @@ void main() {
       expect(
         dirs,
         unorderedEquals([
+          'Invoke-ExpertCouncil',
           'doc-read',
           'doc-write',
           'inquiry-install',


### PR DESCRIPTION
The Invoke-ExpertCouncil skill was added to `assets/skills/` but the hardcoded list in `assets_test.dart` was not updated, breaking CI and Release workflows.

Root cause: EXECUTE phase did not run the full test suite before committing. See #188 for systemic fix.