### PR TITLE
feat: add kritik skill and align 0.4.5 release

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.4.5]
+### Added
+- **Standalone `kritik` skill**: new direct-use SKILL.md for evidential licensing audits over a bounded corpus, with exact evidence spans, explicit warrants, counterevidence search, graded verdicts, and one durable markdown report
+
+### Changed
+- **Naming decision**: the epistemic-audit proposal now adopts `kritik` as the canonical skill name, with evidence audit and epistemic audit retained only as explanatory glosses
+
+### Fixed
+- **Skill inventory tests**: doctor and asset coverage now include the full distributed skill roster, including `research` and `kritik`, so release validation matches deployed assets
+
 ## [0.4.4]
 ### Added
 - **Standalone `research` skill**: new direct-use SKILL.md for staged web investigation with a single durable paper-style markdown report and BibTeX-compatible references (#193)
@@ -191,7 +201,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 - **EVOLUTION infrastructure** (#68): `.ape/config.yaml` + `.ape/mutations.md` lifecycle
   - `ape init` creates `.ape/config.yaml` with `evolution.enabled: false` default
   - `ape init` creates `.ape/mutations.md` with header template for DARWIN
-  - Both files are idempotent (never overwritten if already present)
+  - Both files are idempotent (never overwritten if files already exist)
   - `reset_mutations` effect declared in IDLE→ANALYZE and EVOLUTION→IDLE transitions
   - DARWIN prompt updated to include `mutations.md` as input
 
@@ -211,6 +221,7 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 - Precondition validation gates: issue_selected, feature_branch_selected checks before irreversible actions
 - Fail-closed prompt fragment registry: Explicit error on missing prompt_fragment_id or referenced fragments
 - Full-cycle integration tests: Incident replay prevention, full FSM cycle validation (IDLE→ANALYZE→PLAN→EXECUTE→EVOLUTION→IDLE)
+
 ### Changed
 - IDLE state now supports exploration without issue context, but blocks commitment actions until preconditions validated
 - State transitions now use declarative operation definitions (precheck, effects, commit_policy) instead of agent reasoning
@@ -223,12 +234,14 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 - `ci.yml` — CI workflow with `ubuntu-latest` + `windows-latest` matrix
 - `ape doctor` now checks VS Code Copilot extension (`code --list-extensions`)
 - OS tabs (Windows/Linux) on landing page
+
 ### Changed
 - FSM rewrite: 6-state model with END state, optional EVOLUTION, retrospective.md, git conventions
 - `release.yml` restructured to 3-job pattern: check-version → create-release → build (matrix)
 - `ape upgrade` refactored to use PlatformOps (cross-platform archive extraction)
 - `ape uninstall` refactored to use PlatformOps (cross-platform env vars and deletion)
 - Windows Defender workaround in release.yml now conditional (`if: runner.os == 'Windows'`)
+
 ### Fixed
 - `ape init` `_relative()` now uses `p.relative()` instead of fragile `replaceFirst`
 - Uninstall tests no longer corrupt `dart.exe` (FakePlatformOps injection)
@@ -238,8 +251,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 - TUI shows diagram only in text mode (no "version:", "diagram:" field labels)
 - Doctor shows formatted checkmarks in text mode (✓/✗) like `flutter doctor`
 - Upgrade shows cleaner status message with checkmark
+
 ### Changed
 - Deps: modular_cli_sdk ^0.2.1 (adds `Output.toText()` for custom text formatting)
+
 ### Added
 - `Output.toText()` implementations for TuiOutput, DoctorOutput, UpgradeOutput
 - 5 new tests for toText() behavior
@@ -248,8 +263,10 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - `ape` TUI — displays FSM diagram when invoked without arguments
 - Skill `issue-end` — 9-step protocol for completing APE cycles (EXECUTE → EVOLUTION)
+
 ### Fixed
 - Version inconsistency: unified to single source of truth in `lib/src/version.dart`
+
 ### Changed
 - `ape doctor` now imports shared version constant
 - `ape version` now imports shared version constant

--- a/code/cli/assets/skills/kritik/SKILL.md
+++ b/code/cli/assets/skills/kritik/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: kritik
+description: 'Audit whether conclusions are authorized by a bounded corpus through exact evidence, sources, warrants, counterevidence, and inferential limits, and produce one durable markdown report.'
+---
+
+# kritik - Evidential Licensing Protocol
+
+## When to Use
+
+- You need to audit whether candidate conclusions are actually licensed by a bounded corpus
+- A plausible answer must be separated from its public burden of proof
+- You need a durable, auditable report rather than only chat output
+- The problem requires exact evidence spans, explicit warrants, and counterevidence search
+- You suspect a conclusion may be overextended, support-laundered, or only weakly inferred
+
+## Invocation Scope
+
+- This skill is standalone and user-invoked directly.
+- v1 scope is direct invocation only.
+- Do not couple this protocol to automatic routing, phase-specific flows, or hidden certification steps.
+- `kritik` complements `research`, analysis, and executable validation. It does not replace them.
+
+## Inputs
+
+Required:
+- Bounded corpus
+- Candidate conclusions, claims, or source text to audit
+
+Optional:
+- Desired proof standard
+- Claim type hints
+- Output path
+- Context and constraints
+
+## Output Contract
+
+Produce exactly one markdown artifact (`.md`) with this mandatory structure:
+
+```markdown
+# <Title>
+
+## Corpus Definition
+## Audit Standard
+## Claim Inventory
+## Claim-by-Claim Audit
+### Claim 1 - <short label>
+#### Claim
+#### Type
+#### Evidence
+#### Support Relation
+#### Warrant
+#### Counterevidence
+#### Verdict
+#### Confidence
+## Unsupported or Weakly Supported Claims
+## Contradicted Claims
+## Undecidable Claims
+## Aggregate Summary
+## Methodological Limitations
+```
+
+Rules:
+1. The output is a single durable artifact.
+2. Every substantial judgment must be anchored to exact evidence spans, executable artifacts, or an explicit statement that no adequate anchor was found.
+3. Every claim must include a typed support relation and an explicit warrant.
+4. Every claim must include a counterevidence search result, even when none is found.
+5. Verdicts must use the approved v1 labels only: `entailed`, `directly supported`, `reasonably inferred`, `insufficiently supported`, `contradicted`, `undecidable`.
+6. The report must distinguish evidence from interpretation.
+7. The report must state methodological limitations explicitly, including bounded-corpus limits.
+
+Persist the report as a `.md` file in the appropriate project directory. Use a descriptive filename such as `kritik-<topic>.md`.
+
+## Staged Protocol
+
+Follow stages in order and do not skip forward.
+
+### Stage 1: Corpus Framing
+
+- Normalize the corpus boundary.
+- Identify what is in scope and out of scope.
+- If the corpus is ambiguous, unbounded, or only implied, ask for clarification before continuing.
+- State the proof standard to be used.
+
+Exit condition:
+- Corpus boundary and audit standard are explicit.
+
+### Stage 2: Claim Extraction and Atomization
+
+- Extract candidate conclusions or normalize user-provided claims.
+- Decompose compound statements into atomic claims.
+- Assign each claim an identifier and a claim type.
+
+Claim type options:
+- Descriptive corpus claim
+- Normative claim
+- Historical or repository-state claim
+- Causal claim
+- Code behavior claim
+- Empirical claim
+- Interpretive claim
+- Hypothesis or abductive explanation
+
+Exit condition:
+- The claim inventory is complete and each claim is atomic enough to audit.
+
+### Stage 3: Evidence Retrieval and Anchoring
+
+- Retrieve candidate evidence spans for each claim.
+- Prefer exact quotations, narrow artifacts, and executable outputs over broad document references.
+- If no exact anchor can be found, record that absence explicitly.
+
+Exit condition:
+- Each claim has either a candidate evidence set or an explicit no-anchor finding.
+
+### Stage 4: Relation and Warrant Analysis
+
+- Classify the claim-evidence relation.
+- State the warrant that connects the evidence to the claim.
+- Do not present an abductive bridge as if it were quotation or entailment.
+
+Support relation options:
+- Direct quotation
+- Close textual entailment
+- Structural inference
+- Executable confirmation
+- Inductive summary
+- Abductive explanation
+- Analogy
+- Interpretive synthesis
+
+Exit condition:
+- The inferential bridge is explicit for every claim.
+
+### Stage 5: Counterevidence Search
+
+- Search for contradictions, exceptions, nearby limit clauses, missing conditions, and relevant silences.
+- Look for defeat as actively as you look for support.
+- Record whether the corpus contains counterevidence, unresolved tension, or silence.
+
+Exit condition:
+- Each claim has an explicit defeater search result.
+
+### Stage 6: Verdict Assignment and Report Generation
+
+- Assign one graded verdict per claim.
+- State confidence as high, medium, or low with brief rationale.
+- Produce the final report with aggregate summary and limitations.
+
+Exit condition:
+- The report is durable, traceable, and explicit about uncertainty.
+
+## Quality Gate Checklist
+
+Before finishing, verify:
+
+- Exactly one markdown report was produced
+- Corpus boundary is explicit
+- Claim inventory is atomized
+- Every claim has exact evidence or an explicit no-anchor finding
+- Every claim has a support relation and warrant
+- Every claim has a counterevidence search result
+- Every verdict uses the approved v1 labels
+- Methodological limitations explicitly state that `kritik` is not a truth oracle
+
+## Non-Goals (v1)
+
+- No automatic scheduler integration
+- No hidden certification of generated conclusions
+- No claim that a reported warrant is thereby proven sound in the strongest philosophical sense
+- No replacement of executable validation where executable checks exist
+- No binary collapse of all claims into true or false
+
+## Canonical Definition
+
+`kritik` is the skill that audits whether a conclusion is authorized by the available evidence, sources, warrant, counterevidence, and limits of inference within a bounded corpus.
+
+Short formula:
+
+`kritik` places a conclusion before a tribunal of evidence, source, warrant, counterevidence, and limit.

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.4.4';
+const String inquiryVersion = '0.4.5';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.4.4
+version: 0.4.5
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/ape_transition_test.dart
+++ b/code/cli/test/ape_transition_test.dart
@@ -45,6 +45,35 @@ void main() {
         .writeAsStringSync(buf.toString());
   }
 
+  void setupGitRepoWithFeatureCommit() {
+    void git(List<String> args) {
+      final result = Process.runSync(
+        'git',
+        args,
+        workingDirectory: tmpDir.path,
+      );
+      if (result.exitCode != 0) {
+        fail(
+          'git ${args.join(' ')} failed: ${result.stderr}\n${result.stdout}',
+        );
+      }
+    }
+
+    git(['init']);
+    git(['config', 'user.email', 'test@test.com']);
+    git(['config', 'user.name', 'Test User']);
+
+    final trackedFile = File(p.join(tmpDir.path, 'README.md'));
+    trackedFile.writeAsStringSync('# Test repo\n');
+    git(['add', '.']);
+    git(['commit', '-m', 'init']);
+
+    git(['checkout', '-b', '145-test-branch']);
+    trackedFile.writeAsStringSync('# Test repo\nfeature change\n');
+    git(['add', 'README.md']);
+    git(['commit', '-m', 'phase commit']);
+  }
+
   group('ApeTransitionCommand', () {
     group('successful transitions', () {
       test('socrates clarification --next--> assumptions', () async {
@@ -120,6 +149,33 @@ void main() {
 
         expect(result.from, equals('test'));
         expect(result.to, equals('implement'));
+      });
+
+      test('basho commit --next_phase--> implement preserves outer FSM state', () async {
+        setupGitRepoWithFeatureCommit();
+        writeState(
+          state: 'EXECUTE',
+          issue: '145',
+          apeName: 'basho',
+          apeState: 'commit',
+        );
+
+        final cmd = ApeTransitionCommand(
+          ApeTransitionInput(event: 'next_phase', workingDirectory: tmpDir.path),
+        );
+        final result = await cmd.execute();
+
+        expect(result.from, equals('commit'));
+        expect(result.to, equals('implement'));
+
+        final content = File(p.join(tmpDir.path, '.inquiry', 'state.yaml'))
+            .readAsStringSync();
+        expect(content, contains('state: EXECUTE'));
+        expect(content, contains('issue: "145"'));
+        expect(content, contains('name: basho'));
+        expect(content, contains('state: implement'));
+        expect(content, isNot(contains('issue: null')));
+        expect(content, isNot(contains('state: IDLE')));
       });
 
       test('dewey confirm --complete--> evaluate_scope', () async {

--- a/code/cli/test/assets_test.dart
+++ b/code/cli/test/assets_test.dart
@@ -116,6 +116,13 @@ void main() {
       expect(content, isNotEmpty);
     });
 
+    test('reads skills/kritik/SKILL.md', () {
+      final content = assets.loadString('skills/kritik/SKILL.md');
+      expect(content, contains('kritik'));
+      expect(content, contains('bounded corpus'));
+      expect(content, isNotEmpty);
+    });
+
     test('standard APE identity assets do not own runtime contract markers', () {
       final disallowedMarkers = {
         'socrates': ['output_dir', 'confirmed_doc', 'index_file', 'doc-write'],
@@ -154,6 +161,7 @@ void main() {
           'doc-read',
           'doc-write',
           'inquiry-install',
+          'kritik',
           'legion',
           'research',
           'issue-create',

--- a/code/cli/test/doctor_test.dart
+++ b/code/cli/test/doctor_test.dart
@@ -99,7 +99,9 @@ void main() {
       'doc-read',
       'doc-write',
       'inquiry-install',
+      'kritik',
       'legion',
+      'research',
       'issue-create',
       'issue-start',
       'issue-end',
@@ -315,7 +317,7 @@ void main() {
 
         final text = output.toText()!;
         expect(text, contains('Checking targets...'));
-        expect(text, contains('✓ copilot: agent + 7 skills deployed'));
+        expect(text, contains('✓ copilot: agent + 9 skills deployed'));
         expect(text, contains('All checks passed.'));
       });
 
@@ -375,7 +377,9 @@ void main() {
           'doc-read',
           'doc-write',
           'inquiry-install',
+          'kritik',
           'legion',
+          'research',
           'issue-start',
           'issue-end',
         ]) {
@@ -405,14 +409,14 @@ void main() {
           targetName: 'copilot',
           agentExists: true,
           missingSkills: ['doc-read'],
-          totalSkills: 7,
+          totalSkills: 9,
         );
 
         final json = check.toJson();
         expect(json['targetName'], 'copilot');
         expect(json['agentExists'], true);
         expect(json['missingSkills'], ['doc-read']);
-        expect(json['totalSkills'], 7);
+        expect(json['totalSkills'], 9);
       });
 
       test('TargetCheck.passed is true when agent exists and no missing skills', () {
@@ -420,7 +424,7 @@ void main() {
           targetName: 'copilot',
           agentExists: true,
           missingSkills: [],
-          totalSkills: 7,
+          totalSkills: 9,
         );
         expect(passing.passed, isTrue);
 

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More targets coming soon.</p>
-      <span class="badge">v0.4.4</span>
+      <span class="badge">v0.4.5</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">

--- a/docs/research/council-synthesis-kritik-skill-name.md
+++ b/docs/research/council-synthesis-kritik-skill-name.md
@@ -1,0 +1,230 @@
+# Council of Experts — Synthesis
+
+## Problem Analyzed
+
+Determinar si `kritik` es un buen nombre para una nueva skill de Inquiry cuyo trabajo, según [epistemic-audit-skill-proposal.md](epistemic-audit-skill-proposal.md), es auditar si conclusiones candidatas están realmente autorizadas por un corpus acotado mediante evidencia exacta, fuente, warrant, contraevidencia y límites del salto inferencial.
+
+La decisión no es sobre implementación. Es sobre naming: si `kritik` nombra bien esa capacidad dentro del ecosistema Inquiry, dadas tres presiones simultáneas:
+
+1. Su resonancia filosófica kantiana.
+2. La taxonomía arquitectónica de Inquiry entre APEs y skills.
+3. Su utilidad real como superficie invocable por usuarios y APEs.
+
+## Experts Convened
+
+| # | Persona | Perspective | Confidence |
+|---|---------|-------------|------------|
+| 1 | Dr. Immanuel Critica | Kantian legitimacy and theory of knowledge | high |
+| 2 | Inquiry Runtime and Architecture Specialist | FSM boundaries, warrant taxonomy, skill vs APE distinction | medium |
+| 3 | CLI/DX Naming Specialist | Discoverability, typing friction, and user mental models | medium |
+| 4 | Intellectual Nonfiction Editor & Product Language Strategist | Narrative power, conceptual coherence, and audience fit | high |
+| 5 | Epistemologist & Computational Auditor | Methodological honesty and epistemic overclaim risk | high |
+
+## Individual Dictamens
+
+### Expert: Dr. Immanuel Critica (Kantian Epistemologist)
+**Perspective:** Transcendental critique, bound to conditions of legitimate knowledge-claims and the distinction between constitutive and regulative use
+
+#### Findings
+
+- **Conceptual fit is precise and defensible.** The skill's task—auditing whether a conclusion is "authorized" by evidence, source, warrant, and limits—mirrors Kant's own practice in *Kritik der reinen Vernunft*: examining a cognitive power (abduction) from within to determine its conditions of rightful use, not merely its psychological effects. The skill does not reject abduction; it adjudicates it.
+
+- **"Kritik" preserves a distinction lost in English "Critique."** The English term has drifted toward "review" or "commentary," whereas German *Kritik* retains the technical philosophical meaning: examination of authority and legitimate scope. For a tool meant to be methodological and normative rather than rhetorical, the German term is not ornamental—it carries conceptual load that cannot be replaced by English translation.
+
+- **The claim-verdict taxonomy aligns with Kantian epistemology.** The graded system (entailed, directly supported, reasonably inferred, weakly supported, insufficient, contradicted, undecidable) respects Kant's core insight: different claims carry different burdens of proof, and a single binary verdict collapses distinctions between constitutive knowledge, regulative belief, and mere coherence.
+
+- **"Warrant" and "backing" terminology is Toulmin-ian and Kantian-compatible.** The skill correctly distinguishes evidence from the inferential bridge connecting it to the claim. This echoes Kant's distinction between the content of cognition and the *ground* that makes that content legitimate.
+
+- **Risk of philosophical overload.** Using "Kritik" signals that this is not a neutral tool. It positions the skill as a philosophical tribunal, not a utility. If users expect a generic linter or fact-checker, the name will be misread.
+
+#### Risks
+
+- **Untranslated German terminology may isolate English-speaking users.** If the skill is documented and released in English, "Kritik" requires explanation every time. Contrast with `legion`, `research`, and other Inquiry skills—all English monosyllables. The user may wonder why this one demands German philosophical apparatus.
+
+- **The pairing "Critique of Pure Abduction" + `kritik` skill may reinforce the impression that this is a book artifact, not a general-purpose tool.** If future Inquiry adopters encounter both the title and the skill simultaneously, they may assume `kritik` is proprietary to the philo_sophia project rather than a reusable method.
+
+- **Kant's critique applies to *a priori* conditions of reason; abduction is *empirical* and corrigible.** There is a philosophical tension: Kant examined universal, necessary forms of thought, whereas the epistemic audit here examines corrigible claims against a bounded corpus. The name should not mislead users into thinking the skill provides foundational, Kantian-grade certainty.
+
+- **Over-claiming legitimacy via philosophical association.** If the skill's verdicts are treated as if they carry Kantian transcendental authority, the name has backfired. The skill can be rigorous without being *foundational*.
+
+#### Recommendation
+
+**Approve `kritik` as the skill name under explicit constraints:**
+
+1. **Use the German term consistently.** Do not alternate between `Kritik` and `critique`—the distinction is the point. The skill name is `kritik` in all documentation and code.
+
+2. **Require a one-sentence working definition at every invocation.** The introduction to Kritik documentation or CLI help should state: *"Kritik is the structured examination of whether a conclusion is authorized by the available evidence, sources, warrant, and limits of inference."*
+
+3. **Clearly distinguish Kantian resonance from Kantian commitment.** The skill is *inspired by* Kant's method, not claiming to apply transcendental critique to *a priori* structures of reason. Document this boundary in the skill's philosophical preamble.
+
+4. **Use only in English-language contexts where the user has chosen to engage with Inquiry at the philosophical level.** If Inquiry ever releases a simpler, non-philosophical skill for the same task, give that skill an English name (for example `audit` or `verify`). Do not force all users through the German terminology.
+
+5. **Reserve the full Kantian language for the book and skill internals; use "Critique" in marketing/UI where brevity is required**. But the canonical skill identifier is `kritik`.
+
+#### Confidence
+**High** — The name is conceptually sound and Kantian-legitimate, provided the constraints above are enforced. The risk is not philosophical incorrectness but user misunderstanding due to philosophical overload.
+
+### Expert: Inquiry Runtime and Architecture Specialist
+**Perspective:** Operational boundaries, FSM invariants, and the skill/APE taxonomic distinction in Inquiry's finite state machine and prompt-composition architecture.
+
+#### Findings
+
+- **Strong domain-function fit.** The Kantian sense—examining authority, limits, and lawful use of a faculty—describes exactly the audit of whether conclusions are licensed by evidence, sources, and warrant.
+
+- **Architectural clarity.** `kritik` does not occupy an FSM phase. It has no sub-states managed by `iq`. Like `legion`, it is invocable by any APE, any phase, and any user. That fits skill classification, not APE.
+
+- **Second-order warrant structure.** Like `legion`, Kritik is epistemologically second-order. Abduction, deduction, and induction produce knowledge directly; Kritik audits whether those outputs meet their own evidentiary standards.
+
+- **Naming convention risk.** Existing skills tend to use operational names (`legion`, `research`, `doc-read`, `issue-start`). APEs carry stronger philosophical identity. `kritik` risks sounding like a thinking tool with autonomous warrant rather than a universal auditing capability.
+
+- **Confusion surface.** A reader may infer from the name that Kritik is an APE-like method rather than a composable skill.
+
+#### Risks
+
+- **Architecturally silent category error.** The name does not by itself signal that this is not a phase-bound thinking tool.
+
+- **Skill-function ambiguity.** The word does not tell the reader whether Kritik audits other reasoning or introduces a new reasoning method.
+
+- **Precedent for philosophical skill naming.** Accepting `kritik` as a skill name could blur the visible boundary between universal capabilities and philosophical methods.
+
+#### Recommendation
+
+The expert judges the name **conceptually precise but architecturally risky**. If retained, the SKILL.md should open by saying explicitly that `kritik` is a universal auditing skill, not an APE and not a first-order thinking method. If Inquiry treats names as architectural signals, this caveat matters.
+
+#### Confidence
+**Medium** — The concern is not immediate breakage but future confusion if naming conventions are treated as part of the architecture's public grammar.
+
+### Expert: CLI/DX Naming Specialist
+**Perspective:** Command discoverability, user mental models, and CLI convention alignment in multi-skill ecosystems
+
+#### Findings
+
+- **Naming cultural fit.** `kritik` follows Inquiry's taste for evocative names and positions the skill as methodological rather than merely functional.
+
+- **Typing efficiency.** Six characters, one word, and no hyphen makes it cheaper to invoke than `evidence-audit` or `epistemic-audit`.
+
+- **Pronunciation clarity.** Pronunciation friction is low; spelling and discoverability are the real issue.
+
+- **Help-text burden.** The name does not self-document the claim-evidence-warrant operation. The help text and docs must do more work.
+
+- **Ambiguity surface.** Without strong framing, users may interpret it as generic criticism or linting.
+
+#### Risks
+
+- **User mental-model mismatch.** Plain-English expectations formed by tools like `audit` or `lint` do not automatically transfer to `kritik`.
+
+- **Typo or variant fragmentation.** Users may try `critique`, `kritiq`, or similar variants.
+
+- **Internationalization friction.** The name is German inside an otherwise mostly English interface.
+
+#### Recommendation
+
+**Conditional approval.** Keep `kritik` only if Inquiry commits to explicit framing in help text and docs. The expert also suggests an alias such as `critique` if the runtime ever supports it, to reduce search and typing friction.
+
+#### Confidence
+**Medium** — The name can work, but success depends on documentation and affordances rather than immediate self-evidence.
+
+### Expert: Intellectual Nonfiction Editor & Product Language Strategist
+**Perspective:** Semantic precision, conceptual coherence, audience access, and the contract between naming and utility in philosophical software.
+
+#### Findings
+
+- **Semantic density is exceptional.** `kritik` does not merely label the skill; it states its epistemic mission.
+
+- **Creates productive resonance with the book.** *Critique of Pure Abduction* names the problem; `kritik` names the response. Abduction generates; Kritik adjudicates.
+
+- **Narrative power is considerable but conditional.** For a philosophy-aware audience, the name is strong. For a casual CLI user, it needs scaffolding.
+
+- **Philosophical legitimacy is earned inside Inquiry.** In this ecosystem, the name reads as serious rather than ornamental.
+
+#### Risks
+
+- **Weak documentation would make it sound pretentious.** The name needs an immediate gloss.
+
+- **The Kantian reference is not universally live.** Many readers will not automatically hear the intended sense of critique.
+
+- **Accessibility friction.** Some users may experience the name as gatekeeping if not paired with concrete examples.
+
+#### Recommendation
+
+Use `kritik` as the canonical name, but always ship it with a one-line gloss and concrete examples before abstraction. The name is correct; the burden is on the documentation architecture around it.
+
+#### Confidence
+**High** — The fit is strong. The risk is execution, not the idea.
+
+### Expert: Epistemologist & Computational Auditor
+**Perspective:** Examining whether a name drawn from Kantian philosophy remains operationally honest when instantiated as a computational skill, and whether it accurately telegraphs what the method does and cannot do.
+
+#### Findings
+
+- **Semantic fit is strong.** The skill's design aligns with critique as examination of legitimacy conditions rather than hostile judgment.
+
+- **The name clearly distinguishes generation from audit.** `kritik` marks a separate epistemic operation from generation.
+
+- **Philosophical resonance may mislead.** Users may overread a Kritik verdict as stronger than a bounded-corpus computational classification actually is.
+
+- **The warrant problem is not solved by the name.** Kritik can force warrant exposure and check licensing, but it does not automatically validate every warrant as sound.
+
+- **Corpus boundedness remains non-negotiable.** Strong verdicts remain relative to the selected corpus and proof standard.
+
+#### Risks
+
+- **Verdict inflation.** Users may treat Kritik outputs as near-certainty.
+
+- **Warrant confusion.** An articulated warrant is not the same as a justified warrant.
+
+- **Defeasibility not visible in the bare name.** The method remains graded and defeasible.
+
+- **Overpromise on independence.** If generation and audit are still performed by closely related reasoning surfaces, the name may promise more judicial independence than v1 actually delivers.
+
+#### Recommendation
+
+Use `kritik`, but pair it with explicit methodological framing in every report: corpus scope, proof standard, limitations, and clear distinction between articulated versus fully verified warrant.
+
+#### Confidence
+**High** — The fit between name and design is good, but the implementation must live up to the name's weight.
+
+## Consensuses
+
+- `kritik` has **strong semantic fit** with the proposed skill. All five experts agree that the Kantian sense of critique as examination of legitimacy, scope, limits, and entitlement matches the actual design of the skill much better than generic names such as review.
+
+- The name is especially apt because the skill is **second-order**: it does not generate conclusions but examines whether conclusions deserve to count as established under a bounded corpus. Multiple experts independently framed this as a tribunal function.
+
+- The main risk is **not philosophical incorrectness**, but **user misunderstanding**. Every expert except none emphasized some version of the same point: without strong help text and docs, `kritik` can be misread as either generic criticism, pretentious philosophy, or a stronger guarantee than the implementation can honestly provide.
+
+- The name requires a **canonical one-line gloss** everywhere it appears. There is broad agreement that the skill should always be introduced with an operational definition.
+
+- The name works best if Inquiry explicitly states that `kritik` is **a universal skill, not an APE** and not a first-order thinking method with autonomous warrant.
+
+## Dissents
+
+- **Inquiry Runtime and Architecture Specialist** vs **the other four experts**: the main dissent is not on meaning but on architectural signaling. Four experts accept the philosophical lift as worth the cost if documentation is strong. The architecture expert is more skeptical because the name may blur Inquiry's public distinction between operational skills and philosophical methods.
+
+- **CLI/DX Naming Specialist** vs **Intellectual Nonfiction Editor**: the DX view treats discoverability friction as a serious adoption cost and would welcome aliases or plainer help-facing surfaces. The editorial view accepts that cost as appropriate for Inquiry's audience, provided onboarding is explicit.
+
+## Blind Spots
+
+- No expert evaluated whether the future CLI or target deployment system should support **aliases** such as `critique` for discoverability. That is an implementation and UX question still open.
+
+- No expert assessed whether the name should differ between **internal canonical identifier** and **user-facing label**.
+
+- No expert reviewed the **full future SKILL.md copy** because it does not yet exist. Some risks could be neutralized or aggravated depending on the eventual opening paragraphs, examples, and report contract.
+
+## Final Recommendation
+
+Use `kritik` as the canonical name of the skill.
+
+The decisive reason is that the name fits the method. The proposed skill is not a search utility, not a fact checker, and not a generic review pass. Its job is to place conclusions before a tribunal of evidence, source, warrant, counterevidence, and limit. That is critique in the strong Kantian sense, and `kritik` preserves that sense more precisely than English alternatives.
+
+However, this approval is conditional on four constraints.
+
+1. The skill must be documented from the first line as a **universal auditing skill**, not an APE and not a first-order thinking tradition.
+2. Every public surface should include a one-line gloss, for example: **Kritik audits whether a conclusion is actually authorized by the available evidence, sources, warrant, and limits of inference.**
+3. Every report produced by the skill should foreground **bounded corpus, proof standard, graded verdicts, and limitations**, so the name does not inflate the apparent authority of the output.
+4. The eventual SKILL.md should show **concrete examples before abstraction**, to prevent the name from sounding ornamental or inaccessible.
+
+In short:
+
+**`kritik` is the right name if Inquiry is willing to teach the name.**
+
+Without that surrounding documentation, the name creates avoidable friction. With it, the name is semantically exact, narratively strong, and conceptually aligned with the larger program around *Critique of Pure Abduction*.

--- a/docs/research/epistemic-audit-skill-proposal.md
+++ b/docs/research/epistemic-audit-skill-proposal.md
@@ -1,0 +1,440 @@
+# Epistemic Audit Skill Proposal
+
+## Purpose
+This document records the design proposed after the research in [reasoning-beyond-evidence-humans-llms.md](reasoning-beyond-evidence-humans-llms.md). The central motivation is that a generative AI should not be treated as a subject with reliable introspective access to its own reasons. A model can produce a plausible answer, then produce a plausible retrospective explanation of that answer, without either step constituting an audited evidential trace.
+
+The proposed response is a standalone skill whose job is not to generate conclusions but to audit the evidential status of conclusions against an explicitly bounded corpus.
+
+## Core Thesis
+A generative model is a plausibility optimizer before it is a truth-tracker. Once it finds a plausible direction, it can continue reinforcing that direction through coherence, completion pressure, and local consistency. This creates a familiar failure mode:
+
+1. The model forms a plausible conclusion.
+2. The model treats that conclusion as if it were already well-supported.
+3. The model selectively interprets later evidence in that direction.
+4. The model can then narrate its own error in a way that sounds explanatory, even when that narration is itself only another plausible generation.
+
+The skill proposed here is meant to break that loop by replacing introspective self-justification with public, auditable justification.
+
+## Problem Statement
+The key epistemic problem is not simply that a model can be wrong. The deeper problem is that the model can collapse several distinct epistemic stages into one smooth paragraph:
+
+1. Observed evidence.
+2. Hypothesis generation.
+3. Implicit assumptions.
+4. Intermediate inference.
+5. Final conclusion.
+6. Confidence claim.
+
+When those are collapsed, plausibility is easily mistaken for proof. The user then receives a coherent answer whose real evidential status is unclear.
+
+This also explains why naive self-verification is not enough. If the same style of model simply re-reads its own conclusion and asks whether it is supported, the result can be redundant. The system may only restate the same hidden warrant in different words.
+
+## Design Goal
+The proposed skill should answer this question:
+
+Given a bounded corpus and a set of candidate conclusions, which conclusions are directly supported, which are only inferentially supported, which are contradicted, and which are not licensed by the available evidence?
+
+This is not a truth oracle. It is an evidential licensing system.
+
+## Non-Goals
+The skill should not pretend to do the following:
+
+1. Determine universal truth outside the provided corpus.
+2. Reconstruct the true hidden causal pathway inside the model.
+3. Replace executable validation where executable validation exists.
+4. Treat every inference beyond quotation as invalid.
+5. Collapse all support judgments into a binary true or false label.
+
+## Why This Is Not Redundant
+The generator and the auditor do different jobs.
+
+The generator proposes a claim.
+The auditor checks whether the burden of proof for that claim has been discharged.
+
+That distinction matters. The right verification question is not:
+
+"Do I still believe this conclusion?"
+
+It is:
+
+"What exact evidence in the corpus licenses this conclusion, by what inferential relation, under what assumptions, and against what counterevidence?"
+
+A system that cannot answer that second question should not be allowed to present the conclusion as established.
+
+## Object of Audit
+The atomic unit of output should be a claim record. Each claim record should contain at least the following fields:
+
+1. Claim text.
+2. Claim identifier.
+3. Claim type.
+4. Evidence spans.
+5. Evidence source identifiers.
+6. Support relation type.
+7. Warrant.
+8. Backing.
+9. Rebuttals or counterevidence.
+10. Verdict.
+11. Confidence.
+12. Analyst notes.
+
+This is the minimum public object needed for an auditable epistemic judgment.
+
+## Claim Types
+Different claims require different standards of support. The skill should classify each claim before evaluating it. A practical starting taxonomy is:
+
+1. Descriptive corpus claim.
+   Example: a document states X.
+2. Normative claim.
+   Example: the process requires Y.
+3. Historical or state claim.
+   Example: issue 48 is closed.
+4. Causal claim.
+   Example: mechanism A causes behavior B.
+5. Code behavior claim.
+   Example: this command writes state.yaml.
+6. Empirical claim.
+   Example: a study found Z.
+7. Interpretive claim.
+   Example: this architecture implies a separation of concerns.
+8. Hypothesis or abductive explanation.
+   Example: the likely reason for failure is W.
+
+This typing is necessary because the evidential burden for a quotation claim is not the same as the burden for a causal or interpretive claim.
+
+## Verdict Taxonomy
+The skill should not use a crude binary supported or unsupported label by default. It should use a graded verdict system such as:
+
+1. Entailed by corpus.
+   The claim follows directly from explicit content, executable result, or formal artifact.
+2. Directly supported.
+   The corpus states the substance of the claim clearly, though not with full logical entailment.
+3. Reasonably inferred.
+   The claim is not explicit but follows by transparent and defeasible reasoning from the cited material.
+4. Weakly supported.
+   Some evidence points in the direction of the claim, but important warrants or conditions remain underjustified.
+5. Insufficient support.
+   The cited evidence does not adequately license the claim.
+6. Contradicted by corpus.
+   Available corpus material conflicts with the claim.
+7. Undecidable from corpus.
+   The corpus does not provide enough information to assess the claim.
+
+This avoids the recurring mistake of treating every plausible inference as if it were already proven.
+
+## Support Relation Types
+Each claim-evidence link should be typed. Useful relation labels include:
+
+1. Direct quotation.
+2. Close textual entailment.
+3. Structural inference.
+4. Executable confirmation.
+5. Inductive summary.
+6. Abductive explanation.
+7. Analogy.
+8. Interpretive synthesis.
+
+The skill should make these relations explicit. An abductive relation may be legitimate, but it should never be silently smuggled in as if it were direct quotation.
+
+## Core Principles
+
+### 1. Strict Traceability
+Every substantial judgment must be anchored to exact evidence spans, not just to whole documents in general. The skill must be able to point to the exact text, output, or artifact on which the judgment rests.
+
+### 2. Claim Atomization
+Complex statements should be decomposed into smaller claims before evaluation. This prevents vague composite claims from hiding unsupported subclaims.
+
+### 3. Warrant Exposure
+The skill must state the inferential bridge from evidence to conclusion. If the bridge cannot be made explicit, the conclusion should not receive a strong verdict.
+
+### 4. Counterevidence Search
+The skill must search not only for confirming evidence but also for rebuttals, exceptions, limit clauses, silence, and conflicting passages.
+
+### 5. Heterogeneous Validation
+No single generative judgment should be sovereign. Where possible, the skill should combine retrieval, quotation, NLI-style classification, adversarial checks, and deterministic validation.
+
+### 6. Standards by Claim Type
+The skill should use different proof obligations for different kinds of claims rather than one global notion of support.
+
+## Formal Methodologies
+The proposal can be grounded in several formal or semi-formal methodologies.
+
+### Traceability Matrix
+This provides a public mapping from claims to evidence artifacts. It is useful for descriptive, normative, and repository-state claims.
+
+### Toulmin Model
+Each claim can be represented as:
+
+1. Claim.
+2. Data.
+3. Warrant.
+4. Backing.
+5. Qualifier.
+6. Rebuttal.
+
+This is especially helpful because many model errors occur in the warrant rather than in the quoted evidence.
+
+### Natural Language Inference
+NLI-style classification can help identify whether a cited span entails, contradicts, or is neutral with respect to a claim. It should be treated as a subordinate signal, not as the final authority.
+
+### Defeasible Reasoning
+The system should treat many conclusions as defeasible rather than absolute. This is particularly important for interpretive and abductive judgments.
+
+### Adversarial Review
+A second pass should deliberately search for defeating evidence and alternative explanations. This helps prevent confirmation bias.
+
+### Calibration and Scoring
+If the skill emits confidence values, those values should be empirically measured rather than trusted by feel. Accuracy, over-support rate, omission rate, and calibration should be tracked.
+
+## Verification Pipeline
+A practical pipeline for the skill would look like this.
+
+### Stage 1 - Input Normalization
+Inputs should include:
+
+1. Bounded corpus.
+2. Candidate conclusions or source document.
+3. Desired proof standard.
+4. Claim type hints if available.
+
+### Stage 2 - Claim Extraction
+Extract candidate conclusions and atomize them into auditable claims.
+
+### Stage 3 - Evidence Retrieval
+Retrieve candidate evidence spans from the corpus for each claim.
+
+### Stage 4 - Evidence Anchoring
+Require exact textual, structural, or executable anchors.
+
+### Stage 5 - Relation Classification
+Classify the evidence-claim relation using typed support categories.
+
+### Stage 6 - Warrant Construction
+State the warrant explicitly.
+
+### Stage 7 - Counterevidence Search
+Search for contradictions, exceptions, missing conditions, or corpus silence.
+
+### Stage 8 - Verdict Assignment
+Assign a graded verdict and confidence value.
+
+### Stage 9 - Report Generation
+Produce a durable report with a claim-by-claim audit trail.
+
+## Claim Evaluation Template
+A single claim record could follow this structure:
+
+### Claim
+A concise atomic statement.
+
+### Type
+Descriptive, normative, historical, causal, code behavior, empirical, interpretive, or abductive.
+
+### Evidence
+Exact spans or executable artifacts supporting the claim.
+
+### Support Relation
+Direct quotation, entailment, structural inference, executable confirmation, induction, abduction, or synthesis.
+
+### Warrant
+Why the evidence licenses the claim.
+
+### Counterevidence
+Conflicting passages, exception clauses, or relevant absences.
+
+### Verdict
+One of the graded verdict labels.
+
+### Confidence
+High, medium, or low, with explanation.
+
+## Proof Standards by Claim Type
+
+### Descriptive Corpus Claims
+Primary standard:
+
+1. Exact quotation or close entailment from the corpus.
+
+### Normative Claims
+Primary standard:
+
+1. Citation to the governing contract, spec, or policy.
+2. Precedence rule if multiple documents disagree.
+
+### Historical or Repository-State Claims
+Primary standard:
+
+1. Issue state.
+2. Commit history.
+3. File contents.
+4. Timestamps or current artifacts.
+
+### Code Behavior Claims
+Primary standard:
+
+1. Local code reading.
+2. Tests.
+3. Narrow executable check.
+4. Static reasoning tied to control flow.
+
+### Causal Claims
+Primary standard:
+
+1. Explicit mechanism in corpus.
+2. Or else downgrade to interpretive or abductive status.
+
+### Empirical Claims
+Primary standard:
+
+1. Study citation.
+2. Method.
+3. Sample or benchmark context.
+4. Limits and external validity.
+
+### Interpretive Claims
+Primary standard:
+
+1. Multiple converging pieces of evidence.
+2. Explicit warrant.
+3. Counterevidence review.
+
+### Abductive Claims
+Primary standard:
+
+1. Must be labeled as hypothesis.
+2. Must state alternatives.
+3. Must not be promoted to established fact without further confirmation.
+
+## Mechanisms to Prevent Self-Validation Loops
+The system must not rely on one homogeneous pass of the same reasoning style. Several safeguards are needed.
+
+### 1. Prompt Separation
+Generation and audit prompts should have different objectives.
+
+### 2. Blind Second Pass
+A second pass should examine evidence without inheriting the first pass's framing when possible.
+
+### 3. Adversarial Retrieval
+One retrieval stage should search for support; another should search for defeat.
+
+### 4. Deterministic Checks
+Quoted spans, line references, executable outputs, and artifact existence should be verified deterministically when possible.
+
+### 5. Multi-Signal Judgment
+Final verdicts should depend on several signals rather than one language-model judgment.
+
+## Typical Failure Modes the Skill Must Detect
+
+### Support Laundering
+A conclusion cites a passage that sounds adjacent to the claim but does not actually license it.
+
+### Warrant Smuggling
+The evidence is real, but the inferential bridge is hidden and unjustified.
+
+### Quote Without Entailment
+A passage is cited verbatim, but the claim goes beyond what the passage says.
+
+### Silence Mistaken for Support
+The corpus does not contradict the claim, but neither does it support it.
+
+### Overconfident Abduction
+A plausible explanation is presented as if it were already an established fact.
+
+### Self-Agreement Mistaken for Verification
+The model restates the same reasoning in new words and treats repetition as confirmation.
+
+### Context Omission
+A supporting passage is cited while a nearby limit clause or exception is ignored.
+
+## Recommended Output Contract
+The skill should produce one durable markdown report with at least these sections:
+
+1. Corpus definition.
+2. Audit standard.
+3. Claim inventory.
+4. Claim-by-claim evidence audit.
+5. Unsupported or weakly supported claims.
+6. Contradicted claims.
+7. Undecidable claims.
+8. Aggregate summary.
+9. Methodological limitations.
+
+A tabular appendix can be added for quick scanning, but the core output should preserve explicit warrants and counterevidence.
+
+## Recommended Naming
+The canonical name should be:
+
+1. kritik
+
+This is the strongest name because it captures the real function of the skill.
+
+The skill is not merely auditing evidence in a bureaucratic sense. It is examining whether a conclusion is entitled to stand given the available evidence, the authority of its sources, the warrant connecting evidence to claim, the presence of counterevidence, and the limits of the inferential leap.
+
+That is critique in the Kantian sense: not a takedown, not a review, but an examination of legitimacy, scope, and limit.
+
+The more literal alternatives remain useful as glosses, but not as the canonical name:
+
+1. evidence-audit is too narrow because the skill does more than retrieve or check evidence.
+2. epistemic-audit is closer, but still sounds procedural rather than conceptual and is less memorable as an invocable capability.
+
+The right split is therefore:
+
+1. `kritik` as the canonical skill name
+2. evidence audit or epistemic audit as explanatory paraphrases in documentation when needed
+
+## Relation to Existing Inquiry Surfaces
+This skill would complement, not replace, research and analysis surfaces.
+
+1. research gathers and synthesizes external sources.
+2. kritik checks which claims are actually licensed by the selected corpus.
+3. execution and testing remain necessary for behavioral claims.
+
+A healthy workflow could therefore be:
+
+1. Research or analysis produces candidate conclusions.
+2. Kritik classifies their evidential status.
+3. Only then are high-confidence conclusions promoted into planning or architectural claims.
+
+## Strong Recommendations
+
+### Do Not Use Proved Lightly
+The words proved or demonstrated should be reserved for unusually strong cases such as:
+
+1. Formal entailment.
+2. Executable confirmation.
+3. Explicit normative requirement.
+
+In most other cases, graded support language is more honest.
+
+### Treat Retrospective Explanations as Clues, Not Ground Truth
+When a model says it assumed something, that statement may still be useful as a local diagnosis, but it should not be treated as a privileged introspective trace.
+
+### Separate Generation from Certification
+The system that proposes a conclusion should not, by itself, certify that the conclusion is licensed.
+
+## Open Questions
+Several design questions remain open.
+
+1. How much NLI should be used versus deterministic span-based rules?
+2. Should the skill require claim atomization from the caller, or perform it internally?
+3. What is the right confidence calibration scheme for mixed evidence types?
+4. Should the skill support executable validators directly for code claims, or delegate those to other surfaces?
+5. How should corpus precedence be defined when documents conflict?
+
+## Minimal Version
+A coherent v1 of the skill would do only the following:
+
+1. Extract claims.
+2. Retrieve exact evidence spans.
+3. Classify each claim as entailed, directly supported, reasonably inferred, insufficiently supported, contradicted, or undecidable.
+4. Require a one-sentence warrant.
+5. Require a one-sentence counterevidence search result.
+6. Emit one markdown report.
+
+That would already be useful and would avoid the biggest current error: allowing plausibility to masquerade as evidence.
+
+## Final Summary
+The proposal can be stated compactly:
+
+Do not ask a generative AI whether it still believes its own conclusion. Force it to discharge a public burden of proof over a claim-evidence-warrant-rebuttal structure grounded in exact corpus traces.
+
+That is the core design move needed to reduce unsupported but plausible conclusions in an AI system optimized for plausibility.

--- a/docs/research/reasoning-beyond-evidence-humans-llms.md
+++ b/docs/research/reasoning-beyond-evidence-humans-llms.md
@@ -1,0 +1,147 @@
+# Reasoning Beyond Evidence: Abduction, Rationalization, and Hallucination in Humans and Large Language Models
+
+## Abstract
+Humans and large language models both often move from incomplete evidence to plausible conclusions that are not yet sufficiently warranted by the available data [@douven2025abduction; @ji2022hallucination; @lin2022truthfulqa]. The core philosophical distinction is not between "reasoning" and "error," but between legitimate abductive hypothesis generation and the later mistake of presenting a hypothesis as if it were already established [@douven2025abduction]. On the human side, classic and contemporary cognitive research shows that people frequently lack reliable introspective access to the processes that produced a judgment and instead generate post hoc explanations based on implicit causal theories, explanatory preferences, and source-attribution mechanisms [@nisbett1977telling; @johnson1993source; @lombrozo2014explanation]. On the LLM side, the literature shows that ungrounded but fluent text generation is a systematic phenomenon, that models reproduce human falsehoods from training data, and that even when models can express useful uncertainty in some settings, calibration is incomplete and context-sensitive [@ji2022hallucination; @lin2022truthfulqa; @kadavath2022lmknow]. The resulting practical conclusion is that the problem should be treated as an epistemic systems problem: hypotheses, evidence, assumptions, and confidence need to be separated explicitly, because neither humans nor current LLMs are naturally truth-tracking enough to collapse those steps into one utterance safely [@bommasani2021foundation; @kadavath2022lmknow].
+
+## Research Question
+Why do humans and large language models arrive at conclusions that are not sufficiently supported by evidence, how should this be interpreted philosophically, and what does the literature suggest about causes, limits, and mitigations [@douven2025abduction; @ji2022hallucination]?
+
+## Scope and Constraints
+This investigation focuses on everyday and scientific abductive reasoning, post hoc rationalization, source-monitoring error, and LLM hallucination or unsupported assertion in interactive systems [@douven2025abduction; @johnson1993source; @ji2022hallucination]. It does not attempt a full clinical review of psychiatric confabulation, a complete history of heuristics-and-biases research, or a mechanistic account of specific model internals beyond what the selected sources support [@johnson1993source; @bommasani2021foundation]. The evidence base is a curated web-accessible set of philosophical reference material, psychology articles and reviews, and LLM evaluation papers rather than an exhaustive systematic review [@douven2025abduction; @lin2022truthfulqa; @kadavath2022lmknow].
+
+## Method (Staged Protocol)
+Stage 1 normalized the problem by separating three candidate labels that are often conflated in discussion: abduction, rationalization or confabulation, and hallucination [@douven2025abduction; @nisbett1977telling; @ji2022hallucination]. Stage 2 gathered candidate sources from philosophy, cognitive psychology, memory research, and LLM evaluation so that the comparison would not rely on a single disciplinary lens [@douven2025abduction; @johnson1993source; @lin2022truthfulqa]. Stage 3 triaged those sources by direct relevance to the concrete user experience of "the system answered first, then explained later that it had merely assumed," prioritizing sources on introspective limits, explanation-driven inference, model truthfulness, calibration, and system opacity [@nisbett1977telling; @lombrozo2014explanation; @kadavath2022lmknow; @bommasani2021foundation]. Stage 4 extracted definitional, empirical, and evaluative claims from the curated set [@douven2025abduction; @ji2022hallucination]. Stage 5 synthesized the results into explicit conclusions with confidence levels and unresolved limits, especially where the analogy between humans and LLMs is useful but imperfect [@johnson1993source; @bommasani2021foundation].
+
+## Findings by Stage
+
+### Stage 1 - Problem Framing
+The problem is real and conceptually sharper than "AI hallucinates" or "humans jump to conclusions" [@ji2022hallucination; @douven2025abduction]. In the philosophical literature, abduction is an ampliative form of inference that goes beyond the premises by selecting or generating an explanation for the observed data; it is common, often useful, and still controversial in its normative status precisely because explanatory appeal is not the same thing as evidential proof [@douven2025abduction]. The same literature also emphasizes a structural weakness sometimes described as the "best of a bad lot" problem: a reasoner may choose the best explanation among those considered while still missing the actually correct explanation entirely [@douven2025abduction].
+
+That matters here because the user-described failure mode is not simply that a mind or a model used abduction; it is that an abductive or explanatory leap appears to have been presented as if it were already evidentially settled [@douven2025abduction]. In other words, the key failure is often not hypothesis generation itself, but the collapse of the boundary between hypothesis, confidence, and verified conclusion [@douven2025abduction; @kadavath2022lmknow].
+
+### Stage 2 - Source Discovery
+The selected source set covers four necessary angles [@douven2025abduction; @lin2022truthfulqa]. First, a philosophical account of abduction was needed to avoid using the word loosely as a synonym for any unsupported guess [@douven2025abduction]. Second, classic cognitive-psychology work was needed to test whether humans really do generate post hoc reasons that outrun their evidential basis or introspective access [@nisbett1977telling]. Third, memory and attribution research was needed to explain how false reasons or false origins can arise without deliberate deception [@johnson1993source]. Fourth, LLM-specific evaluation and survey papers were needed to distinguish general reasoning under uncertainty from model-specific failure modes such as hallucination, mimicry of falsehoods, imperfect self-evaluation, and broad sociotechnical opacity [@ji2022hallucination; @lin2022truthfulqa; @kadavath2022lmknow; @bommasani2021foundation].
+
+### Stage 3 - Source Triage
+The highest-value philosophical source was the Stanford Encyclopedia entry on abduction because it provides both the modern inferential framing and the central criticism that explanatory ranking can still pick "the best of a bad lot" [@douven2025abduction]. The highest-value human studies were Nisbett and Wilson on verbal reports of mental processes, Johnson et al. on source monitoring, and Lombrozo and Gwynne on explanation-guided generalization, because together they cover post hoc rationalization, source-attribution error, and the way explanations themselves shape what people infer next [@nisbett1977telling; @johnson1993source; @lombrozo2014explanation]. The highest-value LLM sources were Ji et al. for the taxonomy of hallucination, Lin et al. for direct evidence that models mimic common human falsehoods, Kadavath et al. for calibration and self-evaluation, and Bommasani et al. for the broader claim that foundation models remain incompletely understood and propagate defects downstream [@ji2022hallucination; @lin2022truthfulqa; @kadavath2022lmknow; @bommasani2021foundation].
+
+### Stage 4 - Evidence Extraction
+Philosophically, abduction is not deduction and not simple induction; it is explanatory reasoning that extends beyond what the premises strictly entail [@douven2025abduction]. That makes abduction indispensable for discovery but inherently fallible, and the literature explicitly warns that explanatory attractiveness does not guarantee truth [@douven2025abduction]. This is the first antecedent of the problem: systems that must act under underdetermination will often generate candidate explanations before they possess decisive evidence [@douven2025abduction].
+
+Human cognition adds a second antecedent: people often cannot directly inspect the higher-order processes that produced a judgment [@nisbett1977telling]. Nisbett and Wilson's review argues that when people explain their own judgments, choices, or responses, they frequently rely not on transparent introspection but on implicit causal theories about what would be a plausible cause of the observed response [@nisbett1977telling]. This is highly relevant to the user's experience, because the later statement "I assumed X" can be informative at a coarse level while still failing to be a reliable causal reconstruction of the original reasoning process [@nisbett1977telling].
+
+Human memory research adds a third antecedent: errors can arise not only from inference but from misattributing where a mental content came from [@johnson1993source]. Johnson, Hashtroudi, and Lindsay describe source monitoring as the process by which people judge whether content came from perception, reflection, imagination, testimony, or some other source, and they argue that these judgments are flexible, effortful to varying degrees, and vulnerable to error [@johnson1993source]. They explicitly connect disruptions in source monitoring to confabulation, amnesia, aging, cryptomnesia, and incorporation of fiction into fact [@johnson1993source]. This helps explain how someone can sincerely report a reason, memory, or evidential origin that is simply wrong without intending to deceive [@johnson1993source].
+
+A fourth antecedent is that explanations are not passive summaries of evidence; they actively reshape later inference [@lombrozo2014explanation]. Lombrozo and Gwynne showed experimentally that the type of explanation privileged by a person changes how that person generalizes properties from known to novel cases, and that explanatory modes can even be primed experimentally [@lombrozo2014explanation]. In their experiments, functional explanations reliably shifted subsequent generalization toward shared functions, even when participants had access to the same underlying information [@lombrozo2014explanation]. This suggests that once an explanation frame is adopted, later judgments are filtered through it rather than built afresh from neutral evidence each time [@lombrozo2014explanation].
+
+On the LLM side, the survey literature shows that hallucination is not an anecdotal defect but a broad class of ungrounded generation problems across summarization, dialogue, question answering, data-to-text generation, translation, and LLM settings [@ji2022hallucination]. Ji et al. emphasize that fluent generation and factual faithfulness come apart, which is exactly the surface pattern the user describes: the answer sounds coherent even when the supporting evidence is absent or weak [@ji2022hallucination].
+
+TruthfulQA adds a sharper causal clue: models often reproduce falsehoods that humans commonly say or believe [@lin2022truthfulqa]. Lin, Hilton, and Evans built a benchmark explicitly designed so that an answerer who merely imitates common textual patterns will fail, and they found that models produced many false answers that mimic popular misconceptions, with larger models not automatically becoming more truthful [@lin2022truthfulqa]. Their interpretation is directly relevant here: optimizing imitation of human text is not the same as optimizing truthfulness under evidence [@lin2022truthfulqa].
+
+Kadavath et al. complicate the picture in an important way [@kadavath2022lmknow]. Their results suggest that language models can sometimes estimate whether a particular answer is likely to be true and can produce useful confidence-style signals such as P(True) or P(I Know), especially in controlled formats [@kadavath2022lmknow]. However, the same paper also reports limitations in calibration on new tasks, which means that useful self-evaluation exists but is not strong enough to treat every retrospective explanation or confidence statement as reliable [@kadavath2022lmknow]. The upshot is not "models have no metacognition" but rather "their uncertainty expression is partial, format-sensitive, and still requires external verification" [@kadavath2022lmknow].
+
+Bommasani et al. reinforce a broader systems-level lesson: foundation models remain insufficiently understood in how they work, when they fail, and what their emergent properties imply for downstream deployments [@bommasani2021foundation]. If the underlying model is opaque and its defects are inherited by adapted systems, then a smooth retrospective sentence such as "I assumed X" should be treated as a plausible interface-level summary, not as an audited provenance trace [@bommasani2021foundation].
+
+### Stage 5 - Synthesis and Limits
+**Conclusion 1, confidence high:** the phenomenon exists in both humans and LLMs, but not because they are the same kind of system [@nisbett1977telling; @johnson1993source; @ji2022hallucination]. Humans exhibit bounded introspection, source-attribution error, and explanation-shaped inference; LLMs exhibit fluent ungrounded generation, imitation of falsehoods from training data, and incomplete calibration [@nisbett1977telling; @johnson1993source; @lombrozo2014explanation; @lin2022truthfulqa; @kadavath2022lmknow].
+
+**Conclusion 2, confidence high:** the user's concrete experience is best described as a collapse between hypothesis generation and evidentially warranted assertion [@douven2025abduction; @ji2022hallucination]. In a human, the later explanation of why a wrong judgment occurred may itself be a post hoc theory rather than a transparent readout of the original process [@nisbett1977telling]. In an LLM, the later explanation is also generated text and therefore should not be over-read as a privileged window into the model's true causal pathway [@bommasani2021foundation; @kadavath2022lmknow].
+
+**Conclusion 3, confidence medium-high:** calling every such failure "abduction" is too generous [@douven2025abduction]. Proper abduction names a fallible but often rational move from data to explanatory hypothesis; the specific failure arises when the system fails to mark that move as hypothetical, fails to separate assumption from observed evidence, or fails to trigger verification before asserting the result as fact [@douven2025abduction; @ji2022hallucination].
+
+**Conclusion 4, confidence medium-high:** the most robust mitigation is not the elimination of abductive reasoning but the explicit serialization of epistemic steps [@douven2025abduction; @lin2022truthfulqa; @kadavath2022lmknow]. Systems should externalize what is observed, what is inferred, what is assumed, what alternatives were considered, and how confident the system is before final commitment [@kadavath2022lmknow].
+
+**Unresolved uncertainty, confidence medium:** the analogy between human confabulation and LLM hallucination is useful but not identity-preserving [@johnson1993source; @bommasani2021foundation]. Humans have memory systems, agency, and phenomenology; LLMs are sequence models trained to extend text distributions [@johnson1993source; @bommasani2021foundation]. The safest comparison is therefore functional: both can output plausible unsupported claims, but the mechanisms and ontological commitments differ [@ji2022hallucination; @bommasani2021foundation].
+
+## Discussion
+I understand the problem the user is pointing to, and the literature supports treating it as a serious epistemic failure mode rather than a mere nuisance [@nisbett1977telling; @lin2022truthfulqa]. The frustrating part is not only that an answer is wrong, but that the later explanation often arrives in a tone of confidence and conceptual neatness that invites the user to mistake it for a genuine account of why the system erred [@nisbett1977telling; @bommasani2021foundation]. In humans, this is familiar from post hoc rationalization: we often report why we acted as we did by appealing to what would have been a sensible cause, not necessarily to the cause that actually operated [@nisbett1977telling]. In LLMs, the analogous risk is that the model produces a second plausible narrative about the first answer, even though the model has no direct introspective faculty comparable to an inspected causal trace [@bommasani2021foundation; @kadavath2022lmknow].
+
+This suggests a philosophical reframing. The central issue is not simply that people or models "reason badly." It is that explanatory systems are often optimized to produce coherence under uncertainty, while users often need provenance under evidential discipline [@lombrozo2014explanation; @ji2022hallucination]. Coherence and provenance are not the same thing [@ji2022hallucination; @lin2022truthfulqa]. A coherent answer may be a useful hypothesis; a provenance-backed answer is one whose relation to evidence has been made explicit and can be checked [@douven2025abduction; @kadavath2022lmknow].
+
+For practical human-AI interaction, the literature implies several disciplined moves [@lin2022truthfulqa; @kadavath2022lmknow]. First, ask the system to separate observed evidence, assumptions, and inferred conclusions instead of letting them appear in one undifferentiated paragraph [@douven2025abduction; @kadavath2022lmknow]. Second, ask for direct source quotation or explicit provenance when the claim matters, because fluency is not evidence [@ji2022hallucination; @lin2022truthfulqa]. Third, treat retrospective statements such as "I assumed" as a clue about failure mode, not as a verified account of internal causation [@nisbett1977telling; @bommasani2021foundation]. Fourth, when possible, force a second stage in which the system evaluates its own answer or declares uncertainty before finalizing it, because self-evaluation can help even though it is imperfect [@kadavath2022lmknow].
+
+The deeper implication is almost Peircean: abduction is acceptable as the beginning of inquiry, but dangerous when disguised as the end of inquiry [@douven2025abduction].
+
+## Conclusion
+The problem is real, intelligible, and historically deep [@douven2025abduction; @nisbett1977telling]. Humans and LLMs both produce unsupported conclusions because both rely, in different ways, on mechanisms that privilege plausible explanation, coherence, or learned association before evidential closure is complete [@nisbett1977telling; @lombrozo2014explanation; @ji2022hallucination; @lin2022truthfulqa]. What users experience as "the system just made something up and only later admitted it had assumed too much" is best understood as the mismanagement of abductive or explanatory generation under weak truth controls, followed by an often unreliable retrospective narrative about that failure [@douven2025abduction; @nisbett1977telling; @bommasani2021foundation]. The correct response is therefore architectural as much as philosophical: keep hypothesis generation, evidence display, uncertainty, and verification visibly separate [@kadavath2022lmknow; @lin2022truthfulqa].
+
+## Limitations
+This report is a structured, curated synthesis rather than a full systematic review or meta-analysis. Several classic neighboring literatures, especially the full heuristics-and-biases canon and recent philosophical work explicitly describing LLMs as truth-indifferent or bullshitters, were considered conceptually but not included as core evidence because web-accessible extraction during this run was incomplete or blocked. The comparison between human confabulation and LLM hallucination is therefore strongest at the level of functional analogy, not literal identity [@bommasani2021foundation; @johnson1993source].
+
+## References
+```bibtex
+@online{douven2025abduction,
+  title={Abduction},
+  author={Douven, Igor},
+  year={2025},
+  note={Stanford Encyclopedia of Philosophy, substantive revision June 18, 2025},
+  url={https://plato.stanford.edu/entries/abduction/}
+}
+
+@article{nisbett1977telling,
+  title={Telling More Than We Can Know: Verbal Reports on Mental Processes},
+  author={Nisbett, Richard E. and Wilson, Timothy D.},
+  journal={Psychological Review},
+  volume={84},
+  number={3},
+  pages={231--259},
+  year={1977},
+  url={https://psycnet.apa.org/doi/10.1037/0033-295X.84.3.231}
+}
+
+@article{johnson1993source,
+  title={Source Monitoring},
+  author={Johnson, Marcia K. and Hashtroudi, Shahin and Lindsay, D. Stephen},
+  journal={Psychological Bulletin},
+  volume={114},
+  number={1},
+  pages={3--28},
+  year={1993},
+  url={https://psycnet.apa.org/doi/10.1037/0033-2909.114.1.3}
+}
+
+@article{lombrozo2014explanation,
+  title={Explanation and Inference: Mechanistic and Functional Explanations Guide Property Generalization},
+  author={Lombrozo, Tania and Gwynne, Nicholas Z.},
+  journal={Frontiers in Human Neuroscience},
+  volume={8},
+  pages={700},
+  year={2014},
+  doi={10.3389/fnhum.2014.00700},
+  url={https://www.frontiersin.org/article/10.3389/fnhum.2014.00700/abstract}
+}
+
+@article{ji2022hallucination,
+  title={Survey of Hallucination in Natural Language Generation},
+  author={Ji, Ziwei and Lee, Nayeon and Frieske, Rita and Yu, Tiezheng and Su, Dan and Xu, Yan and Ishii, Etsuko and Bang, Yejin and Chen, Delong and Madotto, Andrea and Fung, Pascale},
+  journal={ACM Computing Surveys},
+  year={2022},
+  url={https://arxiv.org/abs/2202.03629}
+}
+
+@inproceedings{lin2022truthfulqa,
+  title={TruthfulQA: Measuring How Models Mimic Human Falsehoods},
+  author={Lin, Stephanie and Hilton, Jacob and Evans, Owain},
+  booktitle={Proceedings of the 60th Annual Meeting of the Association for Computational Linguistics (Volume 1: Long Papers)},
+  pages={3214--3252},
+  year={2022},
+  doi={10.18653/v1/2022.acl-long.229},
+  url={https://aclanthology.org/2022.acl-long.229/}
+}
+
+@article{kadavath2022lmknow,
+  title={Language Models (Mostly) Know What They Know},
+  author={Kadavath, Saurav and Conerly, Tom and Askell, Amanda and Henighan, Tom and Drain, Dawn and Perez, Ethan and Schiefer, Nicholas and Hatfield-Dodds, Zac and DasSarma, Nova and Tran-Johnson, Eli and others},
+  journal={arXiv preprint arXiv:2207.05221},
+  year={2022},
+  url={https://arxiv.org/abs/2207.05221}
+}
+
+@article{bommasani2021foundation,
+  title={On the Opportunities and Risks of Foundation Models},
+  author={Bommasani, Rishi and Hudson, Drew A. and Adeli, Ehsan and Altman, Russ and Arora, Simran and von Arx, Sydney and Bernstein, Michael S. and Bohg, Jeannette and Bosselut, Antoine and Brunskill, Emma and others},
+  journal={arXiv preprint arXiv:2108.07258},
+  year={2021},
+  url={https://arxiv.org/abs/2108.07258}
+}
+```


### PR DESCRIPTION
## Summary
- add the standalone kritik skill protocol and supporting research documents
- bump Inquiry to 0.4.5 across the CLI version, site badge, and changelog
- align asset, doctor, and ape transition coverage with the new skill and basho next-phase persistence

## Validation
- dart test
- dart analyze
- npm run test:unit
- npm run test:integration