### PR TITLE
architecture: make cleanrooms/<slug> the canonical inquiry root with cycle-local state (#209)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # Inquiry — cleanroom versioning opt-in (this repo tracks cleanrooms as research artifacts)
 !cleanrooms/
+
+# Inquiry — cycle-local runtime state is derived, never tracked
+cleanrooms/**/.iq.state.yaml

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/analyze/canonical-cycle-root-analysis.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/analyze/canonical-cycle-root-analysis.md
@@ -1,0 +1,107 @@
+---
+id: canonical-cycle-root-analysis
+title: "Canonical Cycle Root Analysis"
+date: 2026-05-30
+status: active
+tags: [analysis, architecture, cleanroom, inquiry-root]
+author: socrates
+---
+
+# Canonical Cycle Root Analysis
+
+## Origin
+
+This analysis started from issue #150, which asked whether `mutations.md` should move from `.inquiry/` into the cleanroom, and expanded into a broader architectural question:
+
+- where should the active cycle actually live?
+- what should remain project-scoped?
+- how should the CLI know whether it is inside a live inquiry or merely inside a repository with old cleanrooms?
+
+The current cycle for issue #209 reframes that broader question around an explicit target: `cleanrooms/<slug>/` as the canonical inquiry root.
+
+## Core conclusion
+
+The right design target is:
+
+- `cleanrooms/<slug>/` is the canonical root of a cycle
+- active cycle state is local to that root
+- `project_root` remains explicit for repository operations
+- `IDLE` is derived when no active cycle resolves
+
+## Why this is better than cwd-based state
+
+It preserves an explicit home for the inquiry without forcing the user to invoke `iq` from one special directory.
+
+This distinction matters:
+
+- `inquiry_root` is the cycle's home
+- cwd is just invocation context
+
+Once those are separated, the CLI can be robust without relying on either:
+
+- terminal-scoped environment variables
+- a hidden global memory inside the CLI
+
+## Why this still works without worktrees
+
+The proposal does not depend on worktrees.
+
+In worktree-first mode:
+
+- `project_root` is the worktree root
+- `inquiry_root` is `cleanrooms/<slug>/`
+
+In non-worktree mode:
+
+- `project_root` is the repository root
+- `inquiry_root` is still `cleanrooms/<slug>/`
+
+That symmetry is one of the strongest arguments in favor of the model.
+
+## Why many cleanrooms are not a problem
+
+A repository can contain many historical cleanrooms.
+
+That only becomes ambiguous if the CLI treats `cleanrooms/` itself as the active cycle.
+
+Instead, the CLI should treat `cleanrooms/` as a set of possible cycle roots and resolve one active cycle deterministically from repository context.
+
+Preferred discriminator order:
+
+1. current branch
+2. current cwd only if already inside a cleanroom root
+3. explicit future selection command when heuristics are insufficient
+
+## Why `.iq.state.yaml` is preferable to generic names
+
+The active cycle state file should be both explicit and cycle-scoped.
+
+Compared with candidates such as `inquiry.yaml`, `ape_cycle.yaml`, or `fsm.yaml`, `.iq.state.yaml` is currently the strongest option because it:
+
+- says this is runtime state, not a generic manifest
+- stays local to a single cycle
+- avoids confusion with future tracked project-level config
+
+## Resulting document set
+
+The current working set for the cycle should be centered on:
+
+- `.iq.state.yaml`
+- `issue.md`
+- `analyze/index.md`
+- `analyze/confirmations.md`
+- `analyze/diagnosis.md`
+- `plan.md`
+- `mutations.md`
+- `pr.md` once a PR exists
+
+Files beyond that should not become mandatory until the workflow actually consumes them.
+
+## Next step
+
+The next step is a concrete specification of:
+
+- cycle layout
+- state schema
+- active cycle resolution rules
+- migration boundaries from current `.inquiry/*` behavior

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/analyze/canonical-cycle-root-spec.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/analyze/canonical-cycle-root-spec.md
@@ -1,0 +1,294 @@
+---
+id: canonical-cycle-root-spec
+title: "Canonical Cycle Root Specification"
+date: 2026-05-30
+status: draft
+tags: [specification, architecture, inquiry-root, cleanroom]
+author: socrates
+---
+
+# Canonical Cycle Root Specification
+
+## Status
+
+This is a working specification draft produced during ANALYZE for issue #209.
+
+It defines the target contract being evaluated, not already-implemented behavior.
+
+## 1. Definitions
+
+### 1.1 `project_root`
+
+The git repository root of the current checkout or worktree.
+
+`project_root` owns:
+
+- source code
+- repository documentation
+- repository-level assets
+- repository configuration
+- git branch identity
+
+### 1.2 `inquiry_root`
+
+The canonical root directory of one active or historical cycle.
+
+Canonical value:
+
+`cleanrooms/<branch>/`
+
+The cleanroom directory name **is** the current branch name, formatted
+`<issue>-<slug>` (e.g. `209-cleanroom-canonical-inquiry-root`). The directory name
+must be a single filesystem-safe path segment (no `/`). The bare word "slug" is
+not used to mean the directory.
+
+### 1.3 `inquiry_cli_root`
+
+The root where Inquiry is installed/initialized for the project. It owns general
+CLI configuration (`config.yaml`), which is **not** cycle runtime state.
+
+The model therefore has three distinct roots:
+
+- `project_root` — the git repository / worktree
+- `inquiry_root` — the active cycle, `cleanrooms/<branch>/`
+- `inquiry_cli_root` — the CLI/project-level config home for `config.yaml`
+
+### 1.4 Active cycle
+
+A cycle is active when repository context resolves to one concrete `inquiry_root` whose state indicates a live FSM state.
+
+### 1.5 Derived `IDLE`
+
+`IDLE` is the state returned when no active cycle resolves from the current repository context.
+
+`IDLE` is an FSM state but not part of a persisted APE cycle. It is never stored
+inside a cycle-local state file. When `iq fsm state` returns `IDLE` it dispatches
+the IDLE sub-agent (DEWEY), whose only role is to create atomic, well-scoped
+issues. A cycle only comes into existence at the IDLE→ANALYZE transition.
+
+## 2. Canonical cycle layout
+
+### 2.1 Required files
+
+```text
+cleanrooms/<branch>/
+├── .iq.state.yaml      (ephemeral, gitignored)
+├── analyze/
+│   ├── index.md
+│   ├── confirmations.md
+│   ├── diagnosis.md
+│   └── <other analysis docs>
+├── plan.md
+└── mutations.md
+```
+
+### 2.2 Recommended files
+
+```text
+cleanrooms/<branch>/
+└── issue.md            (local mirror of the GitHub issue body)
+```
+
+`issue.md` is downloaded at cycle bootstrap so the cleanroom is self-explanatory
+when reopened and ANALYZE does not depend on the network or `gh`. It is
+recommended, not a hard precondition for the FSM.
+
+### 2.3 Optional files
+
+```text
+cleanrooms/<branch>/
+├── retrospective.md
+└── pr.md
+```
+
+Optional means:
+
+- not required to initialize a cycle
+- only created when the workflow actually reaches the phase that needs them
+
+Metrics files (`metrics.snapshot.yaml`, `metrics.yaml`) are out of scope for this
+cycle; metrics are not yet consumed by the workflow and are deferred to a
+dedicated metrics cycle.
+
+### 2.4 Tracking and gitignore
+
+Whether a cleanroom corpus is tracked is a per-repository preference. In this
+repository cleanrooms are tracked as research artifacts. Independently of that
+preference, ephemeral runtime state must never be committed:
+
+```gitignore
+cleanrooms/**/.iq.state.yaml
+```
+
+Tracked: `issue.md`, `analyze/*`, `plan.md`, `mutations.md`, `retrospective.md`,
+`pr.md`. Ignored: `.iq.state.yaml`.
+
+## 3. State file
+
+### 3.1 Filename
+
+Canonical name:
+
+`.iq.state.yaml`
+
+Rationale:
+
+- explicit runtime meaning
+- local to a single cycle
+- avoids collision with future tracked project-level `inquiry.yaml`
+
+### 3.2 Minimum schema
+
+```yaml
+version: 1
+issue:
+  number: 209
+  slug: 209-cleanroom-canonical-inquiry-root
+branch: 209-cleanroom-canonical-inquiry-root
+fsm_state: ANALYZE
+prompt_fragment_id: idle_to_analyze
+status: active
+ape:
+  name: socrates
+  state: clarification
+created_at: 2026-05-30T12:00:00Z
+updated_at: 2026-05-30T12:00:00Z
+```
+
+### 3.3 Allowed FSM states in `.iq.state.yaml`
+
+- `ANALYZE`
+- `PLAN`
+- `EXECUTE`
+- `END`
+- `EVOLUTION`
+
+`IDLE` must not be stored in `.iq.state.yaml`.
+
+## 4. Active cycle discovery
+
+### 4.1 Goal
+
+`iq fsm state` must answer:
+
+> does this repository context resolve to an active cycle?
+
+### 4.2 Discovery algorithm
+
+1. Resolve `project_root` using git.
+2. Resolve current branch using git.
+3. If `cleanrooms/<branch>/.iq.state.yaml` exists under `project_root`, resolve that cycle.
+4. Else, if cwd is already inside a cleanroom root containing `.iq.state.yaml`, resolve that cycle as a convenience rule.
+5. Else, return derived `IDLE`.
+
+### 4.3 Non-goals for discovery
+
+The CLI must not infer the active cycle from:
+
+- most recent file timestamp
+- most recently touched cleanroom
+- hidden CLI-global memory
+- terminal-scoped environment as the primary source of truth
+
+## 5. State semantics
+
+### 5.1 New repository, no cycle started
+
+Result: `IDLE` (DEWEY dispatched)
+
+### 5.2 Repository with many historical cleanrooms
+
+Result:
+
+- active cycle resolves only if branch or cwd-contained explicit context identifies one
+- otherwise `IDLE`
+
+### 5.3 Repository on a feature branch with matching cleanroom
+
+Result:
+
+- the matching cleanroom is the active cycle
+
+### 5.4 Edge cases
+
+- Outside a git repository → hard, explicit error (not silent `IDLE`). `iq doctor`
+  already requires git.
+- Detached HEAD (branch resolves to `HEAD`) → derived `IDLE`, since no
+  `<issue>-<slug>` branch resolves.
+- Branch names with `/` → forbidden by the `<issue>-<slug>` convention; the
+  directory name must be a single path segment.
+
+### 5.5 Cycle bootstrap (IDLE→ANALYZE)
+
+The transition IDLE→ANALYZE is the only moment a cycle is materialized:
+
+1. optionally create a worktree
+2. checkout the `<issue>-<slug>` branch
+3. create `cleanrooms/<branch>/` with initial files (`issue.md`,
+   `analyze/index.md`, `analyze/confirmations.md`)
+4. write the first `.iq.state.yaml` with `status: active`
+
+### 5.6 Status lifecycle
+
+`status` has a closed value set:
+
+- `active` — a live cycle, `fsm_state` in ANALYZE..EVOLUTION
+- `completed` — set when the cycle exits via END→IDLE or EVOLUTION→IDLE
+- `blocked` — optional, a cycle parked via the `block` event
+
+Because `IDLE` is derived and never persisted, a closed cycle is simply one whose
+branch no longer resolves as active and/or whose `.iq.state.yaml` reads
+`completed`.
+
+## 6. Issue and PR mirrors
+
+### 6.1 `issue.md`
+
+`issue.md` should exist as a local mirror of the cycle's GitHub issue context.
+
+Purpose:
+
+- stable local reference for title, number, URL, and scope
+- analysis can proceed without repeated GitHub fetches
+- the cleanroom remains self-explanatory when reopened later
+
+### 6.2 `pr.md`
+
+`pr.md` should be optional and created only when END produces or links a real pull request.
+
+Before that moment it should not be required.
+
+## 7. Migration consequences
+
+This is a pre-1.0 (v0.x.x) project with no external users. The migration is a
+clean **breaking change**: the old surface is replaced, with no dual-source-of-truth
+precedence rule.
+
+The following current behaviors would be replaced:
+
+- repo-level `.inquiry/state.yaml` reads and writes → cycle-local `.iq.state.yaml`
+- prompt context that still injects `.inquiry/mutations.md` → cycle-local `mutations.md`
+- `config.yaml` → moved to `inquiry_cli_root` (CLI/project-level config), not a cycle
+- extension activation tied to `workspaceContains:.inquiry/` → driven by the same
+  context resolution `iq fsm state` performs
+- any command that treats cwd as both `project_root` and `inquiry_root`
+
+Metrics surfaces are explicitly excluded from this migration.
+
+## 8. Invariants
+
+1. Every active cycle has exactly one canonical `inquiry_root`.
+2. `project_root` and `inquiry_root` are distinct concepts even when invoked from the same cwd.
+3. `IDLE` is derived, not stored in a cycle-local state file.
+4. Historical cleanrooms must not create ambiguous automatic selection.
+5. The CLI must remain usable from any cwd inside the repository or worktree.
+
+## 9. Open questions
+
+1. Exact `inquiry_cli_root` resolution: where `config.yaml` physically lives after
+   `.inquiry/` shrinks (project-level `inquiry.yaml`?), and how it is discovered.
+2. Does the future command surface need `iq cycle list`, `iq cycle show`, and
+   `iq cycle resume` to surface resumable cycles after branch/directory desync?
+3. Should END persist additional closure artifacts beyond `pr.md`?
+4. Exact `status` transition wiring (who sets `completed`/`blocked`, and when) —
+   to be finalized in PLAN.

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/analyze/confirmations.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/analyze/confirmations.md
@@ -1,0 +1,527 @@
+---
+id: confirmations
+title: "Confirmations"
+date: 2026-05-30
+status: active
+tags: [confirmations, findings]
+---
+
+# Confirmations
+
+> Living document. Update as findings are confirmed, revised, or invalidated.
+> Format: ## F<N>: <title> — CONFIRMED|REVISED|INVALIDATED
+
+## F1: cleanrooms/<slug>/ should be the canonical inquiry_root — CONFIRMED
+
+The cycle needs one explicit home for analysis, diagnosis, plan handoff, and cycle-local runtime surfaces. Using `cleanrooms/<slug>/` gives the same conceptual model in worktree-first and non-worktree usage.
+
+## F2: project_root and inquiry_root must be resolved separately — CONFIRMED
+
+The current CLI overloads `workingDirectory` for repository root, cycle root, git execution base, and runtime state lookup. That coupling is the structural source of cwd sensitivity.
+
+## F3: IDLE should be derived rather than persisted inside a cycle root — CONFIRMED
+
+`IDLE` describes the absence of a resolved active cycle in the current repository context. It is not a property of a specific cleanroom directory.
+
+## F4: active cycle discovery should be deterministic and branch-first — CONFIRMED
+
+Repositories may legitimately contain many historical cleanrooms. The CLI should resolve the active cycle by branch first, then cwd-contained convenience, and never by hidden global memory or timestamp guessing.
+
+## F5: .iq.state.yaml is the strongest current filename candidate — CONFIRMED
+
+The active cycle state file should be explicit, cycle-scoped, and distinct from any future tracked project manifest. `.iq.state.yaml` best matches those constraints among the names discussed so far.
+
+## F6: ephemeral cycle state must be gitignored even inside a tracked cleanroom — CONFIRMED
+
+Tracking the cleanroom corpus is a per-repository preference. In this repository it is valuable (it records how the system solves problems), so cleanrooms stay tracked. But ephemeral runtime state must never be committed. Therefore `.iq.state.yaml` (and any future ephemeral runtime file) must be excluded via a pattern such as `cleanrooms/**/.iq.state.yaml`, regardless of whether the surrounding cleanroom is tracked.
+
+## F7: issue.md is a recommended local mirror of the GitHub issue — CONFIRMED
+
+The issue body already lives in GitHub. `issue.md` is a downloaded local cache so the cleanroom is self-explanatory when reopened and ANALYZE does not depend on the network or `gh`. It is recommended (generated at cycle bootstrap), not a hard precondition for the FSM to function. This resolves former open question C2/diagnosis Q1.
+
+## F8: the cleanroom directory name equals the branch name — CONFIRMED
+
+Canonical term, fixed: the cleanroom directory name **is** the current branch name, formatted `<issue>-<slug>` (e.g., `209-cleanroom-canonical-inquiry-root`). The ambiguous bare word "slug" is no longer used to mean the directory. Discovery matches `cleanrooms/<branch>/`. Issue-number padding (3 vs 4 digits) is a cosmetic sort choice and does not change the rule. This resolves inconsistency I1.
+
+## F9: IDLE is an FSM state but not part of the internal APE cycle — CONFIRMED
+
+IDLE belongs to the FSM, not to a persisted cycle. When no cycle resolves from repository context, `iq fsm state` returns IDLE and dispatches the IDLE sub-agent (DEWEY). DEWEY's only job in IDLE is to create atomic, well-scoped issues. Only when the user expresses intent to work on a specific issue does the system transition to ANALYZE. This resolves inconsistency I2.
+
+## F10: there is a third root — the CLI installation/config root — CONFIRMED
+
+`config.yaml` is general CLI configuration, not cycle runtime state. It belongs at the root where Inquiry is installed/initialized (`inquiry_cli_root`), not inside a cycle. The model therefore has three distinct roots: `project_root` (repository), `inquiry_root` (the active cycle = `cleanrooms/<branch>/`), and `inquiry_cli_root` (CLI/project-level config home for `config.yaml`).
+
+## F11: extension activation must follow what `iq state` detects — CONFIRMED
+
+The VS Code extension must stop activating on the hardcoded marker `workspaceContains:.inquiry/`. Activation should be driven by the same context resolution that `iq fsm state` performs (presence of a resolvable Inquiry context, e.g., `cleanrooms/`), so the extension and the CLI agree on a single source of truth.
+
+## F12: the IDLE→ANALYZE bootstrap is the only cycle-creation moment — CONFIRMED
+
+IDLE persists nothing. The transition IDLE→ANALYZE is what materializes a cycle: optionally create a worktree, checkout the `<issue>-<slug>` branch, create `cleanrooms/<branch>/` with initial files (`issue.md`, `analyze/index.md`, `analyze/confirmations.md`), and write the first `.iq.state.yaml`. This resolves gap G4: there is no separate bootstrap to specify beyond this transition.
+
+## F13: cross-cycle metrics are out of scope for this cycle — CONFIRMED
+
+Metrics are not yet consumed by the workflow. `metrics.snapshot.yaml` / `metrics.yaml` are removed from the required and optional layout for #209 and excluded from migration scope. They can be reintroduced by a dedicated metrics cycle (#141) later.
+
+## F14: this is a breaking change; no migration window is required — CONFIRMED
+
+The project is pre-1.0 (v0.x.x) with no external users. The migration from repo-level `.inquiry/state.yaml` to cycle-local `.iq.state.yaml` is a clean breaking change. No dual-source-of-truth precedence rule is needed (resolves R1); the old surface is simply replaced.
+
+## F15: branch/directory desync is a development-time test risk, not a design hole — CONFIRMED
+
+Renaming a branch without renaming its cleanroom (or vice versa) makes the cycle fall back to IDLE. This is acceptable (safe over guessing) and is to be hardened through extensive testing during EXECUTE, not by adding inference. Tracks R2.
+
+## F16: status lifecycle of .iq.state.yaml must be enumerated — CONFIRMED (needs PLAN detail)
+
+The `status` field needs a defined, closed value set and closure rules. Proposed set: `active` (a live cycle, fsm_state in ANALYZE..EVOLUTION), and `completed` (set when the cycle exits via END→IDLE or EVOLUTION→IDLE). Optional `blocked` may mark a cycle parked via the `block` event. Because IDLE is derived and never persisted, a "closed" cycle is simply one whose branch no longer resolves as active and/or whose `.iq.state.yaml` reads `completed`. Exact transitions belong to PLAN. Resolves G5/G9 at the analysis level.
+
+## F17: non-git / detached-HEAD / slashed-branch edges resolve to IDLE or hard error — CONFIRMED
+
+`iq doctor` already requires git, so discovery may assume a git repo. Specified behavior: outside a git repository → hard, explicit error (not silent IDLE). Detached HEAD (branch resolves to `HEAD`) → derived IDLE, since no `<issue>-<slug>` branch resolves. The `<issue>-<slug>` convention forbids slashes, so nested `cleanrooms/feature/foo/` cannot occur; the spec states the directory name must be a single filesystem-safe path segment. Resolves G7/G8.
+*** Add File: c:\Users\44358590\Code\silicon-brained-machines\inquiry\cleanrooms\209-cleanroom-canonical-inquiry-root\issue.md
+---
+id: issue-209-reference
+title: "Issue #209 Reference"
+date: 2026-05-30
+status: active
+tags: [issue, reference, architecture, inquiry-root]
+author: socrates
+---
+
+# Issue #209
+
+## Metadata
+
+- Number: 209
+- Title: architecture: make cleanrooms/<slug> the canonical inquiry root with cycle-local state
+- URL: https://github.com/ccisnedev/inquiry/issues/209
+
+## Summary
+
+This cycle specifies the architectural shift from a repo-level active runtime state toward a cycle-local root under `cleanrooms/<slug>/`.
+
+The issue consolidates the main pressures already visible in:
+
+- #150 — `mutations.md` belongs with the active cleanroom
+- #178 — `iq` must stop depending on ambient cwd to resolve context
+- worktree-first usage — ignored runtime files do not carry over across newly created worktrees
+
+## Scope
+
+The issue is about cycle-root architecture and active-cycle resolution.
+
+It is not, by itself, approval to implement the full migration in one step.
+*** Add File: c:\Users\44358590\Code\silicon-brained-machines\inquiry\cleanrooms\209-cleanroom-canonical-inquiry-root\analyze\diagnosis.md
+---
+id: diagnosis
+title: "Diagnosis — canonical cycle root and active cycle resolution"
+date: 2026-05-30
+status: active
+tags: [diagnosis, architecture, inquiry-root, cleanroom]
+author: socrates
+---
+
+# Diagnosis
+
+## Problem
+
+The current CLI binds too many responsibilities to one implicit cwd-derived `workingDirectory`.
+
+Today that single value is used as though it were all of the following at once:
+
+- repository root
+- runtime state root
+- cleanroom root
+- asset/config lookup base
+- git command execution base
+
+That is why the current runtime is brittle when cwd drifts and why the repo-level `.inquiry/` directory remains overloaded.
+
+## Main findings
+
+### 1. The cycle needs a canonical local root
+
+The strongest candidate is `cleanrooms/<slug>/`.
+
+That gives one visible and durable home for the active inquiry in both modes:
+
+- worktree-first usage
+- standard single-worktree repository usage
+
+### 2. `IDLE` should be derived
+
+`IDLE` should not be stored inside a cycle-local state file.
+
+Instead, `IDLE` should mean:
+
+> no active cycle resolves from the current repository context
+
+### 3. project_root remains necessary
+
+Accepting `cleanrooms/<slug>/` as `inquiry_root` does not remove `project_root`.
+
+The CLI still needs repository-level resolution for:
+
+- source tree lookup
+- asset loading
+- repository configuration
+- branch discovery
+- transition prechecks outside the cleanroom
+
+### 4. Active cycle resolution must be deterministic
+
+The active cycle should be discovered by rule, not by hidden memory.
+
+Preferred order:
+
+1. resolve `project_root`
+2. resolve current branch
+3. if `cleanrooms/<branch>/.iq.state.yaml` exists, use it
+4. else if cwd is already inside a valid cleanroom root, use it as a convenience rule
+5. else return `IDLE`
+
+## Working conclusion
+
+The cleanest target architecture is:
+
+- `project_root` stays explicit
+- `inquiry_root` becomes `cleanrooms/<slug>/`
+- active cycle state moves into `.iq.state.yaml` inside that root
+- `IDLE` becomes derived instead of persisted in a root-level singleton
+
+## Open design questions
+
+1. Should `issue.md` be mandatory as a local mirror of the issue context?
+2. Should `pr.md` remain optional until END creates a pull request?
+3. Should any tracked project-level `inquiry.yaml` exist for policy, separate from cycle runtime state?
+4. Which currently weak metrics surfaces should remain in the minimal first migration?
+
+## Inputs to planning
+
+Planning should define:
+
+- the exact `.iq.state.yaml` schema
+- the canonical cycle layout
+- the precise discovery algorithm
+- the migration boundary from `.inquiry/*` to cycle-local state
+*** Add File: c:\Users\44358590\Code\silicon-brained-machines\inquiry\cleanrooms\209-cleanroom-canonical-inquiry-root\analyze\canonical-cycle-root-analysis.md
+---
+id: canonical-cycle-root-analysis
+title: "Canonical Cycle Root Analysis"
+date: 2026-05-30
+status: active
+tags: [analysis, architecture, cleanroom, inquiry-root]
+author: socrates
+---
+
+# Canonical Cycle Root Analysis
+
+## Origin
+
+This analysis started from issue #150, which asked whether `mutations.md` should move from `.inquiry/` into the cleanroom, and expanded into a broader architectural question:
+
+- where should the active cycle actually live?
+- what should remain project-scoped?
+- how should the CLI know whether it is inside a live inquiry or merely inside a repository with old cleanrooms?
+
+The current cycle for issue #209 reframes that broader question around an explicit target: `cleanrooms/<slug>/` as the canonical inquiry root.
+
+## Core conclusion
+
+The right design target is no longer "keep `.inquiry/`, but reduce it".
+
+The stronger and cleaner target is:
+
+- `cleanrooms/<slug>/` is the canonical root of a cycle
+- active cycle state is local to that root
+- `project_root` remains explicit for repository operations
+- `IDLE` is derived when no active cycle resolves
+
+## Why this is better than cwd-based state
+
+It preserves an explicit home for the inquiry without forcing the user to invoke `iq` from one special directory.
+
+This distinction matters:
+
+- `inquiry_root` is the cycle's home
+- cwd is just invocation context
+
+Once those are separated, the CLI can be robust without relying on either:
+
+- terminal-scoped environment variables
+- a hidden global memory inside the CLI
+
+## Why this still works without worktrees
+
+The proposal does not depend on worktrees.
+
+In worktree-first mode:
+
+- `project_root` is the worktree root
+- `inquiry_root` is `cleanrooms/<slug>/`
+
+In non-worktree mode:
+
+- `project_root` is the repository root
+- `inquiry_root` is still `cleanrooms/<slug>/`
+
+That symmetry is one of the strongest arguments in favor of the model.
+
+## Why many cleanrooms are not a problem
+
+A repository can contain many historical cleanrooms.
+
+That only becomes ambiguous if the CLI treats `cleanrooms/` itself as the active cycle.
+
+Instead, the CLI should treat `cleanrooms/` as a set of possible cycle roots and resolve one active cycle deterministically from repository context.
+
+Preferred discriminator order:
+
+1. current branch
+2. current cwd only if already inside a cleanroom root
+3. explicit future selection command when heuristics are insufficient
+
+## Why `.iq.state.yaml` is preferable to generic names
+
+The active cycle state file should be both explicit and cycle-scoped.
+
+Compared with candidates such as `inquiry.yaml`, `ape_cycle.yaml`, or `fsm.yaml`, `.iq.state.yaml` is currently the strongest option because it:
+
+- says this is runtime state, not a generic manifest
+- stays local to the cycle root
+- avoids confusion with future tracked project-level config
+
+## Resulting document set
+
+The current working set for the cycle should be centered on:
+
+- `.iq.state.yaml`
+- `issue.md`
+- `analyze/index.md`
+- `analyze/confirmations.md`
+- `analyze/diagnosis.md`
+- `plan.md`
+- `mutations.md`
+- `pr.md` once a PR exists
+
+Files beyond that should not become mandatory until the workflow actually consumes them.
+
+## Next step
+
+The next step is not more open-ended debate. It is a concrete specification of:
+
+- cycle layout
+- state schema
+- active cycle resolution rules
+- migration boundaries from current `.inquiry/*` behavior
+*** Add File: c:\Users\44358590\Code\silicon-brained-machines\inquiry\cleanrooms\209-cleanroom-canonical-inquiry-root\analyze\canonical-cycle-root-spec.md
+---
+id: canonical-cycle-root-spec
+title: "Canonical Cycle Root Specification"
+date: 2026-05-30
+status: draft
+tags: [specification, architecture, inquiry-root, cleanroom]
+author: socrates
+---
+
+# Canonical Cycle Root Specification
+
+## Status
+
+This is a working specification draft produced during ANALYZE for issue #209.
+
+It defines the target contract being evaluated, not an already-implemented behavior.
+
+## 1. Definitions
+
+### 1.1 project_root
+
+The git repository root of the current checkout or worktree.
+
+`project_root` owns:
+
+- source code
+- repository documentation
+- repository-level assets
+- repository configuration
+- git branch identity
+
+### 1.2 inquiry_root
+
+The canonical root directory of one active or historical cycle.
+
+Target value:
+
+`cleanrooms/<slug>/`
+
+### 1.3 active cycle
+
+A cycle is active when repository context resolves to one concrete `inquiry_root` whose state indicates a live FSM state other than derived `IDLE`.
+
+### 1.4 derived IDLE
+
+`IDLE` is the state returned when no active cycle resolves from the current repository context.
+
+`IDLE` is not stored inside a cycle-local state file.
+
+## 2. Canonical cycle layout
+
+### 2.1 Required files
+
+```text
+cleanrooms/<slug>/
+├── .iq.state.yaml
+├── issue.md
+├── analyze/
+│   ├── index.md
+│   ├── confirmations.md
+│   ├── diagnosis.md
+│   └── <other analysis docs>
+├── plan.md
+└── mutations.md
+```
+
+### 2.2 Optional files
+
+```text
+cleanrooms/<slug>/
+├── retrospective.md
+├── pr.md
+├── metrics.snapshot.yaml
+└── metrics.yaml
+```
+
+Optional means:
+
+- not required to initialize a cycle
+- only created when the workflow actually reaches the phase that needs them
+
+## 3. State file
+
+### 3.1 Filename
+
+Canonical name:
+
+`.iq.state.yaml`
+
+Rationale:
+
+- explicit runtime meaning
+- local to a single cycle
+- avoids collision with future project-level `inquiry.yaml`
+
+### 3.2 Minimum schema
+
+```yaml
+version: 1
+issue:
+	number: 209
+	slug: 209-cleanroom-canonical-inquiry-root
+branch: 209-cleanroom-canonical-inquiry-root
+fsm_state: ANALYZE
+prompt_fragment_id: idle_to_analyze
+status: active
+ape:
+	name: socrates
+	state: clarification
+created_at: 2026-05-30T12:00:00Z
+updated_at: 2026-05-30T12:00:00Z
+```
+
+### 3.3 Allowed FSM states in `.iq.state.yaml`
+
+- `ANALYZE`
+- `PLAN`
+- `EXECUTE`
+- `END`
+- `EVOLUTION`
+
+`IDLE` must not be stored in `.iq.state.yaml`.
+
+## 4. Active cycle discovery
+
+### 4.1 Goal
+
+`iq fsm state` must answer:
+
+> does this repository context resolve to an active cycle?
+
+### 4.2 Discovery algorithm
+
+1. Resolve `project_root` using git.
+2. Resolve current branch using git.
+3. If `cleanrooms/<branch>/.iq.state.yaml` exists under `project_root`, resolve that cycle.
+4. Else, if cwd is already inside a cleanroom root containing `.iq.state.yaml`, resolve that cycle as a convenience rule.
+5. Else, return derived `IDLE`.
+
+### 4.3 Non-goals for discovery
+
+The CLI must not infer the active cycle from:
+
+- most recent file timestamp
+- most recently touched cleanroom
+- hidden CLI-global memory
+- terminal-scoped environment as the primary source of truth
+
+## 5. State semantics
+
+### 5.1 New repository, no cycle started
+
+Result: `IDLE`
+
+### 5.2 Repository with many historical cleanrooms
+
+Result:
+
+- active cycle resolves only if branch or cwd-contained explicit context identifies one
+- otherwise `IDLE`
+
+### 5.3 Repository on a feature branch with matching cleanroom
+
+Result:
+
+- the matching cleanroom is the active cycle
+
+## 6. Issue and PR mirrors
+
+### 6.1 issue.md
+
+`issue.md` should exist as a local mirror of the cycle's GitHub issue context.
+
+Purpose:
+
+- stable local reference for title, number, URL, and scope
+- analysis can proceed without repeated GitHub fetches
+- the cleanroom remains self-explanatory when reopened later
+
+### 6.2 pr.md
+
+`pr.md` should be optional and created only when END produces or links a real pull request.
+
+Before that moment it should not be required.
+
+## 7. Migration consequences
+
+The following current behaviors would need migration:
+
+- repo-level `.inquiry/state.yaml` reads and writes
+- prompt context that still injects `.inquiry/mutations.md`
+- evolution instructions referencing repo-level metrics files
+- extension activation assumptions tied to `.inquiry/`
+- any command that treats cwd as both `project_root` and `inquiry_root`
+
+## 8. Invariants
+
+1. Every active cycle has exactly one canonical `inquiry_root`.
+2. `project_root` and `inquiry_root` are distinct concepts even when invoked from the same cwd.
+3. `IDLE` is derived, not stored in a cycle-local state file.
+4. Historical cleanrooms must not create ambiguous automatic selection.
+5. The CLI must remain usable from any cwd inside the repository or worktree.
+
+## 9. Open questions
+
+1. Should a tracked project-level `inquiry.yaml` exist for repository policy?
+2. Which optional metrics files still deserve first-class runtime support?
+3. Does the future command surface need `iq cycle list`, `iq cycle show`, and `iq cycle resume`?
+4. Should END persist additional closure artifacts beyond `pr.md`?
+*** Delete File: c:\Users\44358590\Code\silicon-brained-machines\inquiry\docs\research\issue-150-cleanroom-runtime-boundary-analysis.md

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/analyze/diagnosis.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/analyze/diagnosis.md
@@ -1,0 +1,99 @@
+---
+id: diagnosis
+title: "Diagnosis — canonical cycle root and active cycle resolution"
+date: 2026-05-30
+status: active
+tags: [diagnosis, architecture, inquiry-root, cleanroom]
+author: socrates
+---
+
+# Diagnosis
+
+## Problem
+
+The current CLI binds too many responsibilities to one implicit cwd-derived `workingDirectory`.
+
+Today that single value is used as though it were all of the following at once:
+
+- repository root
+- runtime state root
+- cleanroom root
+- asset/config lookup base
+- git command execution base
+
+That is why the current runtime is brittle when cwd drifts and why the repo-level `.inquiry/` directory remains overloaded.
+
+## Main findings
+
+### 1. The cycle needs a canonical local root
+
+The strongest candidate is `cleanrooms/<slug>/`.
+
+That gives one visible and durable home for the active inquiry in both modes:
+
+- worktree-first usage
+- standard single-worktree repository usage
+
+### 2. `IDLE` should be derived
+
+`IDLE` should not be stored inside a cycle-local state file.
+
+Instead, `IDLE` should mean:
+
+> no active cycle resolves from the current repository context
+
+### 3. `project_root` remains necessary
+
+Accepting `cleanrooms/<slug>/` as `inquiry_root` does not remove `project_root`.
+
+The CLI still needs repository-level resolution for:
+
+- source tree lookup
+- asset loading
+- repository configuration
+- branch discovery
+- transition prechecks outside the cleanroom
+
+### 4. Active cycle resolution must be deterministic
+
+The active cycle should be discovered by rule, not by hidden memory.
+
+Preferred order:
+
+1. resolve `project_root`
+2. resolve current branch
+3. if `cleanrooms/<branch>/.iq.state.yaml` exists, use it
+4. else if cwd is already inside a valid cleanroom root, use it as a convenience rule
+5. else return `IDLE`
+
+## Working conclusion
+
+The cleanest target architecture is:
+
+- `project_root` stays explicit
+- `inquiry_root` becomes `cleanrooms/<slug>/`
+- active cycle state moves into `.iq.state.yaml` inside that root
+- `IDLE` becomes derived instead of persisted in a root-level singleton
+
+## Open design questions
+
+Resolved during ANALYZE (see confirmations F6–F17):
+
+1. `issue.md` — recommended local mirror, generated at bootstrap (not a hard precondition).
+2. `pr.md` — optional until END creates a pull request.
+3. `config.yaml` — belongs to a third root, `inquiry_cli_root` (CLI/project-level config), not a cycle.
+4. Metrics — out of scope for this cycle; deferred.
+
+Remaining for PLAN:
+
+- exact `inquiry_cli_root` resolution and `config.yaml` location
+- exact `status` transition wiring
+
+## Inputs to planning
+
+Planning should define:
+
+- the exact `.iq.state.yaml` schema
+- the canonical cycle layout
+- the precise discovery algorithm
+- the migration boundary from `.inquiry/*` to cycle-local state

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/analyze/index.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/analyze/index.md
@@ -1,0 +1,18 @@
+# Analyze Phase — Index
+
+**Issue:** #209
+**Branch:** 209-cleanroom-canonical-inquiry-root
+**Phase:** ANALYZE
+**Status:** In progress
+
+---
+
+## Documents
+
+| # | File | Title | Status | Tags |
+|---|------|-------|--------|------|
+| 1 | confirmations.md | Confirmations | active | confirmations, findings |
+| 2 | diagnosis.md | Diagnosis | active | diagnosis, architecture, inquiry-root |
+| 3 | canonical-cycle-root-analysis.md | Canonical Cycle Root Analysis | active | analysis, architecture, cleanroom |
+| 4 | canonical-cycle-root-spec.md | Canonical Cycle Root Spec | draft | specification, inquiry-root, cleanroom |
+| 5 | review-risks-gaps.md | Review — Contradictions, Inconsistencies, Gaps, Risks | active | review, risks, gaps |

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/analyze/review-risks-gaps.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/analyze/review-risks-gaps.md
@@ -1,0 +1,225 @@
+---
+id: review-risks-gaps
+title: "Review — Contradictions, Inconsistencies, Gaps, Risks"
+date: 2026-05-30
+status: active
+tags: [review, risks, gaps, architecture, inquiry-root]
+author: socrates
+---
+
+# Review — Contradictions, Inconsistencies, Gaps, Risks
+
+This document audits the current cycle material (`issue.md`, `diagnosis.md`,
+`canonical-cycle-root-analysis.md`, `canonical-cycle-root-spec.md`,
+`confirmations.md`) against the real CLI behavior in the codebase.
+
+Each finding is grounded in a concrete source where possible.
+
+## A. Contradictions (must resolve)
+
+### C1: `.inquiry/` is gitignored, but cleanrooms are committed
+
+This is the most important issue.
+
+- `iq init` adds `.inquiry/` to `.gitignore` and treats it as ephemeral runtime
+  (`code/cli/lib/modules/global/commands/init.dart`, step 2 `_ensureGitignore`).
+- The FSM transition stages and commits cleanroom files
+  (`code/cli/lib/modules/fsm/commands/transition.dart` stages
+  `cleanrooms/<branch>/analyze` and `cleanrooms/<branch>/plan.md`).
+
+Consequence: placing `.iq.state.yaml` **inside** `cleanrooms/<slug>/` would make
+runtime state **git-tracked by default**, the opposite of the current
+intentionally-ignored runtime model. The user explicitly wants this state file
+to remain gitignored.
+
+Required decision: the spec must define a gitignore rule such as
+`cleanrooms/**/.iq.state.yaml` (and any other runtime files like
+`metrics.snapshot.yaml`) so that the cleanroom corpus stays tracked while
+cycle-local runtime state stays ignored.
+
+Status: the spec does not currently address this. Blocking.
+
+### C2: `issue.md` is both "required" and "open question"
+
+- `canonical-cycle-root-spec.md` section 2.1 lists `issue.md` under **Required files**.
+- `diagnosis.md` open question #1 and spec section 6.1 still treat it as undecided
+  ("should exist", "Should `issue.md` be mandatory?").
+
+Required decision: pick one. Recommended: keep `issue.md` required, and remove it
+from the open-questions list, or downgrade it to "recommended" consistently.
+
+## B. Inconsistencies (terminology / internal)
+
+### I1: `slug` vs `branch` used interchangeably
+
+- Spec uses `cleanrooms/<slug>/` as the canonical root (sections 1.2, 2).
+- Spec discovery uses `cleanrooms/<branch>/.iq.state.yaml` (section 4.2).
+- The real implementation names the directory after the **branch**, and the branch
+  convention is `<NNN>-<slug>` (`code/cli/assets/instructions/issue-start.md`,
+  steps 3–5; `effect_executor.dart` builds `cleanrooms/<branch>/analyze`).
+
+So in practice the directory name equals the branch name, which is `NNN-slug`.
+The word "slug" is ambiguous: sometimes it means only the text after `NNN`,
+sometimes the whole `NNN-slug`.
+
+Required fix: define one canonical term. Recommended: the cleanroom directory name
+is exactly the branch name `<NNN>-<slug>`, and discovery matches on that branch
+name. Avoid using bare "slug" to mean the directory.
+
+### I2: "live FSM state other than derived IDLE"
+
+Spec 1.3 says an active cycle has a "live FSM state other than derived IDLE", but
+spec 3.3 already forbids storing `IDLE` in `.iq.state.yaml`. The qualifier is
+redundant and slightly confusing. Minor wording fix.
+
+## C. Gaps (missing specification)
+
+### G1: gitignore handling for cycle-local runtime (ties to C1)
+
+No rule defines which cycle files are tracked vs ignored. Needed:
+
+- tracked: `issue.md`, `analyze/*`, `plan.md`, `mutations.md`, `retrospective.md`, `pr.md`
+- ignored: `.iq.state.yaml`, `metrics.snapshot.yaml`, possibly `metrics.yaml`
+
+### G2: `config.yaml` has no destination
+
+`evolution.enabled` is read from `.inquiry/config.yaml`
+(`code/cli/lib/modules/fsm/commands/state.dart` `_readEvolutionEnabled`).
+The spec never says where repo policy/config goes after `.inquiry/` shrinks.
+It is hinted only as open question #1 ("tracked project-level `inquiry.yaml`").
+
+Needed: decide whether `config.yaml` becomes a tracked `inquiry.yaml` at
+`project_root`, and add it to the migration list.
+
+### G3: extension activation marker not replaced
+
+`code/vscode/package.json` activates on `workspaceContains:.inquiry/`.
+The spec lists this in migration consequences but does not define the replacement
+marker (e.g., `cleanrooms/` or a project-level `inquiry.yaml`).
+
+### G4: first-transition bootstrap is unspecified
+
+During IDLE there is no cycle root yet. The IDLE→ANALYZE transition must create
+`cleanrooms/<branch>/` and write the first `.iq.state.yaml`. The spec describes
+discovery and steady state, but not who creates the state file on the first
+transition, nor the exact write sequence.
+
+### G5: cycle closure / archival lifecycle
+
+When a cycle finishes (END/EVOLUTION) and especially after the branch is deleted:
+
+- discovery by branch will stop matching (good, becomes history),
+- but `.iq.state.yaml` may still say `status: active` and `fsm_state: EVOLUTION`.
+
+Needed: define a closure rule (e.g., set `status: completed` at END/EVOLUTION exit)
+and the meaning of `status`. The `status` field values are never enumerated.
+
+### G6: cross-cycle metrics destination
+
+EVOLUTION currently reads `.inquiry/mutations.md`, `.inquiry/state.yaml`,
+`.inquiry/metrics_snapshot.yaml` and writes `.inquiry/metrics.yaml`
+(`code/cli/assets/fsm/states/evolution.yaml`). Moving everything cycle-local
+leaves cross-cycle aggregation undefined. The spec defers to #141 but does not
+state where aggregated/cross-cycle evidence lives in the meantime.
+
+### G7: non-git and detached-HEAD behavior
+
+Discovery says "resolve project_root using git" and "resolve current branch", but:
+
+- outside a git repo, `git rev-parse --show-toplevel` fails,
+- in detached HEAD, `git rev-parse --abbrev-ref HEAD` returns `HEAD`.
+
+Needed: define behavior for both (likely: error clearly / treat as `IDLE`,
+since `iq doctor` already requires git).
+
+### G8: branch names with slashes
+
+If a branch is `feature/foo`, the cleanroom path becomes nested
+`cleanrooms/feature/foo/`. The `NNN-slug` convention avoids slashes, but the spec
+should state the constraint that the branch (hence directory) must be a single
+filesystem-safe path segment.
+
+### G9: `status` field semantics
+
+`status: active` appears in the schema but its allowed values and transitions are
+undefined (active / completed / blocked / abandoned?). Tied to G5.
+
+## D. Risks (operational)
+
+### R1: migration window with two sources of truth
+
+During migration, both repo-level `.inquiry/state.yaml` and cycle-local
+`.iq.state.yaml` may exist. Without a clear precedence rule and a one-time
+migration step, `iq fsm state` could read stale state. Needs explicit precedence
+and a migration/upgrade path.
+
+### R2: branch rename or cleanroom rename desync
+
+Discovery binds the active cycle to `branch == directory name`. If a user renames
+the branch but not the directory (or vice versa), the cycle silently becomes
+unresolvable (falls back to IDLE). This is safer than guessing, but should be
+documented and ideally surfaced as a hint ("resumable cycles exist").
+
+### R3: hidden file ergonomics
+
+`.iq.state.yaml` is hidden while siblings (`issue.md`, `plan.md`, `pr.md`) are
+visible. Intentional, but mixed visibility should be documented so users and tools
+do not assume the directory is empty of runtime state.
+
+### R4: auto-generated index is hardcoded
+
+`effect_executor.openAnalysisContext()` writes an `index.md` that lists only
+`confirmations.md`. Any spec that promises a richer required layout must also
+update index generation, or the generated index will understate the corpus.
+
+## E. What still needs to be specified
+
+1. Gitignore policy for cycle-local runtime files (C1/G1). Blocking.
+2. Destination of `config.yaml` / project policy (`inquiry.yaml`?) (G2).
+3. Replacement activation marker for the VS Code extension (G3).
+4. First-transition bootstrap sequence for `.iq.state.yaml` (G4).
+5. `status` field value set and closure lifecycle (G5/G9).
+6. Cross-cycle metrics destination, even if interim (G6).
+7. Non-git / detached-HEAD / slashed-branch edge rules (G7/G8).
+8. Migration precedence between old and new state during upgrade (R1).
+9. Canonical term: directory name == branch name `<NNN>-<slug>` (I1).
+10. Resolve `issue.md` required-vs-optional contradiction (C2).
+
+## F. What is already solid
+
+- `cleanrooms/<slug>/` as canonical `inquiry_root` (confirmations F1).
+- `project_root` and `inquiry_root` as distinct concepts (F2).
+- `IDLE` as derived, not persisted (F3).
+- Deterministic, branch-first discovery with cwd convenience fallback (F4).
+- `.iq.state.yaml` as the state filename candidate (F5), pending the gitignore
+  decision in C1.
+
+## Recommended next move
+
+Resolve C1 and C2 first, because they change the spec's required-files table and
+the gitignore contract. The remaining gaps (G2–G9, R1) are best closed in PLAN as
+explicit acceptance criteria rather than reopened as free debate.
+
+---
+
+## Resolution status (2026-05-30)
+
+User decisions applied to `confirmations.md` (F6–F17) and the spec.
+
+| Item | Status | Resolution |
+|------|--------|------------|
+| C1 | RESOLVED | Cleanrooms stay tracked (repo preference); ephemeral `.iq.state.yaml` gitignored via `cleanrooms/**/.iq.state.yaml` (F6). |
+| C2 | RESOLVED | `issue.md` is a recommended local mirror of the GitHub issue, generated at bootstrap (F7). |
+| I1 | RESOLVED | Directory name == branch name == `<issue>-<slug>` (F8). |
+| I2 | RESOLVED | IDLE is FSM-only, derived, dispatches DEWEY (F9). |
+| G1 | RESOLVED | Gitignore policy defined in spec §2.4 (F6). |
+| G2 | OPEN → PLAN | Third root `inquiry_cli_root` owns `config.yaml`; exact location is open question #1 (F10). |
+| G3 | RESOLVED (direction) | Extension activation follows `iq state` context resolution (F11). |
+| G4 | RESOLVED | Bootstrap == IDLE→ANALYZE transition; spec §5.5 (F12). |
+| G5/G9 | RESOLVED (analysis) | `status` value set + closure defined; exact wiring → PLAN (F16, spec §5.6). |
+| G6 | OUT OF SCOPE | Metrics deferred; removed from layout/migration (F13). |
+| G7/G8 | RESOLVED | Non-git → hard error; detached HEAD → IDLE; slashes forbidden; spec §5.4 (F17). |
+| R1 | RESOLVED | Breaking change, pre-1.0, no migration window (F14). |
+| R2 | ACCEPTED RISK | Branch/dir desync hardened via tests in EXECUTE (F15). |
+| R3 | NOTED | Mixed visibility documented. |
+| R4 | RESOLVED | Generated index is updated by the process as docs are added. |

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/issue.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/issue.md
@@ -1,0 +1,32 @@
+---
+id: issue-209-reference
+title: "Issue #209 Reference"
+date: 2026-05-30
+status: active
+tags: [issue, reference, architecture, inquiry-root]
+author: socrates
+---
+
+# Issue #209
+
+## Metadata
+
+- Number: 209
+- Title: architecture: make cleanrooms/<slug> the canonical inquiry root with cycle-local state
+- URL: https://github.com/ccisnedev/inquiry/issues/209
+
+## Summary
+
+This cycle focuses on making `cleanrooms/<slug>/` the canonical root of an inquiry while separating that cycle root from `project_root`.
+
+The issue consolidates the main pressures already visible in:
+
+- #150 — `mutations.md` belongs with the active cleanroom
+- #178 — `iq` must stop depending on ambient cwd to resolve context
+- worktree-first usage — ignored runtime files do not carry over across newly created worktrees
+
+## Scope
+
+The issue is about cycle-root architecture and active-cycle resolution.
+
+It is not approval to migrate every adjacent runtime surface in a single step.

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
@@ -17,7 +17,7 @@ hypothesis ledger (H1–H7) as evidence accumulates.
 | H2 | State can be cycle-local with IDLE derived | CONFIRMED | Phase 2: state at `cleanrooms/<branch>/.iq.state.yaml`, IDLE derived from `status: completed`/no-cycle, never persisted; full suite green (393) |
 | H3 | IDLE→ANALYZE is a sufficient bootstrap | CONFIRMED | Phase 3: transition materializes analyze/index.md + confirmations.md + issue.md mirror + `.iq.state.yaml` (status active, state ANALYZE); freshly created cycle resolves as active; suite green (397) |
 | H4 | Cycle runtime and CLI config separate cleanly | CONFIRMED | Phase 4: cycle-scoped `mutations.md` moves to `cleanrooms/<branch>/`; project-scoped `config.yaml` stays at `.inquiry/` (U1); CLI + VS Code extension both resolve cycle-local mutations; metrics writers made dir-self-sufficient; CLI suite green (397) + extension unit suite green (69) |
-| H5 | status lifecycle expressible without persisting IDLE | PENDING | Phase 5 |
+| H5 | status lifecycle expressible without persisting IDLE | CONFIRMED | Phase 5: `active` (update_state non-IDLE), `completed` (update_state→IDLE), `blocked` (pause_analysis/pause_plan effects) fully cover the lifecycle; centralized in `_markStatus`; `load()` derives IDLE for completed+blocked; full suite green (400) |
 | H6 | Discovery degrades safely at the edges | CONFIRMED | Phase 2: no-cycle (non-git / detached HEAD) resolves to derived IDLE without error; load returns IDLE on missing/malformed state |
 | H7 | Extension can follow CLI resolution | PENDING | Phase 7 |
 
@@ -33,7 +33,23 @@ hypothesis ledger (H1–H7) as evidence accumulates.
   keeping that path yields **zero special cases** and the fewest moving parts, which
   is the deciding criterion. `inquiryCliRoot` remains `project_root`; only
   *cycle-scoped* `mutations.md` moves to `cleanrooms/<branch>/`.
-- U2 (status ownership): PENDING — Phase 5.
+- U2 (status ownership): **DECIDED — one effect owns each `status` write.**
+  - `active`: owned by `update_state` — every non-IDLE transition writes `status: active`
+    (already in place since Phase 2).
+  - `completed`: owned by `update_state` when the target is IDLE — `updateState('IDLE')`
+    → `_markCompleted()` (END→IDLE `pr_ready`/`pr_ready_no_evolution`, EVOLUTION→IDLE
+    `finish_evolution` via `close_cycle`). Already in place since Phase 2.
+  - `blocked`: owned by the **`pause_analysis` / `pause_plan`** effects (the CLI side of the
+    `block` event, ANALYZE→IDLE and PLAN→IDLE). These run *after* `update_state` in
+    `executeAll`, so `_markBlocked()` overrides the default `completed` that
+    `updateState('IDLE')` writes. The pause effect is the single owner of the `blocked` write.
+  - Refactor: `_markCompleted`/`_markBlocked` share a private `_markStatus(status)` helper
+    (centralized status mutation, one place).
+  - `load()` derives IDLE for BOTH `completed` and `blocked` (the FSM target of every
+    closing/pausing transition is IDLE; IDLE is never persisted). The `status` value in the
+    file records *why* the cycle left an active phase. A `blocked` cycle is **not closed**
+    (its branch still resolves and its cleanroom artifacts remain on disk for resumption),
+    but its derived FSM phase is IDLE — consistent with the transition contract.
 - U3 (metrics action): PENDING — Phase 8.
 
 ## Phase log
@@ -114,3 +130,21 @@ hypothesis ledger (H1–H7) as evidence accumulates.
 - Tests: `effect_executor_test` reset_mutations/executeAll repointed cycle-local;
   `ape_prompt_test` darwin assertions repointed. CLI suite: **397 green**. `dart analyze` clean.
 - **H4 CONFIRMED**.
+
+### Phase 5 — status lifecycle wiring (active / completed / blocked)
+
+- Decision U2 recorded above (single owner per status write).
+- `lib/modules/ape/inquiry_state.dart`: `load()` now derives IDLE for `status: blocked`
+  as well as `completed` (both target IDLE; IDLE never persisted).
+- `lib/modules/fsm/effect_executor.dart`:
+  - Refactored `_markCompleted()` and new `_markBlocked()` to share a private
+    `_markStatus(status)` (centralized terminal-status write; clears APE; no-op when already
+    at that status).
+  - `executeAll` now handles the `pause_analysis` / `pause_plan` effects (block event,
+    ANALYZE→IDLE / PLAN→IDLE) → `_markBlocked()`. These run *after* `update_state`, so they
+    override the default `completed` that `updateState('IDLE')` writes — the pause effect is
+    the single owner of the `blocked` write.
+- Tests: `inquiry_state_test` "load returns IDLE when cycle status is blocked"; 2
+  `effect_executor_test` block cases (pause_analysis / pause_plan → blocked + derived IDLE).
+  CLI suite: **400 green**. `dart analyze` clean.
+- **H5 CONFIRMED**.

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
@@ -15,7 +15,7 @@ hypothesis ledger (H1–H7) as evidence accumulates.
 |----|-----------|--------|-------------------|
 | H1 | Centralized resolution is behavior-preserving | CONFIRMED | Phase 1: +7 resolver tests green, existing suite unchanged (386 total) |
 | H2 | State can be cycle-local with IDLE derived | CONFIRMED | Phase 2: state at `cleanrooms/<branch>/.iq.state.yaml`, IDLE derived from `status: completed`/no-cycle, never persisted; full suite green (393) |
-| H3 | IDLE→ANALYZE is a sufficient bootstrap | PENDING | Phase 3 |
+| H3 | IDLE→ANALYZE is a sufficient bootstrap | CONFIRMED | Phase 3: transition materializes analyze/index.md + confirmations.md + issue.md mirror + `.iq.state.yaml` (status active, state ANALYZE); freshly created cycle resolves as active; suite green (397) |
 | H4 | Cycle runtime and CLI config separate cleanly | PENDING | Phase 4 |
 | H5 | status lifecycle expressible without persisting IDLE | PENDING | Phase 5 |
 | H6 | Discovery degrades safely at the edges | CONFIRMED | Phase 2: no-cycle (non-git / detached HEAD) resolves to derived IDLE without error; load returns IDLE on missing/malformed state |
@@ -60,3 +60,20 @@ hypothesis ledger (H1–H7) as evidence accumulates.
   branch and write/read cycle-local state. Removed obsolete "activates dewey on IDLE" test
   (dewey now derived). Full suite: **393 green**. `dart analyze` clean.
 - **H2 CONFIRMED**, **H6 CONFIRMED**.
+
+### Phase 3 — Bootstrap on IDLE→ANALYZE
+
+- `lib/modules/fsm/effect_executor.dart`: `openAnalysisContext()` now also writes a
+  best-effort `cleanrooms/<branch>/issue.md` mirror (F7).
+  - New `typedef IssueBodyProvider = String? Function(String issue, String workingDirectory);`
+    injected via the constructor; default runs `gh issue view <n> --json body -q .body`.
+  - Body fetch is **best-effort**: failure/empty → mirror still written with metadata and a
+    placeholder note (non-fatal).
+  - **Idempotent**: existing `issue.md` is never clobbered.
+- The `.iq.state.yaml` (status `active`, state `ANALYZE`) and analyze bootstrap files were
+  already produced by `updateState` + `openAnalysisContext` (Phase 2); Phase 3 closes the gap
+  with the issue mirror and an end-to-end bootstrap assertion.
+- Tests: 3 new `effect_executor_test` cases (mirror with body / null body non-fatal /
+  no-clobber) + 1 `fsm_transition_integration_test` end-to-end bootstrap. Full suite:
+  **397 green**. `dart analyze` clean.
+- **H3 CONFIRMED**.

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
@@ -19,7 +19,7 @@ hypothesis ledger (H1–H7) as evidence accumulates.
 | H4 | Cycle runtime and CLI config separate cleanly | CONFIRMED | Phase 4: cycle-scoped `mutations.md` moves to `cleanrooms/<branch>/`; project-scoped `config.yaml` stays at `.inquiry/` (U1); CLI + VS Code extension both resolve cycle-local mutations; metrics writers made dir-self-sufficient; CLI suite green (397) + extension unit suite green (69) |
 | H5 | status lifecycle expressible without persisting IDLE | CONFIRMED | Phase 5: `active` (update_state non-IDLE), `completed` (update_state→IDLE), `blocked` (pause_analysis/pause_plan effects) fully cover the lifecycle; centralized in `_markStatus`; `load()` derives IDLE for completed+blocked; full suite green (400) |
 | H6 | Discovery degrades safely at the edges | CONFIRMED | Phase 2: no-cycle (non-git / detached HEAD) resolves to derived IDLE without error; load returns IDLE on missing/malformed state |
-| H7 | Extension can follow CLI resolution | PENDING | Phase 7 |
+| H7 | Extension can follow CLI resolution | CONFIRMED | Phase 7: VS Code extension drives off cycle resolution — `resolveStatePath` → `cleanrooms/<branch>/.iq.state.yaml` (null→IDLE); status bar watches `cleanrooms/**/.iq.state.yaml` and re-resolves per refresh; `parseState` derives IDLE for `status: completed`/`blocked`; activationEvents add `workspaceContains:cleanrooms/`; unit suite green (74) + integration green (13) |
 
 ## Decisions
 
@@ -166,3 +166,19 @@ hypothesis ledger (H1–H7) as evidence accumulates.
   (no repo-level state.yaml / mutations.md); idempotency test trimmed to gitignore+config.
   CLI suite: **399 green**. `dart analyze` clean.
 - **H4 CONFIRMED** (init alignment — nothing cycle-scoped scaffolded at repo-level `.inquiry/`).
+
+### Phase 7 — VS Code extension follows cycle resolution
+
+- `src/cycle.ts`: new `resolveStatePath(workspaceFolder)` → `cleanrooms/<branch>/.iq.state.yaml`
+  on a valid branch, else `null` (no git / unborn / detached / slashed branch → caller IDLE).
+- `src/parsers.ts`: `parseState` now reads `status` and derives IDLE for `completed`/`blocked`,
+  mirroring the CLI's `InquiryState.load()` (IDLE never persisted).
+- `src/status-bar.ts`: no longer hardcodes `.inquiry/state.yaml`. `refresh()` re-resolves the
+  cycle state path each time (IDLE when `null`); the `FileSystemWatcher` follows the cycle
+  pattern `cleanrooms/**/.iq.state.yaml`. `toggleEvolution` stays on `.inquiry/config.yaml` (U1).
+- `package.json`: `activationEvents` adds `workspaceContains:cleanrooms/` (keeps `.inquiry/` for config).
+- Tests: `state-parser` +3 (active keeps phase; completed/blocked derive IDLE); `cycle` +2
+  (`resolveStatePath` valid branch / null outside git); status-bar integration repointed to a
+  real git cycle workspace via new `createCycleWorkspace` helper, +1 case (completed→IDLE in bar).
+  Unit suite **74 green**; integration **13 green**; `tsc` clean.
+- **H7 CONFIRMED** (extension resolves cycle state exactly like the CLI; degrades to IDLE at the edges).

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
@@ -1,0 +1,41 @@
+# Mutations — Issue #209
+
+Cycle notebook for EXECUTE. Records baselines, decisions (U1–U3), and the
+hypothesis ledger (H1–H7) as evidence accumulates.
+
+## Baseline (Phase 0)
+
+- Dart SDK 3.11.5 (stable), windows_x64.
+- Full CLI suite green before any change: **379 tests passing**.
+- The existing 379 tests serve as the characterization net for H1.
+
+## Hypothesis ledger
+
+| ID | Statement | Status | Deciding evidence |
+|----|-----------|--------|-------------------|
+| H1 | Centralized resolution is behavior-preserving | CONFIRMED | Phase 1: +7 resolver tests green, existing suite unchanged (386 total) |
+| H2 | State can be cycle-local with IDLE derived | PENDING | Phase 2 |
+| H3 | IDLE→ANALYZE is a sufficient bootstrap | PENDING | Phase 3 |
+| H4 | Cycle runtime and CLI config separate cleanly | PENDING | Phase 4 |
+| H5 | status lifecycle expressible without persisting IDLE | PENDING | Phase 5 |
+| H6 | Discovery degrades safely at the edges | PARTIAL | Phase 1 resolver: outside-git throws, detached HEAD→IDLE, slashed branch rejected |
+| H7 | Extension can follow CLI resolution | PENDING | Phase 7 |
+
+## Decisions
+
+- U1 (config.yaml location): PENDING — Phase 4.
+- U2 (status ownership): PENDING — Phase 5.
+- U3 (metrics action): PENDING — Phase 8.
+
+## Phase log
+
+### Phase 1 — CycleContext resolver (behavior-preserving)
+
+- Added `getProjectRoot` to `lib/src/git_utils.dart` (git `rev-parse --show-toplevel`).
+- Added `lib/src/cycle_context.dart`: `CycleContext` + `CycleResolutionException`.
+  - Resolves `projectRoot`, `branch`, `inquiryRoot` (`cleanrooms/<branch>/`),
+    `inquiryCliRoot`.
+  - `normalizeBranch`: empty/`HEAD` → null (derived IDLE).
+  - Outside git → throws; branch with `/` or `\` → throws.
+- Not yet wired into command paths (deliberately behavior-preserving).
+- Tests: `test/cycle_context_test.dart` (7). Full suite: 386 green. `dart analyze` clean.

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
@@ -50,7 +50,9 @@ hypothesis ledger (H1–H7) as evidence accumulates.
     file records *why* the cycle left an active phase. A `blocked` cycle is **not closed**
     (its branch still resolves and its cleanroom artifacts remain on disk for resumption),
     but its derived FSM phase is IDLE — consistent with the transition contract.
-- U3 (metrics action): PENDING — Phase 8.
+- U3 (metrics action): DECIDED — deferred by design. Keep `.inquiry/metrics*.yaml`
+  unchanged for now; do not repoint or redesign metrics until Inquiry has a real
+  consumer, a stable schema, and a clear scope decision.
 
 ## Phase log
 
@@ -182,3 +184,24 @@ hypothesis ledger (H1–H7) as evidence accumulates.
   real git cycle workspace via new `createCycleWorkspace` helper, +1 case (completed→IDLE in bar).
   Unit suite **74 green**; integration **13 green**; `tsc` clean.
 - **H7 CONFIRMED** (extension resolves cycle state exactly like the CLI; degrades to IDLE at the edges).
+
+### Phase 8 — Metrics surfaces explicitly deferred by design
+
+- Bounded evidence review for this refactor:
+  - Metrics still exist as current runtime surfaces in `effect_executor.dart`
+    (`snapshotMetrics`, `collectMetrics`), prompt context (`prompt.dart`), and
+    FSM assets / evolution instructions.
+  - No new consumer or cycle-root contract in this issue forced a metrics
+    redesign; the cycle-local refactor was fully closed by Phases 1–7.
+- Decision (U3): do **not** repoint metrics into `cleanrooms/<branch>/` and do
+  **not** quarantine or expand them further in #209. They remain at
+  `.inquiry/metrics*.yaml` until Inquiry reaches a more mature stage with:
+  1. a real consumer,
+  2. a stable schema,
+  3. and an explicit scope choice (project-scoped vs cycle-scoped).
+- Implementation: no runtime code changes in Phase 8. The work here is to make
+  the deferral explicit rather than leaving it as accidental ambiguity.
+- Verification: repo search confirmed metrics are still writers/prompts/assets,
+  but no new production consumer in this issue requires redesign before closing
+  the canonical cleanroom-root refactor.
+- **U3 DECIDED** (deferred by design; revisit only when metrics stop being speculative).

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
@@ -16,14 +16,23 @@ hypothesis ledger (H1–H7) as evidence accumulates.
 | H1 | Centralized resolution is behavior-preserving | CONFIRMED | Phase 1: +7 resolver tests green, existing suite unchanged (386 total) |
 | H2 | State can be cycle-local with IDLE derived | CONFIRMED | Phase 2: state at `cleanrooms/<branch>/.iq.state.yaml`, IDLE derived from `status: completed`/no-cycle, never persisted; full suite green (393) |
 | H3 | IDLE→ANALYZE is a sufficient bootstrap | CONFIRMED | Phase 3: transition materializes analyze/index.md + confirmations.md + issue.md mirror + `.iq.state.yaml` (status active, state ANALYZE); freshly created cycle resolves as active; suite green (397) |
-| H4 | Cycle runtime and CLI config separate cleanly | PENDING | Phase 4 |
+| H4 | Cycle runtime and CLI config separate cleanly | CONFIRMED | Phase 4: cycle-scoped `mutations.md` moves to `cleanrooms/<branch>/`; project-scoped `config.yaml` stays at `.inquiry/` (U1); CLI + VS Code extension both resolve cycle-local mutations; metrics writers made dir-self-sufficient; CLI suite green (397) + extension unit suite green (69) |
 | H5 | status lifecycle expressible without persisting IDLE | PENDING | Phase 5 |
 | H6 | Discovery degrades safely at the edges | CONFIRMED | Phase 2: no-cycle (non-git / detached HEAD) resolves to derived IDLE without error; load returns IDLE on missing/malformed state |
 | H7 | Extension can follow CLI resolution | PENDING | Phase 7 |
 
 ## Decisions
 
-- U1 (config.yaml location): PENDING — Phase 4.
+- U1 (config.yaml location): **DECIDED — option (b): keep `.inquiry/config.yaml`
+  at `project_root`.** Rationale: `config.yaml` holds *project-scoped* settings
+  (the `evolution.enabled` toggle), not cycle runtime, so leaving it at repo-level
+  `.inquiry/` does **not** violate H4 ("nothing *cycle-scoped* lives at repo-level
+  `.inquiry/`"). Experiment outcome: enumerating the three consumers —
+  CLI `_readEvolutionEnabled` (`state.dart`), `init` (`init.dart`), VS Code
+  `toggleEvolution` (`commands.ts`) — they all already resolve `.inquiry/config.yaml`;
+  keeping that path yields **zero special cases** and the fewest moving parts, which
+  is the deciding criterion. `inquiryCliRoot` remains `project_root`; only
+  *cycle-scoped* `mutations.md` moves to `cleanrooms/<branch>/`.
 - U2 (status ownership): PENDING — Phase 5.
 - U3 (metrics action): PENDING — Phase 8.
 
@@ -77,3 +86,31 @@ hypothesis ledger (H1–H7) as evidence accumulates.
   no-clobber) + 1 `fsm_transition_integration_test` end-to-end bootstrap. Full suite:
   **397 green**. `dart analyze` clean.
 - **H3 CONFIRMED**.
+
+### Phase 4 — Separate cycle mutations (cycle-local) from config (CLI root)
+
+- `lib/modules/fsm/effect_executor.dart`:
+  - `resetMutations()` now writes to `_mutationsPath()` instead of `.inquiry/mutations.md`.
+  - New `_mutationsPath()`: `cleanrooms/<branch>/mutations.md` when on a born branch,
+    else falls back to `.inquiry/mutations.md` (no-cycle edge).
+  - **Regression fix**: `resetMutations` previously created `.inquiry/` as a side effect that
+    `snapshotMetrics`/`collectMetrics` implicitly relied on. With mutations now cycle-local,
+    both metrics writers `createSync(recursive: true)` their `.inquiry/` dir before writing.
+    (Metrics *location* unchanged — Phase 8 territory; this only restores the dir guarantee.)
+- `lib/modules/ape/commands/prompt.dart`: darwin runtime context `mutations_file` →
+  `cleanrooms/<branch>/mutations.md`, `state_file` → `cleanrooms/<branch>/.iq.state.yaml`.
+  `metrics_*` paths stay `.inquiry/...` (Phase 8).
+- VS Code extension (per user requirement — the add-mutation command must target the
+  cycle-local ledger):
+  - New `code/vscode/src/cycle.ts`: `resolveBranch(workspaceFolder)` (git
+    `rev-parse --abbrev-ref HEAD`; null on no-repo / `HEAD` / slashed branch) and
+    `resolveMutationsDir(workspaceFolder)` → `cleanrooms/<branch>` or `.inquiry` fallback.
+  - `extension.ts`: `inquiry.addMutation` now resolves `resolveMutationsDir(workspaceFolder)`
+    at invocation time instead of the fixed `.inquiry` path. `toggleEvolution` still targets
+    `.inquiry/config.yaml` (U1).
+  - `commands.ts`: `addMutation` `mkdirSync(recursive)` before append (robust when the
+    cycle dir is resolved fresh).
+  - Tests: new `test/unit/cycle.test.ts` (5 cases, real git repos). Extension unit suite: **69 green**.
+- Tests: `effect_executor_test` reset_mutations/executeAll repointed cycle-local;
+  `ape_prompt_test` darwin assertions repointed. CLI suite: **397 green**. `dart analyze` clean.
+- **H4 CONFIRMED**.

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
@@ -14,11 +14,11 @@ hypothesis ledger (H1–H7) as evidence accumulates.
 | ID | Statement | Status | Deciding evidence |
 |----|-----------|--------|-------------------|
 | H1 | Centralized resolution is behavior-preserving | CONFIRMED | Phase 1: +7 resolver tests green, existing suite unchanged (386 total) |
-| H2 | State can be cycle-local with IDLE derived | PENDING | Phase 2 |
+| H2 | State can be cycle-local with IDLE derived | CONFIRMED | Phase 2: state at `cleanrooms/<branch>/.iq.state.yaml`, IDLE derived from `status: completed`/no-cycle, never persisted; full suite green (393) |
 | H3 | IDLE→ANALYZE is a sufficient bootstrap | PENDING | Phase 3 |
 | H4 | Cycle runtime and CLI config separate cleanly | PENDING | Phase 4 |
 | H5 | status lifecycle expressible without persisting IDLE | PENDING | Phase 5 |
-| H6 | Discovery degrades safely at the edges | PARTIAL | Phase 1 resolver: outside-git throws, detached HEAD→IDLE, slashed branch rejected |
+| H6 | Discovery degrades safely at the edges | CONFIRMED | Phase 2: no-cycle (non-git / detached HEAD) resolves to derived IDLE without error; load returns IDLE on missing/malformed state |
 | H7 | Extension can follow CLI resolution | PENDING | Phase 7 |
 
 ## Decisions
@@ -39,3 +39,24 @@ hypothesis ledger (H1–H7) as evidence accumulates.
   - Outside git → throws; branch with `/` or `\` → throws.
 - Not yet wired into command paths (deliberately behavior-preserving).
 - Tests: `test/cycle_context_test.dart` (7). Full suite: 386 green. `dart analyze` clean.
+
+### Phase 2 — Cycle-local state with derived IDLE
+
+- `lib/modules/ape/inquiry_state.dart`: rewritten.
+  - `const kStateFileName = '.iq.state.yaml';`
+  - `stateFileFor(workingDir)`: resolves cycle via `CycleContext`; returns
+    `<inquiryRoot>/.iq.state.yaml` or null (no cycle).
+  - `loadFrom(path)`: pure file read; missing/malformed → `InquiryState(state: 'IDLE')`.
+  - `load(workingDir)`: no cycle → IDLE; `status: completed` → derived IDLE (issue null).
+  - `saveTo`/`save`: write `version/state/issue/prompt_fragment_id/status/ape/created_at/updated_at`.
+  - Added fields: `version`, `status`, `createdAt`, `updatedAt`; `copyWith` with `clearApe`.
+- `lib/modules/fsm/effect_executor.dart`: `updateState('IDLE')` now `_markCompleted()`
+  (sets `status: completed`, clears APE) — IDLE is **never persisted**. dewey on IDLE is
+  **derived** at query time, not written.
+- `lib/modules/fsm/commands/transition.dart`: `_resolveIssue`/`_isIssueSelected`/
+  `_loadCurrentState` now read via `InquiryState.load` (cycle-local).
+- mutations/metrics/config stay at `.inquiry/` (deferred to Phase 4/8).
+- Tests: added `test/support/cycle_fixture.dart`; repaired legacy tests to git-init a born
+  branch and write/read cycle-local state. Removed obsolete "activates dewey on IDLE" test
+  (dewey now derived). Full suite: **393 green**. `dart analyze` clean.
+- **H2 CONFIRMED**, **H6 CONFIRMED**.

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
@@ -205,3 +205,54 @@ hypothesis ledger (H1–H7) as evidence accumulates.
   but no new production consumer in this issue requires redesign before closing
   the canonical cleanroom-root refactor.
 - **U3 DECIDED** (deferred by design; revisit only when metrics stop being speculative).
+
+### Final QA — gate before END
+
+- Full CLI suite: **399 green** after the final release edits (`dart test`).
+- VS Code extension suite: **74 unit green** + **13 integration green**.
+- Static checks:
+  - `dart analyze`: clean.
+  - `dart format --set-exit-if-changed lib/modules/fsm/effect_executor.dart lib/src/version.dart`:
+    clean (0 changed).
+  - `version_sync_test.dart`: **3 green** after bumping the mandatory version triad to `0.6.0`.
+- Packaged manual smoke (`code/cli/scripts/build.ps1` + `build/bin/inquiry.exe`):
+  - fresh temp repo: `init` succeeded; `fsm state` resolved `State: IDLE`.
+  - cycle start on branch `209-smoke`: `fsm transition --event start_analyze --issue 209`
+    succeeded; `cleanrooms/209-smoke/.iq.state.yaml` created; `.inquiry/state.yaml`
+    remained absent.
+  - resolution from repo root and `cleanrooms/209-smoke/analyze/`: same `ANALYZE`
+    state / issue output.
+  - `main` with historical cleanrooms present: derived `IDLE`.
+- Repo-wide reader check:
+  - no `.inquiry/state.yaml` matches remain in production code under `code/cli/lib/`
+    or `code/vscode/src/`.
+  - remaining `.inquiry/` surfaces in production are intentional: project-scoped
+    `config.yaml`, explicit deferred metrics files, and the no-cycle mutations fallback.
+- Release notes / public surface:
+  - version bumped to **0.6.0** in `pubspec.yaml`, `version.dart`, and the site badge.
+  - `CHANGELOG.md` updated for #209.
+  - site copy for `iq init` corrected: it no longer claims repo-level state/mutations scaffolding.
+
+### Final review — H1 to H7, U1 to U3
+
+- **H1 CONFIRMED** — `cycle_context_test.dart` (+7) held behavior steady while the full suite
+  stayed green at Phase 1 (**386**).
+- **H2 CONFIRMED** — cycle-local `.iq.state.yaml` and derived IDLE were locked by the
+  Phase 2 state/transition test repairs; full suite green at **393**.
+- **H3 CONFIRMED** — the IDLE→ANALYZE integration bootstrap materialized the full cycle
+  (`analyze/index.md`, `confirmations.md`, `issue.md`, active `.iq.state.yaml`) and the
+  suite stayed green at **397**.
+- **H4 CONFIRMED** — mutations moved cycle-local while `config.yaml` stayed project-scoped;
+  `iq init` was later aligned to that same split; CLI and extension both validated the model.
+- **H5 CONFIRMED** — `active` / `completed` / `blocked` lifecycle was locked by
+  `inquiry_state_test.dart` + `effect_executor_test.dart`; `load()` derives IDLE for the
+  terminal statuses and the full suite reached **400 green** in Phase 5.
+- **H6 CONFIRMED** — no-cycle and malformed/missing-state edges safely degrade to IDLE;
+  this was exercised in the Phase 2 state-loading tests and re-confirmed in the packaged
+  manual smoke on `main` with historical cleanrooms.
+- **H7 CONFIRMED** — the extension now resolves the same cycle-local state path as the CLI;
+  Phase 7 closed with **74 unit green** + **13 integration green**.
+- **U1 DECIDED** — `.inquiry/config.yaml` remains project-scoped.
+- **U2 DECIDED** — status ownership is centralized: non-IDLE `update_state` writes `active`,
+  `update_state('IDLE')` writes `completed`, pause effects write `blocked`.
+- **U3 DECIDED** — metrics are deferred by design; no relocation or redesign in #209.

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/mutations.md
@@ -148,3 +148,21 @@ hypothesis ledger (H1–H7) as evidence accumulates.
   `effect_executor_test` block cases (pause_analysis / pause_plan → blocked + derived IDLE).
   CLI suite: **400 green**. `dart analyze` clean.
 - **H5 CONFIRMED**.
+
+### Phase 6 — `iq init` + `.gitignore` aligned with cycle-local model
+
+- `lib/modules/global/commands/init.dart`:
+  - Removed `_ensureStateYaml` and `_ensureMutationsMd` — init no longer scaffolds
+    repo-level `.inquiry/state.yaml` or `.inquiry/mutations.md` (cycle runtime is
+    materialized per cycle under `cleanrooms/<branch>/` by the FSM).
+  - `_ensureGitignore` now ensures **two** entries idempotently: `.inquiry/` and
+    `cleanrooms/**/.iq.state.yaml` (F6 — derived cycle state never tracked).
+  - `_ensureConfigYaml` keeps `.inquiry/config.yaml` (project-scoped, U1) and now creates
+    `.inquiry/` itself when absent (previously relied on the removed state step).
+  - Steps renumbered 1–4; doc comment updated.
+- Real repo `.gitignore`: added `cleanrooms/**/.iq.state.yaml` (no state file was tracked).
+- Tests: removed obsolete `.inquiry/state.yaml` (2) and `.inquiry/mutations.md` (2) groups;
+  added `ignores cycle-local state files under cleanrooms/` + a `cycle-local model` group
+  (no repo-level state.yaml / mutations.md); idempotency test trimmed to gitignore+config.
+  CLI suite: **399 green**. `dart analyze` clean.
+- **H4 CONFIRMED** (init alignment — nothing cycle-scoped scaffolded at repo-level `.inquiry/`).

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/plan.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/plan.md
@@ -275,15 +275,18 @@ outputs from Phase 0 preserved for equivalent scenarios.
 
 **Goal:** keep metrics out of scope without leaving broken reads.
 
-- **Decision (U3):** record the chosen action (repoint reads to new state path
-  **or** quarantine metrics effects behind `evolution.enabled`).
-- **Red:** a test pinning the chosen behavior (e.g., metrics effect is a no-op
-  when evolution disabled, and does not read removed `.inquiry/state.yaml`).
-- **Green:** apply the minimal change to `effect_executor` and
-  `assets/fsm/states/evolution.yaml`.
+- **Decision (U3):** defer metrics by design. Do not repoint or redesign the
+  metrics surfaces in this refactor; keep the existing `.inquiry/metrics*.yaml`
+  behavior until Inquiry has a real consumer, a stable schema, and a clear scope
+  decision (project-scoped vs cycle-scoped).
+- **Red:** bounded evidence only — confirm the current repo still has writers /
+  prompts / contracts for metrics, but no new cycle-root requirement that forces
+  a design decision here.
+- **Green:** record the deferral explicitly in the hypothesis ledger and phase
+  log; leave runtime code unchanged.
 
-**Verification:** test green; full suite green.
-**Commit:** `chore(cli): quarantine deferred metrics surfaces (#209)`
+**Verification:** ledger + plan updated consistently; runtime code unchanged.
+**Commit:** `chore(cli): defer metrics surfaces by design (#209)`
 
 ---
 

--- a/cleanrooms/209-cleanroom-canonical-inquiry-root/plan.md
+++ b/cleanrooms/209-cleanroom-canonical-inquiry-root/plan.md
@@ -1,0 +1,344 @@
+---
+id: plan
+title: "Execution Plan — Canonical Inquiry Root (Scientific / TDD)"
+date: 2026-05-30
+status: draft
+tags: [plan, tdd, experiment, architecture, inquiry-root]
+author: descartes
+---
+
+# Execution Plan — Canonical Inquiry Root
+
+## 0. Framing
+
+This plan implements the diagnosis in
+[diagnosis.md](diagnosis.md) and the confirmed decisions in
+[confirmations.md](confirmations.md) (F6–F17), refining the draft in
+[canonical-cycle-root-spec.md](canonical-cycle-root-spec.md).
+
+It is structured as a **controlled experiment**, not just a task list. The
+refactor carries hypotheses that must be confirmed or refuted by tests, and
+uncertainties that must be resolved by evidence. Every phase follows **TDD**
+(red → green → refactor), ends with a **rigorous QA gate**, and only then a
+**commit**. A **final full-suite QA** closes the cycle.
+
+### Method
+
+- Each phase states the hypothesis it tests and its falsification criterion.
+- Tests are written **before** implementation (red), then made green.
+- A phase is "done" only when its QA gate passes *and* the full existing suite
+  stays green (no regression budget).
+- Commits are per-phase, conventional, and never use `--no-verify`.
+
+### Non-negotiable constraints (from PLAN operational contract)
+
+- No code edits during PLAN. This document is the deliverable.
+- The plan must include a final step that runs the **entire** project test
+  suite, not only phase-specific tests.
+- Each phase has explicit verification criteria.
+- User approval is required before transitioning to EXECUTE.
+
+---
+
+## 1. Hypotheses
+
+> Each hypothesis is falsifiable. The paired test is the instrument.
+
+- **H1 — Centralized resolution is behavior-preserving.**
+  A single `CycleContext` resolver can replace manually threaded
+  `workingDirectory` path-building (`p.join(workingDirectory, '.inquiry', …)`)
+  without changing any existing observable behavior.
+  *Falsified if* any existing test changes meaning or the characterization suite
+  diverges after introducing the resolver while still pointing at old paths.
+
+- **H2 — State can be cycle-local with IDLE derived.**
+  Active FSM state can live in `cleanrooms/<branch>/.iq.state.yaml`, and `IDLE`
+  can be returned purely by *absence of resolution* (never persisted), while
+  `iq fsm state` and `iq fsm transition` keep their contracts.
+  *Falsified if* any state transition needs a persisted IDLE record, or if
+  discovery cannot deterministically distinguish active vs idle.
+
+- **H3 — The IDLE→ANALYZE transition is a sufficient bootstrap.**
+  Materializing the cleanroom, `issue.md` mirror, initial analyze files, and the
+  first `.iq.state.yaml` entirely within the IDLE→ANALYZE transition produces a
+  valid, resolvable active cycle with no separate bootstrap command.
+  *Falsified if* a freshly bootstrapped cycle fails discovery or precondition
+  checks.
+
+- **H4 — Cycle runtime and CLI config separate cleanly.**
+  `mutations.md` (cycle-local) and `config.yaml` (`inquiry_cli_root`) can be
+  separated so that nothing cycle-scoped lives at repo-level `.inquiry/`.
+  *Falsified if* any consumer needs config and cycle runtime in the same root.
+
+- **H5 — `status` lifecycle is expressible without persisting IDLE.**
+  `active` / `completed` / `blocked` fully describe a cycle's lifecycle, with
+  "closed" meaning *non-resolving branch and/or `status: completed`*.
+  *Falsified if* a real lifecycle state cannot be represented by this set.
+
+- **H6 — Discovery degrades safely at the edges.**
+  Outside git → hard error; detached HEAD → derived IDLE; slashed branch names
+  are forbidden by convention and cannot produce nested cleanroom paths.
+  *Falsified if* any edge yields a wrong active cycle or a silent crash.
+
+- **H7 — The extension can follow CLI resolution.**
+  VS Code activation and status bar can be driven by the same context resolution
+  (cleanrooms-based, `.iq.state.yaml`) instead of `workspaceContains:.inquiry/`.
+  *Falsified if* the extension cannot detect an active cycle without `.inquiry/`.
+
+---
+
+## 2. Uncertainties to resolve (with experiments)
+
+- **U1 — `inquiry_cli_root` location for `config.yaml`.**
+  Candidates: (a) repo-level tracked `inquiry.yaml` at `project_root`;
+  (b) keep a minimal repo-level `.inquiry/config.yaml`; (c) user-level config.
+  *Experiment:* enumerate every reader/writer of `config.yaml`
+  (CLI `_readEvolutionEnabled`, `init`, VS Code `toggleEvolution`) and pick the
+  location that keeps all three consistent with the fewest special cases.
+  *Decision recorded in Phase 4.*
+
+- **U2 — `status` transition wiring.**
+  Who sets `completed`/`blocked`, and at which effect/transition.
+  *Experiment:* trace `close_cycle`, END→IDLE, EVOLUTION→IDLE, and the `block`
+  event; choose the single effect that owns each write.
+  *Decision recorded in Phase 5.*
+
+- **U3 — Metrics surfaces during a breaking change.**
+  Metrics are out of scope (F13) but `evolution.yaml` and `effect_executor`
+  still read `.inquiry/state.yaml` / write `.inquiry/metrics*.yaml`.
+  *Experiment:* confirm metrics are not consumed by any passing test or shipped
+  feature; choose minimal action (repoint reads to new state path **or**
+  quarantine the effects behind `evolution.enabled`) that avoids breakage
+  without investing in metrics. *Decision recorded in Phase 8.*
+
+---
+
+## 3. Surfaces in scope (from the diagnosis map)
+
+| Surface | File | Action |
+|---|---|---|
+| State load/save | `code/cli/lib/modules/ape/inquiry_state.dart` | Repoint to `.iq.state.yaml`; add `status`, `created_at`, `updated_at`, `version` |
+| State query | `code/cli/lib/modules/fsm/commands/state.dart` | Use resolver; derive IDLE; read config from `inquiry_cli_root` |
+| Transition | `code/cli/lib/modules/fsm/commands/transition.dart` | Use resolver; bootstrap on IDLE→ANALYZE; status writes |
+| Effects | `code/cli/lib/modules/fsm/effect_executor.dart` | `update_state`, `close_cycle`, `reset_mutations` cycle-local |
+| Prompt context | `code/cli/lib/modules/ape/commands/prompt.dart` | Cycle-local `mutations.md`/state paths |
+| Init | `code/cli/lib/modules/global/commands/init.dart` | New gitignore rule; stop creating repo-level state/mutations |
+| Branch/path | `code/cli/lib/src/git_utils.dart` | Extend with toplevel + edge handling; back `CycleContext` |
+| Evolution asset | `code/cli/assets/fsm/states/evolution.yaml` | Repoint or quarantine (U3) |
+| Extension | `code/vscode/src/{extension,status-bar,commands,parsers}.ts` | Resolution-driven activation + paths |
+
+Out of scope: building a metrics system (F13); migration/back-compat shims
+(F14 — clean breaking change, pre-1.0).
+
+---
+
+## 4. Phases
+
+> Every phase: write failing tests → implement → refactor → QA gate → commit.
+> "Full suite" = `dart test` for the CLI package and the extension test runner.
+
+### Phase 0 — Baseline & characterization
+
+**Goal:** lock a green baseline and capture current behavior so H1 can be judged.
+
+- Run the full CLI suite and extension suite; record pass counts.
+- Add characterization tests (if missing) that assert current observable
+  outputs of `iq fsm state` and `iq fsm transition` for IDLE and a started
+  cycle, so later phases can prove behavior preservation.
+
+**QA gate:** full suite green; baseline counts recorded in `mutations.md`.
+**Commit:** `test: characterize fsm state/transition baseline (#209)`
+
+### Phase 1 — `CycleContext` resolver (H1)
+
+**Goal:** introduce one resolver for `project_root`, current `branch`,
+`inquiry_root` (`cleanrooms/<branch>/`), `inquiry_cli_root`, and derived IDLE —
+**still pointing at current paths** so behavior is unchanged.
+
+- **Red:** unit tests for the resolver:
+  - resolves `project_root` via `git rev-parse --show-toplevel`
+  - resolves branch via `getCurrentBranch`
+  - computes `inquiry_root` = `cleanrooms/<branch>/`
+  - outside git → throws explicit error (H6)
+  - detached HEAD (`HEAD`) → resolves to derived IDLE (H6)
+  - rejects branch names containing `/` (H6)
+- **Green:** implement `CycleContext` in the CLI, backed by `git_utils`.
+- **Refactor:** thread `CycleContext` through the `*Input` classes without
+  changing target paths yet.
+
+**Verification:** new resolver tests green; **all existing tests unchanged and
+green** (this is the H1 instrument).
+**Commit:** `feat(cli): add CycleContext resolver, behavior-preserving (#209)`
+
+### Phase 2 — Cycle-local `.iq.state.yaml` + derived IDLE (H2, H6)
+
+**Goal:** move active state to `cleanrooms/<branch>/.iq.state.yaml`; make IDLE
+the absence of resolution.
+
+- **Red:** tests for
+  - `InquiryState.load` from cycle-local path; missing file → derived IDLE
+  - new schema fields: `version`, `status`, `created_at`, `updated_at`
+  - `iq fsm state` returns IDLE (DEWEY) when no cleanroom/state resolves
+  - discovery: branch match → active; cwd-inside-cleanroom convenience → active;
+    historical cleanrooms on `main` → IDLE
+- **Green:** update `inquiry_state.dart`, `state.dart`, `effect_executor`
+  `update_state`/`close_cycle` to the cycle-local path via `CycleContext`.
+- **Refactor:** remove repo-level `.inquiry/state.yaml` reads/writes.
+
+**Verification:** new tests green; updated existing tests green; characterization
+outputs from Phase 0 preserved for equivalent scenarios.
+**Commit:** `feat(cli): move FSM state to cycle-local .iq.state.yaml (#209)`
+
+### Phase 3 — Bootstrap on IDLE→ANALYZE (H3)
+
+**Goal:** the IDLE→ANALYZE transition materializes the full cycle.
+
+- **Red:** transition tests asserting that after IDLE→ANALYZE:
+  - `cleanrooms/<branch>/` exists with `analyze/index.md`, `analyze/confirmations.md`
+  - `issue.md` mirror is written (recommended, F7)
+  - `.iq.state.yaml` exists with `status: active`, `fsm_state: ANALYZE`
+  - the freshly created cycle passes discovery and ANALYZE preconditions
+- **Green:** extend the transition / `open_analysis_context` effect to bootstrap;
+  fetch issue body for `issue.md` (best-effort; absence is non-fatal).
+- **Refactor:** ensure idempotency (re-running does not clobber existing files).
+
+**Verification:** bootstrap tests green; full suite green.
+**Commit:** `feat(cli): bootstrap cycle on IDLE→ANALYZE transition (#209)`
+
+### Phase 4 — Separate cycle runtime from CLI config (H4, U1)
+
+**Goal:** `mutations.md` cycle-local; `config.yaml` at `inquiry_cli_root`.
+
+- **Decision (U1):** record the chosen `config.yaml` location and rationale in
+  `mutations.md` before implementing.
+- **Red:** tests for
+  - `mutations.md` resolved at `cleanrooms/<branch>/mutations.md`
+  - `reset_mutations` writes cycle-local
+  - prompt context (`prompt.dart`) injects cycle-local mutations/state paths
+  - `_readEvolutionEnabled` reads config from `inquiry_cli_root`
+- **Green:** update `effect_executor`, `prompt.dart`, `state.dart`.
+- **Refactor:** delete repo-level mutations path usage.
+
+**Verification:** new + existing tests green; full suite green.
+**Commit:** `feat(cli): separate cycle mutations from CLI config root (#209)`
+
+### Phase 5 — `status` lifecycle wiring (H5, U2)
+
+**Goal:** implement `active` / `completed` / `blocked`.
+
+- **Decision (U2):** record which effect owns each `status` write.
+- **Red:** tests asserting
+  - new cycle → `status: active`
+  - END→IDLE and EVOLUTION→IDLE → `status: completed`
+  - `block` event → `status: blocked`
+  - a `completed` cycle no longer resolves as active (IDLE returned)
+- **Green:** wire status writes into the owning effects/transitions.
+- **Refactor:** centralize status mutation in one place.
+
+**Verification:** lifecycle tests green; full suite green.
+**Commit:** `feat(cli): add cycle status lifecycle (active/completed/blocked) (#209)`
+
+### Phase 6 — `init` and `.gitignore` (H4 cont.)
+
+**Goal:** align `iq init` with the new model.
+
+- **Red:** `init_command_test` updates:
+  - `.gitignore` contains `cleanrooms/**/.iq.state.yaml` (F6)
+  - `init` no longer creates repo-level `.inquiry/state.yaml` or `mutations.md`
+  - `config.yaml` created at `inquiry_cli_root`
+  - `cleanrooms/` still created
+- **Green:** update `init.dart` (`_ensureGitignore`, remove state/mutations
+  scaffolding, relocate config).
+- **Refactor:** simplify init steps.
+
+**Verification:** init tests green; full suite green.
+**Commit:** `feat(cli): align iq init with cycle-local model (#209)`
+
+### Phase 7 — VS Code extension follows resolution (H7)
+
+**Goal:** activation + status bar driven by resolution, not `.inquiry/`.
+
+- **Red:** extension tests:
+  - activation triggers on a workspace with `cleanrooms/` (replace
+    `workspaceContains:.inquiry/`)
+  - status bar reads `cleanrooms/<branch>/.iq.state.yaml`; IDLE when none
+  - `addMutation` targets cycle-local `mutations.md`
+  - `toggleEvolution` targets the new `config.yaml` location
+- **Green:** update `extension.ts`, `status-bar.ts`, `commands.ts`, `parsers.ts`,
+  and `package.json` `activationEvents`.
+- **Refactor:** share a single path-resolution helper in TS.
+
+**Verification:** extension test suite green.
+**Commit:** `feat(vscode): drive activation/status from cycle resolution (#209)`
+
+### Phase 8 — Metrics surfaces decision (U3)
+
+**Goal:** keep metrics out of scope without leaving broken reads.
+
+- **Decision (U3):** record the chosen action (repoint reads to new state path
+  **or** quarantine metrics effects behind `evolution.enabled`).
+- **Red:** a test pinning the chosen behavior (e.g., metrics effect is a no-op
+  when evolution disabled, and does not read removed `.inquiry/state.yaml`).
+- **Green:** apply the minimal change to `effect_executor` and
+  `assets/fsm/states/evolution.yaml`.
+
+**Verification:** test green; full suite green.
+**Commit:** `chore(cli): quarantine deferred metrics surfaces (#209)`
+
+---
+
+## 5. Final rigorous QA (cycle gate)
+
+Run as one block before END:
+
+1. **Full CLI suite:** `dart test` (entire package, not phase subsets) — all green.
+2. **Extension suite:** run the VS Code extension tests — all green.
+3. **Static checks:** `dart analyze` clean; `dart format --set-exit-if-changed`.
+4. **Manual smoke (documented in `mutations.md`):**
+   - fresh repo: `iq init` → `iq fsm state` returns IDLE
+   - start a cycle → `.iq.state.yaml` created, `.inquiry/state.yaml` absent
+   - run `iq` from a sub-cwd and from repo root → same resolved state
+   - on `main` with historical cleanrooms → IDLE
+5. **Version discipline (mandatory):** bump `code/cli/pubspec.yaml`,
+   `code/cli/lib/src/version.dart`, `code/site/index.html` badge; update CHANGELOG;
+   confirm `version_sync_test.dart` passes.
+6. **Hypothesis ledger:** in `mutations.md`, mark each of H1–H7 as
+   CONFIRMED/REFUTED with the test that decided it, and record U1–U3 outcomes.
+
+A red result at any step blocks END.
+
+---
+
+## 6. Dependency order & rationale
+
+```
+Phase 0 (baseline)
+   └─ Phase 1 (resolver, no behavior change)   ← enables everything
+        └─ Phase 2 (state cycle-local + derived IDLE)
+             ├─ Phase 3 (bootstrap)            ← needs cycle-local state
+             ├─ Phase 4 (mutations/config split)
+             │     └─ Phase 6 (init alignment)
+             └─ Phase 5 (status lifecycle)
+                  └─ Phase 7 (extension)        ← reads new state shape
+                       └─ Phase 8 (metrics decision)
+                            └─ Final QA
+```
+
+Phase 1 is deliberately behavior-preserving so H1 isolates "did centralizing
+resolution change anything?" from "did moving paths change anything?" (Phase 2).
+This keeps each hypothesis independently falsifiable.
+
+## 7. Risks & mitigations
+
+- **R2 (branch/dir desync):** hardened by Phase 2 discovery tests and the final
+  smoke test; documented as accepted operational risk (F15).
+- **Breaking change blast radius:** mitigated by per-phase QA gates and the
+  Phase 0 characterization net; pre-1.0 with no external users (F14).
+- **Hidden `.inquiry/` reader:** mitigated by a repo-wide search for
+  `.inquiry/` literals as part of Final QA step 3.
+
+## 8. Open items deferred to EXECUTE decisions
+
+- U1 (config location) → decided and recorded in Phase 4.
+- U2 (status ownership) → decided and recorded in Phase 5.
+- U3 (metrics action) → decided and recorded in Phase 8.

--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.6.0]
+### Breaking changes
+- **Canonical cycle runtime root**: active cycle state now persists at `cleanrooms/<branch>/.iq.state.yaml`, and cycle mutations now resolve to `cleanrooms/<branch>/mutations.md`; repo-level `.inquiry/state.yaml` is no longer the canonical runtime state surface (#209)
+- **`iq init` cycle-local alignment**: init no longer scaffolds repo-level `.inquiry/state.yaml` or `.inquiry/mutations.md`; it keeps project-scoped `.inquiry/config.yaml`, deploys the repo agent, and ensures `cleanrooms/**/.iq.state.yaml` stays ignored (#209)
+
+### Changed
+- **Explicit cycle status lifecycle**: cycle state now records `active`, `completed`, or `blocked`, while `IDLE` remains derived; completed and blocked cycles reload as derived `IDLE` instead of persisting `IDLE` directly (#209)
+- **VS Code extension cycle resolution**: activation/status handling now follows cleanroom-local cycle resolution and watches `cleanrooms/**/.iq.state.yaml` instead of the old repo-level state path (#209)
+- **Metrics scope decision**: metrics surfaces remain at `.inquiry/metrics*.yaml` for now and are explicitly deferred by design until Inquiry has a real consumer, a stable schema, and an explicit scope choice (#209)
+
 ## [0.5.3]
 ### Changed
 - **ANALYZE contract ownership**: ANALYZE now owns visibility, participation, required artifacts, and completion proof through the FSM state contract instead of leaking those responsibilities into SOCRATES or generic scheduler assumptions (#180)

--- a/code/cli/lib/modules/ape/commands/prompt.dart
+++ b/code/cli/lib/modules/ape/commands/prompt.dart
@@ -106,14 +106,13 @@ class ApePromptCommand implements Command<ApePromptInput, ApePromptOutput> {
     if (input.name == null || input.name!.trim().isEmpty) {
       throw CommandException(
         code: 'MISSING_NAME',
-        message: 'Missing required flag --name. Usage: iq ape prompt --name <name>',
+        message:
+            'Missing required flag --name. Usage: iq ape prompt --name <name>',
         exitCode: ExitCode.validationFailed,
       );
     }
     final inquiry = InquiryState.load(input.workingDirectory);
-    final currentState = FsmState.fromValue(
-      inquiry.state.trim().toUpperCase(),
-    );
+    final currentState = FsmState.fromValue(inquiry.state.trim().toUpperCase());
 
     // Verify the APE exists
     final yamlPath = _resolveApePath(input.name!);
@@ -131,7 +130,8 @@ class ApePromptCommand implements Command<ApePromptInput, ApePromptOutput> {
     if (!activeApes.contains(input.name!)) {
       throw CommandException(
         code: 'APE_NOT_ACTIVE',
-        message: '"${input.name!}" is not active in state '
+        message:
+            '"${input.name!}" is not active in state '
             '${currentState.value}. Active APEs: ${activeApes.join(', ')}',
         exitCode: ExitCode.conflict,
       );
@@ -203,8 +203,7 @@ class ApePromptCommand implements Command<ApePromptInput, ApePromptOutput> {
   /// Resolves dynamic context paths per APE and FSM state.
   Map<String, String>? _resolveContext(
     String apeName,
-    String? subState,
-    {
+    String? subState, {
     required OperationalContract operationalContract,
   }) {
     final context = <String, String>{};
@@ -258,8 +257,8 @@ class ApePromptCommand implements Command<ApePromptInput, ApePromptOutput> {
           'diagnosis_file': '${analyzeDir}diagnosis.md',
           'plan_file': 'cleanrooms/$branch/plan.md',
           'retrospective_file': 'cleanrooms/$branch/retrospective.md',
-          'mutations_file': '.inquiry/mutations.md',
-          'state_file': '.inquiry/state.yaml',
+          'mutations_file': 'cleanrooms/$branch/mutations.md',
+          'state_file': 'cleanrooms/$branch/.iq.state.yaml',
           'metrics_snapshot_file': '.inquiry/metrics_snapshot.yaml',
           'metrics_file': '.inquiry/metrics.yaml',
           'output_dir': 'cleanrooms/$branch/',
@@ -275,5 +274,4 @@ class ApePromptCommand implements Command<ApePromptInput, ApePromptOutput> {
     }
     return p.join(input.workingDirectory, 'assets', 'apes', '$name.yaml');
   }
-
 }

--- a/code/cli/lib/modules/ape/inquiry_state.dart
+++ b/code/cli/lib/modules/ape/inquiry_state.dart
@@ -122,14 +122,15 @@ class InquiryState {
   /// Reads the active cycle state for [workingDirectory].
   ///
   /// Returns derived IDLE when no cycle resolves, the file is missing, or the
-  /// cycle's `status` is `completed`.
+  /// cycle's `status` is `completed` or `blocked` (every closing/pausing
+  /// transition targets IDLE, which is never persisted).
   static InquiryState load(String workingDirectory) {
     final path = stateFileFor(workingDirectory);
     if (path == null) {
       return const InquiryState(state: 'IDLE');
     }
     final raw = loadFrom(path);
-    if (raw.status == 'completed') {
+    if (raw.status == 'completed' || raw.status == 'blocked') {
       return const InquiryState(state: 'IDLE');
     }
     return raw;

--- a/code/cli/lib/modules/ape/inquiry_state.dart
+++ b/code/cli/lib/modules/ape/inquiry_state.dart
@@ -1,4 +1,9 @@
-/// Reads and writes `.inquiry/state.yaml` including the `ape:` field.
+/// Reads and writes the cycle-local FSM state file `.iq.state.yaml`.
+///
+/// The state file lives inside the active cycle root
+/// (`cleanrooms/<branch>/.iq.state.yaml`), resolved via [CycleContext].
+/// `IDLE` is never persisted: it is the absence of a resolved active cycle, or a
+/// cycle whose `status` is `completed`.
 library;
 
 import 'dart:io';
@@ -6,7 +11,12 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
 
-/// Represents the full contents of `.inquiry/state.yaml`.
+import '../../src/cycle_context.dart';
+
+/// Canonical cycle-local state file name.
+const kStateFileName = '.iq.state.yaml';
+
+/// Represents the full contents of a cycle's `.iq.state.yaml`.
 class InquiryState {
   final String state;
   final String? issue;
@@ -14,17 +24,51 @@ class InquiryState {
   final String? apeName;
   final String? apeState;
 
+  /// Schema version of the state file.
+  final int version;
+
+  /// Lifecycle status: `active`, `completed`, or `blocked`. `null` is treated
+  /// as `active` for backward tolerance.
+  final String? status;
+
+  /// ISO-8601 creation timestamp, preserved across saves.
+  final String? createdAt;
+
+  /// ISO-8601 timestamp of the last save.
+  final String? updatedAt;
+
   const InquiryState({
     required this.state,
     this.issue,
     this.promptFragmentId,
     this.apeName,
     this.apeState,
+    this.version = 1,
+    this.status,
+    this.createdAt,
+    this.updatedAt,
   });
 
-  /// Read from `.inquiry/state.yaml` in [workingDirectory].
-  static InquiryState load(String workingDirectory) {
-    final file = File(p.join(workingDirectory, '.inquiry', 'state.yaml'));
+  /// Resolves the cycle-local state file path for [workingDirectory].
+  ///
+  /// Returns `null` when no active cycle resolves (not a git repository,
+  /// detached HEAD, or no branch), which maps to derived IDLE.
+  static String? stateFileFor(String workingDirectory) {
+    try {
+      final ctx = CycleContext.resolve(workingDirectory);
+      final root = ctx.inquiryRoot;
+      if (root == null) return null;
+      return p.join(root, kStateFileName);
+    } on CycleResolutionException {
+      return null;
+    }
+  }
+
+  /// Reads state from an explicit [stateFilePath] without IDLE mapping.
+  ///
+  /// Returns a raw IDLE placeholder when the file is missing or malformed.
+  static InquiryState loadFrom(String stateFilePath) {
+    final file = File(stateFilePath);
     if (!file.existsSync()) {
       return const InquiryState(state: 'IDLE');
     }
@@ -34,14 +78,17 @@ class InquiryState {
       return const InquiryState(state: 'IDLE');
     }
 
-    final state = (yaml['state'] as String?) ?? 'IDLE';
+    final state =
+        (yaml['state'] as String?) ?? (yaml['fsm_state'] as String?) ?? 'IDLE';
     final rawIssue = yaml['issue'];
-    final issue = (rawIssue is String && rawIssue.isNotEmpty) ? rawIssue
-        : (rawIssue is int) ? rawIssue.toString()
+    final issue = (rawIssue is String && rawIssue.isNotEmpty)
+        ? rawIssue
+        : (rawIssue is int)
+        ? rawIssue.toString()
         : null;
     final rawPromptFragmentId = yaml['prompt_fragment_id'];
     final promptFragmentId =
-      (rawPromptFragmentId is String && rawPromptFragmentId.isNotEmpty)
+        (rawPromptFragmentId is String && rawPromptFragmentId.isNotEmpty)
         ? rawPromptFragmentId
         : null;
 
@@ -53,20 +100,50 @@ class InquiryState {
       apeState = apeMap['state'] as String?;
     }
 
+    final rawVersion = yaml['version'];
+    final version = rawVersion is int ? rawVersion : 1;
+    final status = yaml['status'] as String?;
+    final createdAt = yaml['created_at'] as String?;
+    final updatedAt = yaml['updated_at'] as String?;
+
     return InquiryState(
       state: state,
       issue: issue,
       promptFragmentId: promptFragmentId,
       apeName: apeName,
       apeState: apeState,
+      version: version,
+      status: status,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
     );
   }
 
-  /// Write to `.inquiry/state.yaml` in [workingDirectory].
-  void save(String workingDirectory) {
-    final file = File(p.join(workingDirectory, '.inquiry', 'state.yaml'));
+  /// Reads the active cycle state for [workingDirectory].
+  ///
+  /// Returns derived IDLE when no cycle resolves, the file is missing, or the
+  /// cycle's `status` is `completed`.
+  static InquiryState load(String workingDirectory) {
+    final path = stateFileFor(workingDirectory);
+    if (path == null) {
+      return const InquiryState(state: 'IDLE');
+    }
+    final raw = loadFrom(path);
+    if (raw.status == 'completed') {
+      return const InquiryState(state: 'IDLE');
+    }
+    return raw;
+  }
+
+  /// Writes this state to an explicit [stateFilePath].
+  void saveTo(String stateFilePath) {
+    final file = File(stateFilePath);
     file.parent.createSync(recursive: true);
+    final now = DateTime.now().toUtc().toIso8601String();
+    final created = createdAt ?? now;
+
     final buf = StringBuffer();
+    buf.writeln('version: $version');
     buf.writeln('state: $state');
     buf.writeln(issue != null ? 'issue: "$issue"' : 'issue: null');
     buf.writeln(
@@ -74,6 +151,7 @@ class InquiryState {
           ? 'prompt_fragment_id: $promptFragmentId'
           : 'prompt_fragment_id: null',
     );
+    buf.writeln('status: ${status ?? 'active'}');
     if (apeName != null) {
       buf.writeln('ape:');
       buf.writeln('  name: $apeName');
@@ -81,7 +159,23 @@ class InquiryState {
     } else {
       buf.writeln('ape: null');
     }
+    buf.writeln('created_at: "$created"');
+    buf.writeln('updated_at: "$now"');
     file.writeAsStringSync(buf.toString());
+  }
+
+  /// Writes the active cycle state for [workingDirectory].
+  ///
+  /// Throws [StateError] when no cycle resolves (IDLE is never persisted).
+  void save(String workingDirectory) {
+    final path = stateFileFor(workingDirectory);
+    if (path == null) {
+      throw StateError(
+        'cannot persist FSM state: no active cycle resolves for '
+        '"$workingDirectory" (IDLE is derived, not stored)',
+      );
+    }
+    saveTo(path);
   }
 
   InquiryState copyWith({
@@ -90,6 +184,10 @@ class InquiryState {
     String? promptFragmentId,
     String? apeName,
     String? apeState,
+    int? version,
+    String? status,
+    String? createdAt,
+    String? updatedAt,
     bool clearApe = false,
   }) {
     return InquiryState(
@@ -98,6 +196,10 @@ class InquiryState {
       promptFragmentId: promptFragmentId ?? this.promptFragmentId,
       apeName: clearApe ? null : (apeName ?? this.apeName),
       apeState: clearApe ? null : (apeState ?? this.apeState),
+      version: version ?? this.version,
+      status: status ?? this.status,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
     );
   }
 }

--- a/code/cli/lib/modules/fsm/commands/transition.dart
+++ b/code/cli/lib/modules/fsm/commands/transition.dart
@@ -5,17 +5,18 @@ import 'dart:io';
 import 'package:cli_router/cli_router.dart';
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 import 'package:path/path.dart' as p;
-import 'package:yaml/yaml.dart';
 
 import '../../../assets.dart';
 import '../../../fsm_contract.dart';
+import '../../ape/inquiry_state.dart';
 import '../effect_executor.dart';
 
 typedef BranchProvider = Future<String> Function(String workingDirectory);
-typedef GitCommandRunner = Future<ProcessResult> Function(
-  String workingDirectory,
-  List<String> arguments,
-);
+typedef GitCommandRunner =
+    Future<ProcessResult> Function(
+      String workingDirectory,
+      List<String> arguments,
+    );
 
 class _BoundaryCommitSpec {
   final String label;
@@ -129,10 +130,9 @@ class StateTransitionCommand
     BranchProvider? branchProvider,
     GitCommandRunner? gitCommandRunner,
     Assets? assets,
-  })
-    : branchProvider = branchProvider ?? _defaultBranchProvider,
-      gitCommandRunner = gitCommandRunner ?? _defaultGitCommandRunner,
-      _assets = assets;
+  }) : branchProvider = branchProvider ?? _defaultBranchProvider,
+       gitCommandRunner = gitCommandRunner ?? _defaultGitCommandRunner,
+       _assets = assets;
 
   @override
   String? validate() => null;
@@ -149,13 +149,17 @@ class StateTransitionCommand
 
     final contractPath = _assets != null
         ? _assets.path('fsm/transition_contract.yaml')
-        : p.join(input.workingDirectory, 'assets', 'fsm', 'transition_contract.yaml');
+        : p.join(
+            input.workingDirectory,
+            'assets',
+            'fsm',
+            'transition_contract.yaml',
+          );
     final contract = parseFsmContract(File(contractPath).readAsStringSync());
 
-    final current =
-        input.currentState != null
-            ? FsmState.fromValue(input.currentState!.trim().toUpperCase())
-            : _loadCurrentState(input.workingDirectory);
+    final current = input.currentState != null
+        ? FsmState.fromValue(input.currentState!.trim().toUpperCase())
+        : _loadCurrentState(input.workingDirectory);
     final event = FsmEvent.fromValue(input.event!.trim().toLowerCase());
 
     final transition = contract.transitionFor(current, event);
@@ -220,11 +224,13 @@ class StateTransitionCommand
 
     final operations = transition.operations;
     final promptId = operations?.promptFragmentId;
-    final prompt =
-        promptId != null ? contract.promptFragments[promptId] : null;
+    final prompt = promptId != null ? contract.promptFragments[promptId] : null;
 
     // Execute CLI-side effects
-    final executor = EffectExecutor(workingDirectory: input.workingDirectory, assets: _assets);
+    final executor = EffectExecutor(
+      workingDirectory: input.workingDirectory,
+      assets: _assets,
+    );
     final executedEffects = executor.executeAll(
       effects: operations?.effects ?? const <String>[],
       newState: transition.to?.value ?? current.value,
@@ -259,7 +265,8 @@ class StateTransitionCommand
     String? inputIssue,
   }) async {
     final prechecks = transition.operations?.prechecks ?? const <String>[];
-    final issueSelected = _isIssueSelected(workingDirectory) ||
+    final issueSelected =
+        _isIssueSelected(workingDirectory) ||
         (inputIssue != null && inputIssue.trim().isNotEmpty);
 
     if ((prechecks.contains('issue_selected') ||
@@ -288,7 +295,8 @@ class StateTransitionCommand
       return 'ERROR_PRECONDITION_CONFIRMATIONS_MISSING: confirmations.md missing for current issue branch';
     }
 
-    if (prechecks.contains('plan_approved') && !_planExists(branch, workingDirectory)) {
+    if (prechecks.contains('plan_approved') &&
+        !_planExists(branch, workingDirectory)) {
       return 'ERROR_PRECONDITION_PLAN_MISSING: plan.md missing for current issue branch';
     }
 
@@ -367,7 +375,9 @@ class StateTransitionCommand
   }
 
   String _boundaryCommitMessage(String boundary, String? issue) {
-    final suffix = issue != null && issue.trim().isNotEmpty ? ' for #$issue' : '';
+    final suffix = issue != null && issue.trim().isNotEmpty
+        ? ' for #$issue'
+        : '';
     return 'approve $boundary boundary$suffix';
   }
 
@@ -431,68 +441,25 @@ class StateTransitionCommand
     if (inputIssue != null && inputIssue.trim().isNotEmpty) {
       return inputIssue.trim();
     }
-
-    final statePath = p.join(workingDirectory, '.inquiry', 'state.yaml');
-    final stateFile = File(statePath);
-    if (!stateFile.existsSync()) return null;
-
-    final yaml = loadYaml(stateFile.readAsStringSync());
-    if (yaml is! YamlMap) return null;
-
-    final issue = yaml['issue'];
-    if (issue is String && issue.trim().isNotEmpty) return issue.trim();
-    if (issue is int && issue > 0) return issue.toString();
-    if (issue is YamlMap) {
-      final id = issue['id'] ?? issue['number'];
-      if (id is String && id.trim().isNotEmpty) return id.trim();
-      if (id is int && id > 0) return id.toString();
-    }
-
-    return null;
+    return InquiryState.load(workingDirectory).issue;
   }
 
   bool _isIssueSelected(String workingDirectory) {
-    final statePath = p.join(workingDirectory, '.inquiry', 'state.yaml');
-    final stateFile = File(statePath);
-    if (!stateFile.existsSync()) return false;
-
-    final yaml = loadYaml(stateFile.readAsStringSync());
-    if (yaml is! YamlMap) return false;
-
-    final issue = yaml['issue'];
-    if (issue == null) return false;
-
-    if (issue is String) return issue.trim().isNotEmpty;
-    if (issue is int) return issue > 0;
-    if (issue is YamlMap) {
-      final id = issue['id'] ?? issue['number'];
-      if (id is int) return id > 0;
-      if (id is String) return id.trim().isNotEmpty;
-    }
-
-    return false;
+    return InquiryState.load(workingDirectory).issue != null;
   }
 
   FsmState _loadCurrentState(String workingDirectory) {
-    final statePath = p.join(workingDirectory, '.inquiry', 'state.yaml');
-    final file = File(statePath);
-    if (!file.existsSync()) {
-      return FsmState.idle;
-    }
-
-    final yaml = loadYaml(file.readAsStringSync());
-    if (yaml is! YamlMap) return FsmState.idle;
-    final phase = yaml['state'];
-    if (phase is! String || phase.trim().isEmpty) return FsmState.idle;
+    final phase = InquiryState.load(workingDirectory).state;
+    if (phase.trim().isEmpty) return FsmState.idle;
     return FsmState.fromValue(phase.trim().toUpperCase());
   }
 
   static Future<String> _defaultBranchProvider(String workingDirectory) async {
-    final result = await Process.run(
-      'git',
-      ['rev-parse', '--abbrev-ref', 'HEAD'],
-      workingDirectory: workingDirectory,
-    );
+    final result = await Process.run('git', [
+      'rev-parse',
+      '--abbrev-ref',
+      'HEAD',
+    ], workingDirectory: workingDirectory);
     if (result.exitCode != 0) return '';
     return result.stdout.toString().trim();
   }
@@ -501,10 +468,6 @@ class StateTransitionCommand
     String workingDirectory,
     List<String> arguments,
   ) {
-    return Process.run(
-      'git',
-      arguments,
-      workingDirectory: workingDirectory,
-    );
+    return Process.run('git', arguments, workingDirectory: workingDirectory);
   }
 }

--- a/code/cli/lib/modules/fsm/effect_executor.dart
+++ b/code/cli/lib/modules/fsm/effect_executor.dart
@@ -102,14 +102,24 @@ class EffectExecutor {
   }
 
   /// Mark the active cycle as `completed` (IDLE is derived, never persisted).
-  void _markCompleted() {
+  void _markCompleted() => _markStatus('completed');
+
+  /// Mark the active cycle as `blocked` (IDLE is derived, never persisted).
+  void _markBlocked() => _markStatus('blocked');
+
+  /// Centralized terminal-status write for the active cycle.
+  ///
+  /// IDLE is never persisted: the cycle file keeps its last phase but records
+  /// [status] (`completed` or `blocked`) so `load()` derives IDLE. Clears any
+  /// active APE sub-state. No-op when already at [status].
+  void _markStatus(String status) {
     final path = InquiryState.stateFileFor(workingDirectory);
     if (path == null) return;
     if (!File(path).existsSync()) return;
     final raw = InquiryState.loadFrom(path);
-    if (raw.status == 'completed') return;
-    final completed = raw.copyWith(status: 'completed', clearApe: true);
-    completed.saveTo(path);
+    if (raw.status == status) return;
+    final marked = raw.copyWith(status: status, clearApe: true);
+    marked.saveTo(path);
   }
 
   /// Create `cleanrooms/<branch>/analyze/index.md` and `confirmations.md` for ANALYZE phase.
@@ -353,6 +363,10 @@ class EffectExecutor {
           executed.add(effect);
         case 'collect_metrics':
           collectMetrics();
+          executed.add(effect);
+        case 'pause_analysis':
+        case 'pause_plan':
+          _markBlocked();
           executed.add(effect);
         // Skill-side effects — not executed by CLI
         default:

--- a/code/cli/lib/modules/fsm/effect_executor.dart
+++ b/code/cli/lib/modules/fsm/effect_executor.dart
@@ -239,9 +239,9 @@ class EffectExecutor {
     return getCurrentBranch(workingDirectory);
   }
 
-  /// Reset `.inquiry/mutations.md` to empty template.
+  /// Reset the cycle-local `cleanrooms/<branch>/mutations.md` to empty template.
   void resetMutations() {
-    final file = File(p.join(_inquiryDir, 'mutations.md'));
+    final file = File(_mutationsPath());
     file.parent.createSync(recursive: true);
     file.writeAsStringSync(
       '# Mutations\n'
@@ -249,6 +249,18 @@ class EffectExecutor {
       'Notes for DARWIN. Write observations about the current cycle here.\n'
       'This file is read during EVOLUTION and cleared afterwards.\n',
     );
+  }
+
+  /// Resolve the cycle-local `mutations.md` path.
+  ///
+  /// Falls back to repo-level `.inquiry/mutations.md` only when no cycle
+  /// resolves (derived IDLE / not a git repo).
+  String _mutationsPath() {
+    final branch = _getCurrentBranch();
+    if (branch.isEmpty) {
+      return p.join(_inquiryDir, 'mutations.md');
+    }
+    return p.join(workingDirectory, 'cleanrooms', branch, 'mutations.md');
   }
 
   /// Resolve the initial_state for an APE by loading its YAML definition.
@@ -272,6 +284,7 @@ class EffectExecutor {
     final issueLine = current.issue != null
         ? 'issue: "${current.issue}"'
         : 'issue: null';
+    Directory(_inquiryDir).createSync(recursive: true);
     final snapshot = File(p.join(_inquiryDir, 'metrics_snapshot.yaml'));
     snapshot.writeAsStringSync(
       'snapshot_at: "${DateTime.now().toUtc().toIso8601String()}"\n'
@@ -296,6 +309,7 @@ class EffectExecutor {
         '  - $issueLine\n'
         '    completed_at: "${DateTime.now().toUtc().toIso8601String()}"\n';
 
+    Directory(_inquiryDir).createSync(recursive: true);
     final metricsFile = File(p.join(_inquiryDir, 'metrics.yaml'));
     if (metricsFile.existsSync()) {
       metricsFile.writeAsStringSync(entry, mode: FileMode.append);

--- a/code/cli/lib/modules/fsm/effect_executor.dart
+++ b/code/cli/lib/modules/fsm/effect_executor.dart
@@ -55,7 +55,8 @@ class EffectExecutor {
     'EVOLUTION': 'darwin',
   };
 
-  /// Update `.inquiry/state.yaml` with [newState], including APE auto-activation.
+  /// Update the cycle-local `.iq.state.yaml` with [newState], including APE
+  /// auto-activation.
   ///
   /// If the new state has an associated APE, loads its YAML to find `initial_state`
   /// and writes `ape: {name, state}`. Otherwise clears the `ape:` field.

--- a/code/cli/lib/modules/fsm/effect_executor.dart
+++ b/code/cli/lib/modules/fsm/effect_executor.dart
@@ -25,12 +25,23 @@ const cliEffects = {
   'open_analysis_context',
 };
 
+/// Resolves the body of a GitHub issue for the `issue.md` mirror.
+///
+/// Returns `null` when the body cannot be fetched (best-effort; non-fatal).
+typedef IssueBodyProvider =
+    String? Function(String issue, String workingDirectory);
+
 class EffectExecutor {
   final String workingDirectory;
   final Assets? _assets;
+  final IssueBodyProvider _issueBodyProvider;
 
-  EffectExecutor({required this.workingDirectory, Assets? assets})
-    : _assets = assets;
+  EffectExecutor({
+    required this.workingDirectory,
+    Assets? assets,
+    IssueBodyProvider? issueBodyProvider,
+  }) : _assets = assets,
+       _issueBodyProvider = issueBodyProvider ?? _defaultIssueBodyProvider;
 
   String get _inquiryDir => p.join(workingDirectory, '.inquiry');
 
@@ -156,6 +167,71 @@ class EffectExecutor {
         '> Living document. Update as findings are confirmed, revised, or invalidated.\n'
         '> Format: ## F<N>: <title> — CONFIRMED|REVISED|INVALIDATED\n',
       );
+    }
+
+    _writeIssueMirror(branch, issue, today);
+  }
+
+  /// Best-effort `cleanrooms/<branch>/issue.md` mirror of the GitHub issue.
+  ///
+  /// Idempotent: never clobbers an existing mirror. A failed/empty body fetch
+  /// is non-fatal — the mirror is still written with the available metadata.
+  void _writeIssueMirror(String branch, String issue, String today) {
+    final issueFile = File(
+      p.join(workingDirectory, 'cleanrooms', branch, 'issue.md'),
+    );
+    if (issueFile.existsSync()) return;
+
+    String? body;
+    if (issue.isNotEmpty) {
+      try {
+        body = _issueBodyProvider(issue, workingDirectory);
+      } catch (_) {
+        body = null;
+      }
+    }
+
+    final issueRef = issue.isNotEmpty ? '#$issue' : '(unassigned)';
+    final buffer = StringBuffer()
+      ..write('---\n')
+      ..write('id: issue\n')
+      ..write('issue: "$issue"\n')
+      ..write('branch: $branch\n')
+      ..write('date: $today\n')
+      ..write('---\n')
+      ..write('\n')
+      ..write('# Issue $issueRef\n')
+      ..write('\n');
+    if (body != null && body.trim().isNotEmpty) {
+      buffer.write(body.trim());
+      buffer.write('\n');
+    } else {
+      buffer.write('> Issue body unavailable (fetched best-effort).\n');
+    }
+
+    issueFile.parent.createSync(recursive: true);
+    issueFile.writeAsStringSync(buffer.toString());
+  }
+
+  static String? _defaultIssueBodyProvider(
+    String issue,
+    String workingDirectory,
+  ) {
+    try {
+      final result = Process.runSync('gh', [
+        'issue',
+        'view',
+        issue,
+        '--json',
+        'body',
+        '-q',
+        '.body',
+      ], workingDirectory: workingDirectory);
+      if (result.exitCode != 0) return null;
+      final body = result.stdout.toString().trim();
+      return body.isEmpty ? null : body;
+    } catch (_) {
+      return null;
     }
   }
 

--- a/code/cli/lib/modules/fsm/effect_executor.dart
+++ b/code/cli/lib/modules/fsm/effect_executor.dart
@@ -29,7 +29,8 @@ class EffectExecutor {
   final String workingDirectory;
   final Assets? _assets;
 
-  EffectExecutor({required this.workingDirectory, Assets? assets}) : _assets = assets;
+  EffectExecutor({required this.workingDirectory, Assets? assets})
+    : _assets = assets;
 
   String get _inquiryDir => p.join(workingDirectory, '.inquiry');
 
@@ -48,16 +49,15 @@ class EffectExecutor {
   /// If the new state has an associated APE, loads its YAML to find `initial_state`
   /// and writes `ape: {name, state}`. Otherwise clears the `ape:` field.
   void updateState(String newState, {String? issue, String? promptFragmentId}) {
+    if (newState == 'IDLE') {
+      _markCompleted();
+      return;
+    }
+
     final currentState = InquiryState.load(workingDirectory);
     String? resolvedIssue = issue;
     String? resolvedPromptFragmentId = promptFragmentId;
-
-    if (newState == 'IDLE') {
-      resolvedIssue = null;
-      resolvedPromptFragmentId = null;
-    } else {
-      resolvedIssue ??= currentState.issue;
-    }
+    resolvedIssue ??= currentState.issue;
 
     // Auto-activate APE
     String? apeName;
@@ -66,7 +66,8 @@ class EffectExecutor {
     if (ape != null) {
       apeName = ape;
       if (currentState.apeName == ape && currentState.apeState != null) {
-        if (currentState.state == newState && currentState.apeState == '_DONE') {
+        if (currentState.state == newState &&
+            currentState.apeState == '_DONE') {
           apeInitialState = _resolveInitialState(ape);
         } else {
           apeInitialState = currentState.apeState;
@@ -82,8 +83,22 @@ class EffectExecutor {
       promptFragmentId: resolvedPromptFragmentId,
       apeName: apeName,
       apeState: apeInitialState,
+      version: currentState.version,
+      status: 'active',
+      createdAt: currentState.createdAt,
     );
     updated.save(workingDirectory);
+  }
+
+  /// Mark the active cycle as `completed` (IDLE is derived, never persisted).
+  void _markCompleted() {
+    final path = InquiryState.stateFileFor(workingDirectory);
+    if (path == null) return;
+    if (!File(path).existsSync()) return;
+    final raw = InquiryState.loadFrom(path);
+    if (raw.status == 'completed') return;
+    final completed = raw.copyWith(status: 'completed', clearApe: true);
+    completed.saveTo(path);
   }
 
   /// Create `cleanrooms/<branch>/analyze/index.md` and `confirmations.md` for ANALYZE phase.
@@ -92,7 +107,12 @@ class EffectExecutor {
     if (branch.isEmpty) return;
 
     final issue = InquiryState.load(workingDirectory).issue ?? '';
-    final cleanroomDir = p.join(workingDirectory, 'cleanrooms', branch, 'analyze');
+    final cleanroomDir = p.join(
+      workingDirectory,
+      'cleanrooms',
+      branch,
+      'analyze',
+    );
     final dir = Directory(cleanroomDir);
     if (!dir.existsSync()) {
       dir.createSync(recursive: true);
@@ -146,6 +166,7 @@ class EffectExecutor {
   /// Reset `.inquiry/mutations.md` to empty template.
   void resetMutations() {
     final file = File(p.join(_inquiryDir, 'mutations.md'));
+    file.parent.createSync(recursive: true);
     file.writeAsStringSync(
       '# Mutations\n'
       '\n'
@@ -172,8 +193,9 @@ class EffectExecutor {
   void snapshotMetrics() {
     final current = InquiryState.load(workingDirectory);
 
-    final issueLine =
-        current.issue != null ? 'issue: "${current.issue}"' : 'issue: null';
+    final issueLine = current.issue != null
+        ? 'issue: "${current.issue}"'
+        : 'issue: null';
     final snapshot = File(p.join(_inquiryDir, 'metrics_snapshot.yaml'));
     snapshot.writeAsStringSync(
       'snapshot_at: "${DateTime.now().toUtc().toIso8601String()}"\n'
@@ -191,8 +213,9 @@ class EffectExecutor {
   void collectMetrics() {
     final current = InquiryState.load(workingDirectory);
 
-    final issueLine =
-        current.issue != null ? 'issue: "${current.issue}"' : 'issue: null';
+    final issueLine = current.issue != null
+        ? 'issue: "${current.issue}"'
+        : 'issue: null';
     final entry =
         '  - $issueLine\n'
         '    completed_at: "${DateTime.now().toUtc().toIso8601String()}"\n';
@@ -221,11 +244,7 @@ class EffectExecutor {
     final executed = <String>[];
 
     // Always update state on valid transition
-    updateState(
-      newState,
-      issue: issue,
-      promptFragmentId: promptFragmentId,
-    );
+    updateState(newState, issue: issue, promptFragmentId: promptFragmentId);
     executed.add('update_state');
 
     for (final effect in effects) {

--- a/code/cli/lib/modules/global/commands/init.dart
+++ b/code/cli/lib/modules/global/commands/init.dart
@@ -1,13 +1,13 @@
 /// `inquiry init` — initializes Inquiry in the working directory.
 ///
-/// Seven idempotent steps:
+/// Idempotent steps:
 /// 1. Create cleanrooms/ at project root if missing
-/// 2. Add .inquiry/ to .gitignore
-/// 3. Create .inquiry/state.yaml with IDLE state
-/// 4. Create .inquiry/config.yaml with defaults
-/// 5. Create .inquiry/mutations.md with header template
-/// 6. Deploy inquiry.agent.md to active target
-/// 7. Deploy inquiry.agent.md to .github/agents/ (repo-scoped)
+/// 2. Add .inquiry/ and cleanrooms/**/.iq.state.yaml to .gitignore
+/// 3. Create .inquiry/config.yaml with defaults (project-scoped)
+/// 4. Deploy inquiry.agent.md to .github/agents/ (repo-scoped)
+///
+/// Cycle runtime (`.iq.state.yaml`, `mutations.md`) is materialized per cycle
+/// under `cleanrooms/<branch>/` by the FSM, not scaffolded at init.
 library;
 
 import 'dart:io';
@@ -79,21 +79,13 @@ class InitCommand implements Command<InitInput, InitOutput> {
       steps.add('Created ${_relative(root, issuesDir.path)}');
     }
 
-    // Step 2: Add .inquiry/ to .gitignore
+    // Step 2: Add .inquiry/ and cycle-local state to .gitignore
     _ensureGitignore(root, steps);
 
-    // Step 3: Create .inquiry/state.yaml with IDLE state
-    _ensureStateYaml(root, steps);
-
-    // Step 4: Create .inquiry/config.yaml with defaults
+    // Step 3: Create .inquiry/config.yaml with defaults (project-scoped)
     _ensureConfigYaml(root, steps);
 
-    // Step 5: Create .inquiry/mutations.md with header template
-    _ensureMutationsMd(root, steps);
-
-    // Step 6: (legacy — agent deploy moved to step 7)
-
-    // Step 7: Deploy inquiry.agent.md to .github/agents/ (repo-scoped)
+    // Step 4: Deploy inquiry.agent.md to .github/agents/ (repo-scoped)
     if (assets != null) {
       _deployAgent(root, assets!, steps);
     }
@@ -110,53 +102,46 @@ class InitCommand implements Command<InitInput, InitOutput> {
 
   void _deployAgent(String root, Assets assets, List<String> steps) {
     final content = assets.loadString('agents/inquiry.agent.md');
-    final agentFile = File(p.join(root, '.github', 'agents', 'inquiry.agent.md'));
+    final agentFile = File(
+      p.join(root, '.github', 'agents', 'inquiry.agent.md'),
+    );
     agentFile.parent.createSync(recursive: true);
     agentFile.writeAsStringSync(content);
     steps.add('Deployed inquiry.agent.md to .github/agents/');
   }
 
-  /// Ensures `.inquiry/` is in `.gitignore`.
+  /// Ensures `.inquiry/` and cycle-local state are in `.gitignore`.
   void _ensureGitignore(String root, List<String> steps) {
+    const entries = <String>['.inquiry/', 'cleanrooms/**/.iq.state.yaml'];
     final gitignore = File('$root/.gitignore');
 
-    if (gitignore.existsSync()) {
-      final content = gitignore.readAsStringSync();
-      if (!content.contains('.inquiry/')) {
-        gitignore.writeAsStringSync(
-          '$content\n# Inquiry — local cycle state\n.inquiry/\n',
-        );
-        steps.add('Added .inquiry/ to .gitignore');
-      }
-    } else {
+    if (!gitignore.existsSync()) {
       gitignore.writeAsStringSync(
-        '# Inquiry — local cycle state\n.inquiry/\n',
+        '# Inquiry — local cycle state\n'
+        '.inquiry/\n'
+        'cleanrooms/**/.iq.state.yaml\n',
       );
-      steps.add('Created .gitignore with .inquiry/');
+      steps.add('Created .gitignore with Inquiry entries');
+      return;
     }
-  }
 
-  /// Ensures `.inquiry/state.yaml` exists with IDLE state.
-  void _ensureStateYaml(String root, List<String> steps) {
-    final inquiryDir = Directory('$root/.inquiry');
-    final stateFile = File('$root/.inquiry/state.yaml');
+    var content = gitignore.readAsStringSync();
+    final missing = entries.where((e) => !content.contains(e)).toList();
+    if (missing.isEmpty) return;
 
-    if (!stateFile.existsSync()) {
-      if (!inquiryDir.existsSync()) inquiryDir.createSync();
-      stateFile.writeAsStringSync(
-        'state: IDLE\n'
-        'issue: null\n'
-        'ape: null\n',
-      );
-      steps.add('Created .inquiry/state.yaml');
-    }
+    if (!content.endsWith('\n')) content = '$content\n';
+    content = '$content# Inquiry — local cycle state\n${missing.join('\n')}\n';
+    gitignore.writeAsStringSync(content);
+    steps.add('Added Inquiry entries to .gitignore');
   }
 
   /// Ensures `.inquiry/config.yaml` exists with default configuration.
   void _ensureConfigYaml(String root, List<String> steps) {
+    final configDir = Directory('$root/.inquiry');
     final configFile = File('$root/.inquiry/config.yaml');
 
     if (!configFile.existsSync()) {
+      if (!configDir.existsSync()) configDir.createSync(recursive: true);
       configFile.writeAsStringSync(
         'evolution:\n'
         '  enabled: false\n',
@@ -165,21 +150,5 @@ class InitCommand implements Command<InitInput, InitOutput> {
     }
   }
 
-  /// Ensures `.inquiry/mutations.md` exists with header template.
-  void _ensureMutationsMd(String root, List<String> steps) {
-    final mutationsFile = File('$root/.inquiry/mutations.md');
-
-    if (!mutationsFile.existsSync()) {
-      mutationsFile.writeAsStringSync(
-        '# Mutations\n'
-        '\n'
-        'Notes for DARWIN. Write observations about the current cycle here.\n'
-        'This file is read during EVOLUTION and cleared afterwards.\n',
-      );
-      steps.add('Created .inquiry/mutations.md');
-    }
-  }
-
-  String _relative(String root, String path) =>
-      p.relative(path, from: root);
+  String _relative(String root, String path) => p.relative(path, from: root);
 }

--- a/code/cli/lib/src/cycle_context.dart
+++ b/code/cli/lib/src/cycle_context.dart
@@ -1,0 +1,92 @@
+/// Resolves the distinct roots an Inquiry invocation depends on.
+///
+/// The CLI historically overloaded a single cwd-derived `workingDirectory` for
+/// the repository root, the cycle root, the config home, and the git execution
+/// base. [CycleContext] separates those concerns:
+///
+/// - [projectRoot]    — the git repository / worktree root.
+/// - [inquiryRoot]    — the active cycle root, `cleanrooms/<branch>/`, or `null`
+///   when no cycle resolves (derived IDLE).
+/// - [inquiryCliRoot] — the home for CLI/project-level config (`config.yaml`).
+///
+/// `IDLE` is never persisted: it is the absence of a resolved [inquiryRoot].
+library;
+
+import 'package:path/path.dart' as p;
+
+import 'git_utils.dart';
+
+/// Raised when repository context cannot be resolved into a [CycleContext].
+class CycleResolutionException implements Exception {
+  final String message;
+  const CycleResolutionException(this.message);
+
+  @override
+  String toString() => 'CycleResolutionException: $message';
+}
+
+/// The resolved roots for a single CLI invocation.
+class CycleContext {
+  /// The git repository / worktree root.
+  final String projectRoot;
+
+  /// The current branch, or `null` for derived IDLE (detached HEAD / no branch).
+  final String? branch;
+
+  /// The active cycle root `cleanrooms/<branch>/`, or `null` for derived IDLE.
+  final String? inquiryRoot;
+
+  /// The home for CLI/project-level configuration.
+  final String inquiryCliRoot;
+
+  const CycleContext({
+    required this.projectRoot,
+    required this.branch,
+    required this.inquiryRoot,
+    required this.inquiryCliRoot,
+  });
+
+  /// Whether no active cycle resolves from the current repository context.
+  bool get isIdle => inquiryRoot == null;
+
+  /// Normalizes a raw branch token into an active branch name.
+  ///
+  /// Returns `null` for an empty token or the detached-HEAD sentinel `HEAD`,
+  /// both of which map to derived IDLE.
+  static String? normalizeBranch(String raw) {
+    final b = raw.trim();
+    if (b.isEmpty || b == 'HEAD') return null;
+    return b;
+  }
+
+  /// Resolves the context for [workingDirectory] using git.
+  ///
+  /// Throws [CycleResolutionException] when:
+  /// - [workingDirectory] is not inside a git repository, or
+  /// - the current branch name contains a path separator (`/`), which the
+  ///   `<issue>-<slug>` convention forbids.
+  static CycleContext resolve(String workingDirectory) {
+    final root = getProjectRoot(workingDirectory);
+    if (root == null) {
+      throw const CycleResolutionException('not a git repository');
+    }
+
+    final branch = normalizeBranch(getCurrentBranch(workingDirectory));
+    if (branch != null && (branch.contains('/') || branch.contains(r'\'))) {
+      throw CycleResolutionException(
+        'branch name must be a single path segment: $branch',
+      );
+    }
+
+    final inquiryRoot = branch == null
+        ? null
+        : p.join(root, 'cleanrooms', branch);
+
+    return CycleContext(
+      projectRoot: root,
+      branch: branch,
+      inquiryRoot: inquiryRoot,
+      inquiryCliRoot: root,
+    );
+  }
+}

--- a/code/cli/lib/src/git_utils.dart
+++ b/code/cli/lib/src/git_utils.dart
@@ -5,14 +5,32 @@ import 'dart:io';
 /// Returns an empty string if git is unavailable or not in a repository.
 String getCurrentBranch(String workingDirectory) {
   try {
-    final result = Process.runSync(
-      'git',
-      ['rev-parse', '--abbrev-ref', 'HEAD'],
-      workingDirectory: workingDirectory,
-    );
+    final result = Process.runSync('git', [
+      'rev-parse',
+      '--abbrev-ref',
+      'HEAD',
+    ], workingDirectory: workingDirectory);
     if (result.exitCode != 0) return '';
     return (result.stdout as String).trim();
   } catch (_) {
     return '';
+  }
+}
+
+/// Returns the git repository top-level directory for [workingDirectory].
+///
+/// Returns `null` when [workingDirectory] is not inside a git repository or
+/// git is unavailable.
+String? getProjectRoot(String workingDirectory) {
+  try {
+    final result = Process.runSync('git', [
+      'rev-parse',
+      '--show-toplevel',
+    ], workingDirectory: workingDirectory);
+    if (result.exitCode != 0) return null;
+    final out = (result.stdout as String).trim();
+    return out.isEmpty ? null : out;
+  } catch (_) {
+    return null;
   }
 }

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.5.3';
+const String inquiryVersion = '0.6.0';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.5.3
+version: 0.6.0
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/ape_prompt_test.dart
+++ b/code/cli/test/ape_prompt_test.dart
@@ -1,47 +1,72 @@
 import 'dart:io';
 
 import 'package:inquiry_cli/modules/ape/commands/prompt.dart';
+import 'package:inquiry_cli/modules/ape/inquiry_state.dart';
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
   late Directory tmpDir;
+  late String stateFilePath;
+
+  const branch = '145-test-branch';
 
   setUp(() {
     tmpDir = Directory.systemTemp.createTempSync('ape_prompt_test_');
 
-    // Create .inquiry/state.yaml
+    // Cycle-local state lives at cleanrooms/<branch>/.iq.state.yaml.
     Directory(p.join(tmpDir.path, '.inquiry')).createSync();
+    _initGitRepo(tmpDir.path, branch: branch);
+    Directory(
+      p.join(tmpDir.path, 'cleanrooms', branch),
+    ).createSync(recursive: true);
+    stateFilePath = p.join(tmpDir.path, 'cleanrooms', branch, kStateFileName);
 
     // Copy assets/apes/ from real assets
     final apesDir = Directory(p.join(tmpDir.path, 'assets', 'apes'));
     apesDir.createSync(recursive: true);
     for (final name in ['socrates', 'dewey', 'descartes', 'basho', 'darwin']) {
-      File('assets/apes/$name.yaml')
-          .copySync(p.join(apesDir.path, '$name.yaml'));
+      File(
+        'assets/apes/$name.yaml',
+      ).copySync(p.join(apesDir.path, '$name.yaml'));
     }
 
     final statesDir = Directory(p.join(tmpDir.path, 'assets', 'fsm', 'states'));
     statesDir.createSync(recursive: true);
-    for (final name in ['idle', 'analyze', 'plan', 'execute', 'end', 'evolution']) {
-      File('assets/fsm/states/$name.yaml')
-          .copySync(p.join(statesDir.path, '$name.yaml'));
+    for (final name in [
+      'idle',
+      'analyze',
+      'plan',
+      'execute',
+      'end',
+      'evolution',
+    ]) {
+      File(
+        'assets/fsm/states/$name.yaml',
+      ).copySync(p.join(statesDir.path, '$name.yaml'));
     }
 
     final fsmDir = Directory(p.join(tmpDir.path, 'assets', 'fsm'));
     fsmDir.createSync(recursive: true);
-    File('assets/fsm/transition_contract.yaml').copySync(
-      p.join(fsmDir.path, 'transition_contract.yaml'),
-    );
+    File(
+      'assets/fsm/transition_contract.yaml',
+    ).copySync(p.join(fsmDir.path, 'transition_contract.yaml'));
 
     final instructionsDir = Directory(
       p.join(tmpDir.path, 'assets', 'instructions'),
     );
     instructionsDir.createSync(recursive: true);
-    for (final name in ['doc-read', 'doc-write', 'issue-create', 'issue-end', 'issue-start']) {
-      File('assets/instructions/$name.md')
-          .copySync(p.join(instructionsDir.path, '$name.md'));
+    for (final name in [
+      'doc-read',
+      'doc-write',
+      'issue-create',
+      'issue-end',
+      'issue-start',
+    ]) {
+      File(
+        'assets/instructions/$name.md',
+      ).copySync(p.join(instructionsDir.path, '$name.md'));
     }
   });
 
@@ -50,27 +75,28 @@ void main() {
   });
 
   void writeState(String state, {String? issue, String? promptFragmentId}) {
-    File(p.join(tmpDir.path, '.inquiry', 'state.yaml')).writeAsStringSync(
+    File(stateFilePath).writeAsStringSync(
       'state: $state\n'
       'issue: ${issue ?? 'null'}\n',
       mode: FileMode.write,
     );
 
     if (promptFragmentId != null) {
-      File(p.join(tmpDir.path, '.inquiry', 'state.yaml')).writeAsStringSync(
+      File(stateFilePath).writeAsStringSync(
         'prompt_fragment_id: $promptFragmentId\n',
         mode: FileMode.append,
       );
     }
   }
 
-  void writeStateWithApe(String state, {
+  void writeStateWithApe(
+    String state, {
     String? issue,
     String? promptFragmentId,
     required String apeName,
     required String apeState,
   }) {
-    File(p.join(tmpDir.path, '.inquiry', 'state.yaml')).writeAsStringSync(
+    File(stateFilePath).writeAsStringSync(
       'state: $state\n'
       'issue: ${issue != null ? '"$issue"' : 'null'}\n'
       '${promptFragmentId != null ? 'prompt_fragment_id: $promptFragmentId\n' : ''}'
@@ -96,21 +122,24 @@ void main() {
         expect(result.prompt, contains('Socratic method'));
       });
 
-      test('socrates with sub-state clarification appends state prompt', () async {
-        writeState('ANALYZE');
-        final cmd = ApePromptCommand(
-          ApePromptInput(
-            name: 'socrates',
-            subState: 'clarification',
-            workingDirectory: tmpDir.path,
-          ),
-        );
-        final result = await cmd.execute();
+      test(
+        'socrates with sub-state clarification appends state prompt',
+        () async {
+          writeState('ANALYZE');
+          final cmd = ApePromptCommand(
+            ApePromptInput(
+              name: 'socrates',
+              subState: 'clarification',
+              workingDirectory: tmpDir.path,
+            ),
+          );
+          final result = await cmd.execute();
 
-        expect(result.subState, equals('clarification'));
-        expect(result.prompt, contains('SOCRATES'));
-        expect(result.prompt, contains('Clarification questions'));
-      });
+          expect(result.subState, equals('clarification'));
+          expect(result.prompt, contains('SOCRATES'));
+          expect(result.prompt, contains('Clarification questions'));
+        },
+      );
 
       test('descartes in PLAN returns base prompt', () async {
         writeState('PLAN');
@@ -125,47 +154,57 @@ void main() {
         expect(result.prompt, contains('scientific method'));
       });
 
-      test('injects transition-owned instruction summary when prompt_fragment_id exists', () async {
-        writeState('PLAN', issue: '145', promptFragmentId: 'analyze_to_plan');
+      test(
+        'injects transition-owned instruction summary when prompt_fragment_id exists',
+        () async {
+          writeState('PLAN', issue: '145', promptFragmentId: 'analyze_to_plan');
 
-        final cmd = ApePromptCommand(
-          ApePromptInput(
-            name: 'descartes',
-            subState: 'decomposition',
-            workingDirectory: tmpDir.path,
-          ),
-        );
-        final result = await cmd.execute();
+          final cmd = ApePromptCommand(
+            ApePromptInput(
+              name: 'descartes',
+              subState: 'decomposition',
+              workingDirectory: tmpDir.path,
+            ),
+          );
+          final result = await cmd.execute();
 
-        final stateIndex = result.prompt.indexOf('FOCUS: Division.');
-        final instructionIndex = result.prompt.indexOf(
-          'Write inside the CLI-created template and keep frontmatter unchanged.',
-        );
-        final contractIndex = result.prompt.indexOf('## Phase-Owned Operational Contract');
-
-        expect(instructionIndex, greaterThan(stateIndex));
-        expect(contractIndex, greaterThan(instructionIndex));
-      });
-
-      test('does not inject transition-owned summary when prompt_fragment_id is absent', () async {
-        writeState('PLAN', issue: '145');
-
-        final cmd = ApePromptCommand(
-          ApePromptInput(
-            name: 'descartes',
-            subState: 'decomposition',
-            workingDirectory: tmpDir.path,
-          ),
-        );
-        final result = await cmd.execute();
-
-        expect(
-          result.prompt,
-          isNot(contains(
+          final stateIndex = result.prompt.indexOf('FOCUS: Division.');
+          final instructionIndex = result.prompt.indexOf(
             'Write inside the CLI-created template and keep frontmatter unchanged.',
-          )),
-        );
-      });
+          );
+          final contractIndex = result.prompt.indexOf(
+            '## Phase-Owned Operational Contract',
+          );
+
+          expect(instructionIndex, greaterThan(stateIndex));
+          expect(contractIndex, greaterThan(instructionIndex));
+        },
+      );
+
+      test(
+        'does not inject transition-owned summary when prompt_fragment_id is absent',
+        () async {
+          writeState('PLAN', issue: '145');
+
+          final cmd = ApePromptCommand(
+            ApePromptInput(
+              name: 'descartes',
+              subState: 'decomposition',
+              workingDirectory: tmpDir.path,
+            ),
+          );
+          final result = await cmd.execute();
+
+          expect(
+            result.prompt,
+            isNot(
+              contains(
+                'Write inside the CLI-created template and keep frontmatter unchanged.',
+              ),
+            ),
+          );
+        },
+      );
 
       test('basho in EXECUTE returns base prompt', () async {
         writeState('EXECUTE');
@@ -204,10 +243,7 @@ void main() {
       });
 
       test('dewey in IDLE returns base prompt', () async {
-        writeStateWithApe('IDLE',
-          apeName: 'dewey',
-          apeState: 'evaluate_scope',
-        );
+        writeStateWithApe('IDLE', apeName: 'dewey', apeState: 'evaluate_scope');
         final cmd = ApePromptCommand(
           ApePromptInput(name: 'dewey', workingDirectory: tmpDir.path),
         );
@@ -233,7 +269,11 @@ void main() {
           throwsA(
             isA<CommandException>()
                 .having((e) => e.code, 'code', equals('MISSING_NAME'))
-                .having((e) => e.exitCode, 'exitCode', equals(ExitCode.validationFailed)),
+                .having(
+                  (e) => e.exitCode,
+                  'exitCode',
+                  equals(ExitCode.validationFailed),
+                ),
           ),
         );
       });
@@ -251,7 +291,11 @@ void main() {
           throwsA(
             isA<CommandException>()
                 .having((e) => e.code, 'code', equals('MISSING_NAME'))
-                .having((e) => e.exitCode, 'exitCode', equals(ExitCode.validationFailed)),
+                .having(
+                  (e) => e.exitCode,
+                  'exitCode',
+                  equals(ExitCode.validationFailed),
+                ),
           ),
         );
       });
@@ -269,7 +313,11 @@ void main() {
           throwsA(
             isA<CommandException>()
                 .having((e) => e.code, 'code', equals('APE_NOT_FOUND'))
-                .having((e) => e.exitCode, 'exitCode', equals(ExitCode.notFound)),
+                .having(
+                  (e) => e.exitCode,
+                  'exitCode',
+                  equals(ExitCode.notFound),
+                ),
           ),
         );
       });
@@ -287,7 +335,11 @@ void main() {
           throwsA(
             isA<CommandException>()
                 .having((e) => e.code, 'code', equals('APE_NOT_ACTIVE'))
-                .having((e) => e.exitCode, 'exitCode', equals(ExitCode.conflict)),
+                .having(
+                  (e) => e.exitCode,
+                  'exitCode',
+                  equals(ExitCode.conflict),
+                ),
           ),
         );
       });
@@ -303,22 +355,25 @@ void main() {
           throwsA(
             isA<CommandException>()
                 .having((e) => e.code, 'code', equals('APE_NOT_ACTIVE'))
-                .having((e) => e.exitCode, 'exitCode', equals(ExitCode.conflict)),
+                .having(
+                  (e) => e.exitCode,
+                  'exitCode',
+                  equals(ExitCode.conflict),
+                ),
           ),
         );
       });
 
       test('socrates-idle in IDLE throws not active', () async {
-        writeStateWithApe('IDLE',
-          apeName: 'dewey',
-          apeState: 'evaluate_scope',
+        writeStateWithApe('IDLE', apeName: 'dewey', apeState: 'evaluate_scope');
+        File(
+          p.join(tmpDir.path, 'assets', 'apes', 'socrates-idle.yaml'),
+        ).writeAsStringSync(
+          File('assets/apes/dewey.yaml').readAsStringSync().replaceFirst(
+            'name: dewey',
+            'name: socrates-idle',
+          ),
         );
-        File(p.join(tmpDir.path, 'assets', 'apes', 'socrates-idle.yaml'))
-            .writeAsStringSync(
-              File('assets/apes/dewey.yaml')
-                  .readAsStringSync()
-                  .replaceFirst('name: dewey', 'name: socrates-idle'),
-            );
         final cmd = ApePromptCommand(
           ApePromptInput(name: 'socrates-idle', workingDirectory: tmpDir.path),
         );
@@ -328,7 +383,11 @@ void main() {
           throwsA(
             isA<CommandException>()
                 .having((e) => e.code, 'code', equals('APE_NOT_ACTIVE'))
-                .having((e) => e.exitCode, 'exitCode', equals(ExitCode.conflict)),
+                .having(
+                  (e) => e.exitCode,
+                  'exitCode',
+                  equals(ExitCode.conflict),
+                ),
           ),
         );
       });
@@ -382,7 +441,7 @@ void main() {
     group('missing .inquiry/state.yaml', () {
       test('defaults to IDLE when no state file exists', () async {
         // Delete the state file if it exists
-        final stateFile = File(p.join(tmpDir.path, '.inquiry', 'state.yaml'));
+        final stateFile = File(stateFilePath);
         if (stateFile.existsSync()) stateFile.deleteSync();
 
         final cmd = ApePromptCommand(
@@ -395,7 +454,11 @@ void main() {
           throwsA(
             isA<CommandException>()
                 .having((e) => e.code, 'code', equals('APE_NOT_ACTIVE'))
-                .having((e) => e.exitCode, 'exitCode', equals(ExitCode.conflict)),
+                .having(
+                  (e) => e.exitCode,
+                  'exitCode',
+                  equals(ExitCode.conflict),
+                ),
           ),
         );
       });
@@ -487,7 +550,9 @@ void main() {
         );
         expect(
           result.prompt,
-          contains('EVOLUTION owns the repository procedure for issue search/comment/create and metrics collection.'),
+          contains(
+            'EVOLUTION owns the repository procedure for issue search/comment/create and metrics collection.',
+          ),
         );
         expect(result.prompt, contains('Observation'));
       });
@@ -495,7 +560,8 @@ void main() {
 
     group('auto-read sub-state from state.yaml', () {
       test('reads ape.state when no --state flag', () async {
-        writeStateWithApe('ANALYZE',
+        writeStateWithApe(
+          'ANALYZE',
           issue: '145',
           apeName: 'socrates',
           apeState: 'evidence',
@@ -511,7 +577,8 @@ void main() {
       });
 
       test('--state flag overrides ape.state from state.yaml', () async {
-        writeStateWithApe('ANALYZE',
+        writeStateWithApe(
+          'ANALYZE',
           issue: '145',
           apeName: 'socrates',
           apeState: 'evidence',
@@ -531,7 +598,8 @@ void main() {
       });
 
       test('works with basho ape sub-state', () async {
-        writeStateWithApe('EXECUTE',
+        writeStateWithApe(
+          'EXECUTE',
           issue: '145',
           apeName: 'basho',
           apeState: 'test',
@@ -554,10 +622,16 @@ void main() {
         final promptIndex = prompt.indexOf(promptFragment);
         final contextIndex = prompt.indexOf('# --- inquiry-context ---');
 
-        expect(promptIndex, greaterThanOrEqualTo(0),
-            reason: 'Missing assembled prompt fragment: $promptFragment');
-        expect(contextIndex, greaterThan(promptIndex),
-            reason: 'inquiry-context should stay explicit after the prompt body');
+        expect(
+          promptIndex,
+          greaterThanOrEqualTo(0),
+          reason: 'Missing assembled prompt fragment: $promptFragment',
+        );
+        expect(
+          contextIndex,
+          greaterThan(promptIndex),
+          reason: 'inquiry-context should stay explicit after the prompt body',
+        );
       }
 
       void expectOperationalContractBetween(
@@ -566,31 +640,57 @@ void main() {
         required String contractFragment,
       }) {
         final identityIndex = prompt.indexOf(identityFragment);
-        final contractIndex = prompt.indexOf('## Phase-Owned Operational Contract');
+        final contractIndex = prompt.indexOf(
+          '## Phase-Owned Operational Contract',
+        );
         final detailIndex = prompt.indexOf(contractFragment);
         final contextIndex = prompt.indexOf('# --- inquiry-context ---');
 
-        expect(identityIndex, greaterThanOrEqualTo(0),
-            reason: 'Missing assembled prompt identity fragment: $identityFragment');
-        expect(contractIndex, greaterThan(identityIndex),
-            reason: 'Operational contract should come after the APE identity');
-        expect(detailIndex, greaterThan(contractIndex),
-            reason: 'Operational contract should expose the phase-owned details');
-        expect(contextIndex, greaterThan(detailIndex),
-            reason: 'inquiry-context should stay explicit after the operational contract');
+        expect(
+          identityIndex,
+          greaterThanOrEqualTo(0),
+          reason:
+              'Missing assembled prompt identity fragment: $identityFragment',
+        );
+        expect(
+          contractIndex,
+          greaterThan(identityIndex),
+          reason: 'Operational contract should come after the APE identity',
+        );
+        expect(
+          detailIndex,
+          greaterThan(contractIndex),
+          reason: 'Operational contract should expose the phase-owned details',
+        );
+        expect(
+          contextIndex,
+          greaterThan(detailIndex),
+          reason:
+              'inquiry-context should stay explicit after the operational contract',
+        );
       }
 
-        void expectContextKeyOnlyInInquiryContext(String prompt, String key) {
+      void expectContextKeyOnlyInInquiryContext(String prompt, String key) {
         final contextIndex = prompt.indexOf('# --- inquiry-context ---');
         final keyIndex = prompt.indexOf(key);
 
-        expect(contextIndex, greaterThanOrEqualTo(0),
-          reason: 'Missing inquiry-context block for key: $key');
-        expect(keyIndex, greaterThan(contextIndex),
-          reason: '$key should be owned by inquiry-context, not the APE identity');
-        expect(prompt.indexOf(key, keyIndex + key.length), equals(-1),
-          reason: '$key should appear only once in the assembled prompt');
-        }
+        expect(
+          contextIndex,
+          greaterThanOrEqualTo(0),
+          reason: 'Missing inquiry-context block for key: $key',
+        );
+        expect(
+          keyIndex,
+          greaterThan(contextIndex),
+          reason:
+              '$key should be owned by inquiry-context, not the APE identity',
+        );
+        expect(
+          prompt.indexOf(key, keyIndex + key.length),
+          equals(-1),
+          reason: '$key should appear only once in the assembled prompt',
+        );
+      }
 
       setUp(() {
         gitTmpDir = Directory.systemTemp.createTempSync('ape_ctx_test_');
@@ -598,30 +698,62 @@ void main() {
 
         // Init a git repo with a branch and initial commit
         Process.runSync('git', ['init'], workingDirectory: gitTmpDir.path);
-        Process.runSync('git', ['config', 'user.email', 'test@test.com'],
-            workingDirectory: gitTmpDir.path);
-        Process.runSync('git', ['config', 'user.name', 'Test'],
-            workingDirectory: gitTmpDir.path);
+        Process.runSync('git', [
+          'config',
+          'user.email',
+          'test@test.com',
+        ], workingDirectory: gitTmpDir.path);
+        Process.runSync('git', [
+          'config',
+          'user.name',
+          'Test',
+        ], workingDirectory: gitTmpDir.path);
         File(p.join(gitTmpDir.path, '.gitkeep')).writeAsStringSync('');
         Process.runSync('git', ['add', '.'], workingDirectory: gitTmpDir.path);
-        Process.runSync('git', ['commit', '-m', 'init'],
-            workingDirectory: gitTmpDir.path);
-        Process.runSync('git', ['checkout', '-b', '152-test-branch'],
-            workingDirectory: gitTmpDir.path);
+        Process.runSync('git', [
+          'commit',
+          '-m',
+          'init',
+        ], workingDirectory: gitTmpDir.path);
+        Process.runSync('git', [
+          'checkout',
+          '-b',
+          '152-test-branch',
+        ], workingDirectory: gitTmpDir.path);
+        Directory(
+          p.join(gitTmpDir.path, 'cleanrooms', '152-test-branch'),
+        ).createSync(recursive: true);
 
         // Copy ape YAMLs
         final apesDir = Directory(p.join(gitTmpDir.path, 'assets', 'apes'));
         apesDir.createSync(recursive: true);
-        for (final name in ['socrates', 'dewey', 'descartes', 'basho', 'darwin']) {
-          File('assets/apes/$name.yaml')
-              .copySync(p.join(apesDir.path, '$name.yaml'));
+        for (final name in [
+          'socrates',
+          'dewey',
+          'descartes',
+          'basho',
+          'darwin',
+        ]) {
+          File(
+            'assets/apes/$name.yaml',
+          ).copySync(p.join(apesDir.path, '$name.yaml'));
         }
 
-        final statesDir = Directory(p.join(gitTmpDir.path, 'assets', 'fsm', 'states'));
+        final statesDir = Directory(
+          p.join(gitTmpDir.path, 'assets', 'fsm', 'states'),
+        );
         statesDir.createSync(recursive: true);
-        for (final name in ['idle', 'analyze', 'plan', 'execute', 'end', 'evolution']) {
-          File('assets/fsm/states/$name.yaml')
-              .copySync(p.join(statesDir.path, '$name.yaml'));
+        for (final name in [
+          'idle',
+          'analyze',
+          'plan',
+          'execute',
+          'end',
+          'evolution',
+        ]) {
+          File(
+            'assets/fsm/states/$name.yaml',
+          ).copySync(p.join(statesDir.path, '$name.yaml'));
         }
       });
 
@@ -630,8 +762,14 @@ void main() {
       });
 
       test('socrates prompt includes inquiry-context with output_dir', () async {
-        File(p.join(gitTmpDir.path, '.inquiry', 'state.yaml'))
-            .writeAsStringSync('state: ANALYZE\nissue: "152"\n');
+        File(
+          p.join(
+            gitTmpDir.path,
+            'cleanrooms',
+            '152-test-branch',
+            kStateFileName,
+          ),
+        ).writeAsStringSync('state: ANALYZE\nissue: "152"\n');
 
         final cmd = ApePromptCommand(
           ApePromptInput(
@@ -645,9 +783,20 @@ void main() {
         expect(result.prompt, contains('diagnosis.md'));
         expect(result.prompt, contains('Clarification questions'));
         expect(result.prompt, contains('# --- inquiry-context ---'));
-        expect(result.prompt, contains('output_dir: cleanrooms/152-test-branch/analyze/'));
-        expect(result.prompt, contains('confirmations_doc: cleanrooms/152-test-branch/analyze/confirmations.md'));
-        expect(result.prompt, contains('index_file: cleanrooms/152-test-branch/analyze/index.md'));
+        expect(
+          result.prompt,
+          contains('output_dir: cleanrooms/152-test-branch/analyze/'),
+        );
+        expect(
+          result.prompt,
+          contains(
+            'confirmations_doc: cleanrooms/152-test-branch/analyze/confirmations.md',
+          ),
+        );
+        expect(
+          result.prompt,
+          contains('index_file: cleanrooms/152-test-branch/analyze/index.md'),
+        );
         expect(result.prompt, contains('doc_protocol: doc-write'));
         expect(result.prompt, isNot(contains('confirmed_doc')));
         expect(result.prompt, isNot(contains('confirmed.md')));
@@ -671,8 +820,14 @@ void main() {
       });
 
       test('descartes prompt includes analysis_input path', () async {
-        File(p.join(gitTmpDir.path, '.inquiry', 'state.yaml'))
-            .writeAsStringSync('state: PLAN\nissue: "152"\n');
+        File(
+          p.join(
+            gitTmpDir.path,
+            'cleanrooms',
+            '152-test-branch',
+            kStateFileName,
+          ),
+        ).writeAsStringSync('state: PLAN\nissue: "152"\n');
 
         final cmd = ApePromptCommand(
           ApePromptInput(
@@ -686,8 +841,16 @@ void main() {
         expect(result.prompt, contains('EVIDENCE'));
         expect(result.prompt, contains('FOCUS: Division.'));
         expect(result.prompt, contains('# --- inquiry-context ---'));
-        expect(result.prompt, contains('analysis_input: cleanrooms/152-test-branch/analyze/diagnosis.md'));
-        expect(result.prompt, contains('plan_file: cleanrooms/152-test-branch/plan.md'));
+        expect(
+          result.prompt,
+          contains(
+            'analysis_input: cleanrooms/152-test-branch/analyze/diagnosis.md',
+          ),
+        );
+        expect(
+          result.prompt,
+          contains('plan_file: cleanrooms/152-test-branch/plan.md'),
+        );
         expect(result.prompt, contains('doc_protocol: doc-read'));
         expect(result.prompt, isNot(contains('Commit:')));
         expectContextKeyOnlyInInquiryContext(
@@ -706,8 +869,14 @@ void main() {
       });
 
       test('basho prompt includes plan contract in assembled prompt', () async {
-        File(p.join(gitTmpDir.path, '.inquiry', 'state.yaml'))
-            .writeAsStringSync('state: EXECUTE\nissue: "152"\n');
+        File(
+          p.join(
+            gitTmpDir.path,
+            'cleanrooms',
+            '152-test-branch',
+            kStateFileName,
+          ),
+        ).writeAsStringSync('state: EXECUTE\nissue: "152"\n');
 
         final cmd = ApePromptCommand(
           ApePromptInput(
@@ -726,17 +895,22 @@ void main() {
         expect(result.prompt, contains('## Phase-Owned Operational Contract'));
         expect(
           result.prompt,
-          contains('Implement the plan phase by phase under its formal constraints.'),
+          contains(
+            'Implement the plan phase by phase under its formal constraints.',
+          ),
         );
-        expect(
-          result.prompt,
-          contains('Follow plan.md phases in order'),
-        );
+        expect(result.prompt, contains('Follow plan.md phases in order'));
         expect(result.prompt, contains('Allowed actions:'));
         expect(result.prompt, contains('Edit code files'));
         expect(result.prompt, contains('# --- inquiry-context ---'));
-        expect(result.prompt, contains('plan_file: cleanrooms/152-test-branch/plan.md'));
-        expect(result.prompt, contains('output_dir: cleanrooms/152-test-branch/'));
+        expect(
+          result.prompt,
+          contains('plan_file: cleanrooms/152-test-branch/plan.md'),
+        );
+        expect(
+          result.prompt,
+          contains('output_dir: cleanrooms/152-test-branch/'),
+        );
         expect(result.prompt, contains('doc_protocol: doc-read'));
         expect(result.prompt, isNot(contains('Run tests, lint, build')));
         expect(result.prompt, isNot(contains('retrospective.md')));
@@ -754,131 +928,221 @@ void main() {
         );
         expectOperationalContractBetween(
           result.prompt,
-          identityFragment: 'Implement exactly what the plan says. No more, no less.',
-          contractFragment: 'Implement the plan phase by phase under its formal constraints.',
+          identityFragment:
+              'Implement exactly what the plan says. No more, no less.',
+          contractFragment:
+              'Implement the plan phase by phase under its formal constraints.',
         );
       });
 
-      test('dewey create_or_select prompt includes IDLE-owned routing context', () async {
-        File(p.join(gitTmpDir.path, '.inquiry', 'state.yaml'))
-            .writeAsStringSync(
-              'state: IDLE\n'
-              'issue: null\n'
-              'ape:\n'
-              '  name: dewey\n'
-              '  state: create_or_select\n',
-            );
+      test(
+        'dewey create_or_select prompt includes IDLE-owned routing context',
+        () async {
+          File(
+            p.join(
+              gitTmpDir.path,
+              'cleanrooms',
+              '152-test-branch',
+              kStateFileName,
+            ),
+          ).writeAsStringSync(
+            'state: IDLE\n'
+            'issue: null\n'
+            'ape:\n'
+            '  name: dewey\n'
+            '  state: create_or_select\n',
+          );
 
-        final cmd = ApePromptCommand(
-          ApePromptInput(name: 'dewey', workingDirectory: gitTmpDir.path),
-        );
-        final result = await cmd.execute();
+          final cmd = ApePromptCommand(
+            ApePromptInput(name: 'dewey', workingDirectory: gitTmpDir.path),
+          );
+          final result = await cmd.execute();
 
-        expect(result.subState, equals('create_or_select'));
-        expect(result.prompt, contains('FOCUS: Issue formulation. Create or select.'));
-        expect(result.prompt, contains('# --- inquiry-context ---'));
-        expect(
-          result.prompt,
-          contains('IDLE owns that fast-path routing contract: triage_objective=create_or_select, deterministic_skill=issue-create, allowed_commands=gh issue list, gh issue view, gh issue create, gh issue edit.'),
-        );
-        expect(result.prompt, contains('triage_objective: create_or_select'));
-        expect(result.prompt, contains('deterministic_skill: issue-create'));
-        expect(
-          result.prompt,
-          contains('allowed_commands: gh issue list, gh issue view, gh issue create, gh issue edit'),
-        );
-        expectOperationalContractBetween(
-          result.prompt,
-          identityFragment: 'FOCUS: Issue formulation. Create or select.',
-          contractFragment: 'IDLE owns that fast-path routing contract: triage_objective=create_or_select',
-        );
-        expectExplicitContextAfter(
-          result.prompt,
-          'FOCUS: Issue formulation. Create or select.',
-        );
-      });
+          expect(result.subState, equals('create_or_select'));
+          expect(
+            result.prompt,
+            contains('FOCUS: Issue formulation. Create or select.'),
+          );
+          expect(result.prompt, contains('# --- inquiry-context ---'));
+          expect(
+            result.prompt,
+            contains(
+              'IDLE owns that fast-path routing contract: triage_objective=create_or_select, deterministic_skill=issue-create, allowed_commands=gh issue list, gh issue view, gh issue create, gh issue edit.',
+            ),
+          );
+          expect(result.prompt, contains('triage_objective: create_or_select'));
+          expect(result.prompt, contains('deterministic_skill: issue-create'));
+          expect(
+            result.prompt,
+            contains(
+              'allowed_commands: gh issue list, gh issue view, gh issue create, gh issue edit',
+            ),
+          );
+          expectOperationalContractBetween(
+            result.prompt,
+            identityFragment: 'FOCUS: Issue formulation. Create or select.',
+            contractFragment:
+                'IDLE owns that fast-path routing contract: triage_objective=create_or_select',
+          );
+          expectExplicitContextAfter(
+            result.prompt,
+            'FOCUS: Issue formulation. Create or select.',
+          );
+        },
+      );
 
-      test('dewey search_existing prompt keeps GitHub procedure in the IDLE contract', () async {
-        File(p.join(gitTmpDir.path, '.inquiry', 'state.yaml'))
-            .writeAsStringSync(
-              'state: IDLE\n'
-              'issue: null\n'
-              'ape:\n'
-              '  name: dewey\n'
-              '  state: search_existing\n',
-            );
+      test(
+        'dewey search_existing prompt keeps GitHub procedure in the IDLE contract',
+        () async {
+          File(
+            p.join(
+              gitTmpDir.path,
+              'cleanrooms',
+              '152-test-branch',
+              kStateFileName,
+            ),
+          ).writeAsStringSync(
+            'state: IDLE\n'
+            'issue: null\n'
+            'ape:\n'
+            '  name: dewey\n'
+            '  state: search_existing\n',
+          );
 
-        final cmd = ApePromptCommand(
-          ApePromptInput(name: 'dewey', workingDirectory: gitTmpDir.path),
-        );
-        final result = await cmd.execute();
+          final cmd = ApePromptCommand(
+            ApePromptInput(name: 'dewey', workingDirectory: gitTmpDir.path),
+          );
+          final result = await cmd.execute();
 
-        expect(result.subState, equals('search_existing'));
-        expect(result.prompt, contains('FOCUS: Deduplication. Search before creating.'));
-        expect(
-          result.prompt,
-          isNot(contains('Use: `gh issue list --search "<keywords>"` to find existing issues.')),
-        );
-        expect(
-          result.prompt,
-          contains('IDLE owns that fast-path routing contract: triage_objective=create_or_select, deterministic_skill=issue-create, allowed_commands=gh issue list, gh issue view, gh issue create, gh issue edit.'),
-        );
-        final promptIndex = result.prompt.indexOf(
-          'FOCUS: Deduplication. Search before creating.',
-        );
-        final contractIndex = result.prompt.indexOf(
-          '## Phase-Owned Operational Contract',
-        );
-        final detailIndex = result.prompt.indexOf(
-          'IDLE owns that fast-path routing contract: triage_objective=create_or_select',
-        );
+          expect(result.subState, equals('search_existing'));
+          expect(
+            result.prompt,
+            contains('FOCUS: Deduplication. Search before creating.'),
+          );
+          expect(
+            result.prompt,
+            isNot(
+              contains(
+                'Use: `gh issue list --search "<keywords>"` to find existing issues.',
+              ),
+            ),
+          );
+          expect(
+            result.prompt,
+            contains(
+              'IDLE owns that fast-path routing contract: triage_objective=create_or_select, deterministic_skill=issue-create, allowed_commands=gh issue list, gh issue view, gh issue create, gh issue edit.',
+            ),
+          );
+          final promptIndex = result.prompt.indexOf(
+            'FOCUS: Deduplication. Search before creating.',
+          );
+          final contractIndex = result.prompt.indexOf(
+            '## Phase-Owned Operational Contract',
+          );
+          final detailIndex = result.prompt.indexOf(
+            'IDLE owns that fast-path routing contract: triage_objective=create_or_select',
+          );
 
-        expect(promptIndex, greaterThanOrEqualTo(0));
-        expect(contractIndex, greaterThan(promptIndex));
-        expect(detailIndex, greaterThan(contractIndex));
-      });
+          expect(promptIndex, greaterThanOrEqualTo(0));
+          expect(contractIndex, greaterThan(promptIndex));
+          expect(detailIndex, greaterThan(contractIndex));
+        },
+      );
 
-      test('darwin prompt includes cycle artifact contract in assembled prompt', () async {
-        File(p.join(gitTmpDir.path, '.inquiry', 'state.yaml'))
-            .writeAsStringSync('state: EVOLUTION\nissue: "152"\n');
+      test(
+        'darwin prompt includes cycle artifact contract in assembled prompt',
+        () async {
+          File(
+            p.join(
+              gitTmpDir.path,
+              'cleanrooms',
+              '152-test-branch',
+              kStateFileName,
+            ),
+          ).writeAsStringSync('state: EVOLUTION\nissue: "152"\n');
 
-        final cmd = ApePromptCommand(
-          ApePromptInput(
-            name: 'darwin',
-            subState: 'observe',
-            workingDirectory: gitTmpDir.path,
-          ),
-        );
-        final result = await cmd.execute();
+          final cmd = ApePromptCommand(
+            ApePromptInput(
+              name: 'darwin',
+              subState: 'observe',
+              workingDirectory: gitTmpDir.path,
+            ),
+          );
+          final result = await cmd.execute();
 
-        expect(result.prompt, contains('diagnosis.md'));
-        expect(result.prompt, contains('FOCUS: Observation.'));
-        expect(
-          result.prompt,
-          contains('EVOLUTION owns the repository procedure for issue search/comment/create and metrics collection.'),
-        );
-        expect(result.prompt, contains('# --- inquiry-context ---'));
-        expect(result.prompt, contains('analyze_dir: cleanrooms/152-test-branch/analyze/'));
-        expect(result.prompt, contains('plan_file: cleanrooms/152-test-branch/plan.md'));
-        expect(
-          result.prompt,
-          contains('retrospective_file: cleanrooms/152-test-branch/retrospective.md'),
-        );
-        expect(result.prompt, contains('mutations_file: .inquiry/mutations.md'));
-        expect(result.prompt, contains('state_file: .inquiry/state.yaml'));
-        expect(
-          result.prompt,
-          contains('metrics_snapshot_file: .inquiry/metrics_snapshot.yaml'),
-        );
-        expect(result.prompt, contains('metrics_file: .inquiry/metrics.yaml'));
-        expect(result.prompt, contains('output_dir: cleanrooms/152-test-branch/'));
-        expectExplicitContextAfter(result.prompt, 'FOCUS: Observation.');
-      });
+          expect(result.prompt, contains('diagnosis.md'));
+          expect(result.prompt, contains('FOCUS: Observation.'));
+          expect(
+            result.prompt,
+            contains(
+              'EVOLUTION owns the repository procedure for issue search/comment/create and metrics collection.',
+            ),
+          );
+          expect(result.prompt, contains('# --- inquiry-context ---'));
+          expect(
+            result.prompt,
+            contains('analyze_dir: cleanrooms/152-test-branch/analyze/'),
+          );
+          expect(
+            result.prompt,
+            contains('plan_file: cleanrooms/152-test-branch/plan.md'),
+          );
+          expect(
+            result.prompt,
+            contains(
+              'retrospective_file: cleanrooms/152-test-branch/retrospective.md',
+            ),
+          );
+          expect(
+            result.prompt,
+            contains('mutations_file: .inquiry/mutations.md'),
+          );
+          expect(result.prompt, contains('state_file: .inquiry/state.yaml'));
+          expect(
+            result.prompt,
+            contains('metrics_snapshot_file: .inquiry/metrics_snapshot.yaml'),
+          );
+          expect(
+            result.prompt,
+            contains('metrics_file: .inquiry/metrics.yaml'),
+          );
+          expect(
+            result.prompt,
+            contains('output_dir: cleanrooms/152-test-branch/'),
+          );
+          expectExplicitContextAfter(result.prompt, 'FOCUS: Observation.');
+        },
+      );
 
       test('no context injected when not in a git repo', () async {
-        writeState('ANALYZE');
+        // A fresh directory with no git repo → no cycle resolves.
+        final nonGitDir = Directory.systemTemp.createTempSync('ape_nogit_');
+        addTearDown(() => nonGitDir.deleteSync(recursive: true));
+        final apesDir = Directory(p.join(nonGitDir.path, 'assets', 'apes'));
+        apesDir.createSync(recursive: true);
+        File(
+          'assets/apes/dewey.yaml',
+        ).copySync(p.join(apesDir.path, 'dewey.yaml'));
+        final statesDir = Directory(
+          p.join(nonGitDir.path, 'assets', 'fsm', 'states'),
+        );
+        statesDir.createSync(recursive: true);
+        for (final name in [
+          'idle',
+          'analyze',
+          'plan',
+          'execute',
+          'end',
+          'evolution',
+        ]) {
+          File(
+            'assets/fsm/states/$name.yaml',
+          ).copySync(p.join(statesDir.path, '$name.yaml'));
+        }
+
+        // Outside any git repo, no cycle resolves → derived IDLE (dewey).
         final cmd = ApePromptCommand(
-          ApePromptInput(name: 'socrates', workingDirectory: tmpDir.path),
+          ApePromptInput(name: 'dewey', workingDirectory: nonGitDir.path),
         );
         final result = await cmd.execute();
 
@@ -886,4 +1150,21 @@ void main() {
       });
     });
   });
+}
+
+void _initGitRepo(String root, {required String branch}) {
+  void git(List<String> args) {
+    final result = Process.runSync('git', args, workingDirectory: root);
+    if (result.exitCode != 0) {
+      throw StateError('git ${args.join(' ')} failed: ${result.stderr}');
+    }
+  }
+
+  git(['init']);
+  git(['config', 'user.email', 'test@test.com']);
+  git(['config', 'user.name', 'Test']);
+  File(p.join(root, '.gitkeep')).writeAsStringSync('');
+  git(['add', '.']);
+  git(['commit', '-m', 'init']);
+  git(['checkout', '-b', branch]);
 }

--- a/code/cli/test/ape_prompt_test.dart
+++ b/code/cli/test/ape_prompt_test.dart
@@ -1095,9 +1095,12 @@ void main() {
           );
           expect(
             result.prompt,
-            contains('mutations_file: .inquiry/mutations.md'),
+            contains('mutations_file: cleanrooms/152-test-branch/mutations.md'),
           );
-          expect(result.prompt, contains('state_file: .inquiry/state.yaml'));
+          expect(
+            result.prompt,
+            contains('state_file: cleanrooms/152-test-branch/.iq.state.yaml'),
+          );
           expect(
             result.prompt,
             contains('metrics_snapshot_file: .inquiry/metrics_snapshot.yaml'),

--- a/code/cli/test/ape_state_test.dart
+++ b/code/cli/test/ape_state_test.dart
@@ -1,22 +1,27 @@
 import 'dart:io';
 
 import 'package:inquiry_cli/modules/ape/commands/state.dart';
+import 'package:inquiry_cli/modules/ape/inquiry_state.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
   late Directory tmpDir;
 
+  const branch = '145-test-branch';
+
   setUp(() {
     tmpDir = Directory.systemTemp.createTempSync('ape_state_test_');
     Directory(p.join(tmpDir.path, '.inquiry')).createSync(recursive: true);
+    _initGitRepo(tmpDir.path, branch: branch);
 
     // Copy APE YAML assets
     final apesDir = Directory(p.join(tmpDir.path, 'assets', 'apes'));
     apesDir.createSync(recursive: true);
     for (final name in ['socrates', 'descartes', 'basho', 'darwin']) {
-      File('assets/apes/$name.yaml')
-          .copySync(p.join(apesDir.path, '$name.yaml'));
+      File(
+        'assets/apes/$name.yaml',
+      ).copySync(p.join(apesDir.path, '$name.yaml'));
     }
   });
 
@@ -40,17 +45,16 @@ void main() {
     } else {
       buf.writeln('ape: null');
     }
-    File(p.join(tmpDir.path, '.inquiry', 'state.yaml'))
-        .writeAsStringSync(buf.toString());
+    File(p.join(tmpDir.path, 'cleanrooms', branch, kStateFileName))
+      ..createSync(recursive: true)
+      ..writeAsStringSync(buf.toString());
   }
 
   group('ApeStateCommand', () {
     test('returns null ape when no APE active', () async {
       writeState(state: 'IDLE');
 
-      final cmd = ApeStateCommand(
-        ApeStateInput(workingDirectory: tmpDir.path),
-      );
+      final cmd = ApeStateCommand(ApeStateInput(workingDirectory: tmpDir.path));
       final result = await cmd.execute();
 
       expect(result.apeName, isNull);
@@ -66,9 +70,7 @@ void main() {
         apeState: 'clarification',
       );
 
-      final cmd = ApeStateCommand(
-        ApeStateInput(workingDirectory: tmpDir.path),
-      );
+      final cmd = ApeStateCommand(ApeStateInput(workingDirectory: tmpDir.path));
       final result = await cmd.execute();
 
       expect(result.apeName, equals('socrates'));
@@ -88,9 +90,7 @@ void main() {
         apeState: '_DONE',
       );
 
-      final cmd = ApeStateCommand(
-        ApeStateInput(workingDirectory: tmpDir.path),
-      );
+      final cmd = ApeStateCommand(ApeStateInput(workingDirectory: tmpDir.path));
       final result = await cmd.execute();
 
       expect(result.apeName, equals('socrates'));
@@ -106,9 +106,7 @@ void main() {
         apeState: 'implement',
       );
 
-      final cmd = ApeStateCommand(
-        ApeStateInput(workingDirectory: tmpDir.path),
-      );
+      final cmd = ApeStateCommand(ApeStateInput(workingDirectory: tmpDir.path));
       final result = await cmd.execute();
 
       expect(result.apeName, equals('basho'));
@@ -125,9 +123,7 @@ void main() {
         apeState: 'decomposition',
       );
 
-      final cmd = ApeStateCommand(
-        ApeStateInput(workingDirectory: tmpDir.path),
-      );
+      final cmd = ApeStateCommand(ApeStateInput(workingDirectory: tmpDir.path));
       final result = await cmd.execute();
       final text = result.toText()!;
 
@@ -144,9 +140,7 @@ void main() {
         apeState: 'observe',
       );
 
-      final cmd = ApeStateCommand(
-        ApeStateInput(workingDirectory: tmpDir.path),
-      );
+      final cmd = ApeStateCommand(ApeStateInput(workingDirectory: tmpDir.path));
       final result = await cmd.execute();
       final json = result.toJson();
 
@@ -158,8 +152,7 @@ void main() {
 
     test('handles missing APE YAML gracefully', () async {
       // Delete the YAML file
-      File(p.join(tmpDir.path, 'assets', 'apes', 'socrates.yaml'))
-          .deleteSync();
+      File(p.join(tmpDir.path, 'assets', 'apes', 'socrates.yaml')).deleteSync();
 
       writeState(
         state: 'ANALYZE',
@@ -168,9 +161,7 @@ void main() {
         apeState: 'clarification',
       );
 
-      final cmd = ApeStateCommand(
-        ApeStateInput(workingDirectory: tmpDir.path),
-      );
+      final cmd = ApeStateCommand(ApeStateInput(workingDirectory: tmpDir.path));
       final result = await cmd.execute();
 
       expect(result.apeName, equals('socrates'));
@@ -178,4 +169,21 @@ void main() {
       expect(result.transitions, isEmpty);
     });
   });
+}
+
+void _initGitRepo(String root, {required String branch}) {
+  void git(List<String> args) {
+    final result = Process.runSync('git', args, workingDirectory: root);
+    if (result.exitCode != 0) {
+      throw StateError('git ${args.join(' ')} failed: ${result.stderr}');
+    }
+  }
+
+  git(['init']);
+  git(['config', 'user.email', 'test@test.com']);
+  git(['config', 'user.name', 'Test']);
+  File(p.join(root, '.gitkeep')).writeAsStringSync('');
+  git(['add', '.']);
+  git(['commit', '-m', 'init']);
+  git(['checkout', '-b', branch]);
 }

--- a/code/cli/test/ape_transition_test.dart
+++ b/code/cli/test/ape_transition_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:inquiry_cli/modules/ape/commands/transition.dart';
+import 'package:inquiry_cli/modules/ape/inquiry_state.dart';
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -8,16 +9,20 @@ import 'package:test/test.dart';
 void main() {
   late Directory tmpDir;
 
+  const branch = '145-test-branch';
+
   setUp(() {
     tmpDir = Directory.systemTemp.createTempSync('ape_transition_test_');
     Directory(p.join(tmpDir.path, '.inquiry')).createSync(recursive: true);
+    _initGitRepo(tmpDir.path, branch: branch);
 
     // Copy APE YAML assets
     final apesDir = Directory(p.join(tmpDir.path, 'assets', 'apes'));
     apesDir.createSync(recursive: true);
     for (final name in ['socrates', 'dewey', 'descartes', 'basho', 'darwin']) {
-      File('assets/apes/$name.yaml')
-          .copySync(p.join(apesDir.path, '$name.yaml'));
+      File(
+        'assets/apes/$name.yaml',
+      ).copySync(p.join(apesDir.path, '$name.yaml'));
     }
   });
 
@@ -41,8 +46,9 @@ void main() {
     } else {
       buf.writeln('ape: null');
     }
-    File(p.join(tmpDir.path, '.inquiry', 'state.yaml'))
-        .writeAsStringSync(buf.toString());
+    File(p.join(tmpDir.path, 'cleanrooms', branch, kStateFileName))
+      ..createSync(recursive: true)
+      ..writeAsStringSync(buf.toString());
   }
 
   void setupGitRepoWithFeatureCommit() {
@@ -59,16 +65,9 @@ void main() {
       }
     }
 
-    git(['init']);
-    git(['config', 'user.email', 'test@test.com']);
-    git(['config', 'user.name', 'Test User']);
-
+    // setUp already initialised the repo on the feature branch; add a
+    // feature commit on top.
     final trackedFile = File(p.join(tmpDir.path, 'README.md'));
-    trackedFile.writeAsStringSync('# Test repo\n');
-    git(['add', '.']);
-    git(['commit', '-m', 'init']);
-
-    git(['checkout', '-b', '145-test-branch']);
     trackedFile.writeAsStringSync('# Test repo\nfeature change\n');
     git(['add', 'README.md']);
     git(['commit', '-m', 'phase commit']);
@@ -109,8 +108,9 @@ void main() {
         await cmd.execute();
 
         // Verify persisted
-        final content = File(p.join(tmpDir.path, '.inquiry', 'state.yaml'))
-            .readAsStringSync();
+        final content = File(
+          p.join(tmpDir.path, 'cleanrooms', branch, kStateFileName),
+        ).readAsStringSync();
         expect(content, contains('state: assumptions'));
         // Main FSM state preserved
         expect(content, contains('state: ANALYZE'));
@@ -151,39 +151,42 @@ void main() {
         expect(result.to, equals('implement'));
       });
 
-      test('basho commit --next_phase--> implement preserves outer FSM state', () async {
-        setupGitRepoWithFeatureCommit();
-        writeState(
-          state: 'EXECUTE',
-          issue: '145',
-          apeName: 'basho',
-          apeState: 'commit',
-        );
+      test(
+        'basho commit --next_phase--> implement preserves outer FSM state',
+        () async {
+          setupGitRepoWithFeatureCommit();
+          writeState(
+            state: 'EXECUTE',
+            issue: '145',
+            apeName: 'basho',
+            apeState: 'commit',
+          );
 
-        final cmd = ApeTransitionCommand(
-          ApeTransitionInput(event: 'next_phase', workingDirectory: tmpDir.path),
-        );
-        final result = await cmd.execute();
+          final cmd = ApeTransitionCommand(
+            ApeTransitionInput(
+              event: 'next_phase',
+              workingDirectory: tmpDir.path,
+            ),
+          );
+          final result = await cmd.execute();
 
-        expect(result.from, equals('commit'));
-        expect(result.to, equals('implement'));
+          expect(result.from, equals('commit'));
+          expect(result.to, equals('implement'));
 
-        final content = File(p.join(tmpDir.path, '.inquiry', 'state.yaml'))
-            .readAsStringSync();
-        expect(content, contains('state: EXECUTE'));
-        expect(content, contains('issue: "145"'));
-        expect(content, contains('name: basho'));
-        expect(content, contains('state: implement'));
-        expect(content, isNot(contains('issue: null')));
-        expect(content, isNot(contains('state: IDLE')));
-      });
+          final content = File(
+            p.join(tmpDir.path, 'cleanrooms', branch, kStateFileName),
+          ).readAsStringSync();
+          expect(content, contains('state: EXECUTE'));
+          expect(content, contains('issue: "145"'));
+          expect(content, contains('name: basho'));
+          expect(content, contains('state: implement'));
+          expect(content, isNot(contains('issue: null')));
+          expect(content, isNot(contains('state: IDLE')));
+        },
+      );
 
       test('dewey confirm --complete--> evaluate_scope', () async {
-        writeState(
-          state: 'IDLE',
-          apeName: 'dewey',
-          apeState: 'confirm',
-        );
+        writeState(state: 'IDLE', apeName: 'dewey', apeState: 'confirm');
 
         final cmd = ApeTransitionCommand(
           ApeTransitionInput(event: 'complete', workingDirectory: tmpDir.path),
@@ -266,22 +269,34 @@ void main() {
     });
 
     group('error cases', () {
-      test('throws CommandException MISSING_EVENT when event flag is null', () async {
-        writeState(state: 'ANALYZE', issue: '145', apeName: 'socrates', apeState: 'clarification');
+      test(
+        'throws CommandException MISSING_EVENT when event flag is null',
+        () async {
+          writeState(
+            state: 'ANALYZE',
+            issue: '145',
+            apeName: 'socrates',
+            apeState: 'clarification',
+          );
 
-        final cmd = ApeTransitionCommand(
-          ApeTransitionInput(event: null, workingDirectory: tmpDir.path),
-        );
+          final cmd = ApeTransitionCommand(
+            ApeTransitionInput(event: null, workingDirectory: tmpDir.path),
+          );
 
-        expect(
-          () => cmd.execute(),
-          throwsA(
-            isA<CommandException>()
-                .having((e) => e.code, 'code', equals('MISSING_EVENT'))
-                .having((e) => e.exitCode, 'exitCode', equals(ExitCode.validationFailed)),
-          ),
-        );
-      });
+          expect(
+            () => cmd.execute(),
+            throwsA(
+              isA<CommandException>()
+                  .having((e) => e.code, 'code', equals('MISSING_EVENT'))
+                  .having(
+                    (e) => e.exitCode,
+                    'exitCode',
+                    equals(ExitCode.validationFailed),
+                  ),
+            ),
+          );
+        },
+      );
 
       test('throws NO_ACTIVE_APE when no APE in state', () async {
         writeState(state: 'IDLE');
@@ -295,7 +310,11 @@ void main() {
           throwsA(
             isA<CommandException>()
                 .having((e) => e.code, 'code', equals('NO_ACTIVE_APE'))
-                .having((e) => e.exitCode, 'exitCode', equals(ExitCode.conflict)),
+                .having(
+                  (e) => e.exitCode,
+                  'exitCode',
+                  equals(ExitCode.conflict),
+                ),
           ),
         );
       });
@@ -317,7 +336,11 @@ void main() {
           throwsA(
             isA<CommandException>()
                 .having((e) => e.code, 'code', equals('APE_COMPLETED'))
-                .having((e) => e.exitCode, 'exitCode', equals(ExitCode.conflict)),
+                .having(
+                  (e) => e.exitCode,
+                  'exitCode',
+                  equals(ExitCode.conflict),
+                ),
           ),
         );
       });
@@ -339,15 +362,20 @@ void main() {
           throwsA(
             isA<CommandException>()
                 .having((e) => e.code, 'code', equals('INVALID_APE_EVENT'))
-                .having((e) => e.exitCode, 'exitCode', equals(ExitCode.validationFailed)),
+                .having(
+                  (e) => e.exitCode,
+                  'exitCode',
+                  equals(ExitCode.validationFailed),
+                ),
           ),
         );
       });
 
       test('throws APE_NOT_FOUND when YAML missing', () async {
         // Delete socrates YAML
-        File(p.join(tmpDir.path, 'assets', 'apes', 'socrates.yaml'))
-            .deleteSync();
+        File(
+          p.join(tmpDir.path, 'assets', 'apes', 'socrates.yaml'),
+        ).deleteSync();
 
         writeState(
           state: 'ANALYZE',
@@ -365,7 +393,11 @@ void main() {
           throwsA(
             isA<CommandException>()
                 .having((e) => e.code, 'code', equals('APE_NOT_FOUND'))
-                .having((e) => e.exitCode, 'exitCode', equals(ExitCode.notFound)),
+                .having(
+                  (e) => e.exitCode,
+                  'exitCode',
+                  equals(ExitCode.notFound),
+                ),
           ),
         );
       });
@@ -409,4 +441,21 @@ void main() {
       });
     });
   });
+}
+
+void _initGitRepo(String root, {required String branch}) {
+  void git(List<String> args) {
+    final result = Process.runSync('git', args, workingDirectory: root);
+    if (result.exitCode != 0) {
+      throw StateError('git ${args.join(' ')} failed: ${result.stderr}');
+    }
+  }
+
+  git(['init']);
+  git(['config', 'user.email', 'test@test.com']);
+  git(['config', 'user.name', 'Test']);
+  File(p.join(root, '.gitkeep')).writeAsStringSync('');
+  git(['add', '.']);
+  git(['commit', '-m', 'init']);
+  git(['checkout', '-b', branch]);
 }

--- a/code/cli/test/cycle_context_test.dart
+++ b/code/cli/test/cycle_context_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:inquiry_cli/src/cycle_context.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// Runs a git command synchronously in [dir], failing the test on error.
+void _git(String dir, List<String> args) {
+  final r = Process.runSync('git', args, workingDirectory: dir);
+  if (r.exitCode != 0) {
+    fail('git ${args.join(' ')} failed: ${r.stderr}');
+  }
+}
+
+void _initRepo(String dir) {
+  _git(dir, ['init', '-q']);
+  _git(dir, ['config', 'user.email', 'test@example.com']);
+  _git(dir, ['config', 'user.name', 'test']);
+  _git(dir, ['config', 'commit.gpgsign', 'false']);
+  File(p.join(dir, 'README.md')).writeAsStringSync('# test\n');
+  _git(dir, ['add', '.']);
+  _git(dir, ['commit', '-q', '-m', 'init']);
+}
+
+void main() {
+  group('CycleContext.normalizeBranch', () {
+    test('returns null for detached HEAD token', () {
+      expect(CycleContext.normalizeBranch('HEAD'), isNull);
+    });
+
+    test('returns null for empty/whitespace', () {
+      expect(CycleContext.normalizeBranch(''), isNull);
+      expect(CycleContext.normalizeBranch('   '), isNull);
+    });
+
+    test('returns the branch name when valid', () {
+      expect(
+        CycleContext.normalizeBranch('209-cleanroom-canonical-inquiry-root'),
+        equals('209-cleanroom-canonical-inquiry-root'),
+      );
+    });
+  });
+
+  group('CycleContext.resolve', () {
+    late Directory tmp;
+
+    setUp(() {
+      tmp = Directory.systemTemp.createTempSync('cycle_context_test_');
+    });
+
+    tearDown(() {
+      tmp.deleteSync(recursive: true);
+    });
+
+    test('throws outside a git repository', () {
+      expect(
+        () => CycleContext.resolve(tmp.path),
+        throwsA(isA<CycleResolutionException>()),
+      );
+    });
+
+    test(
+      'resolves project root, branch and inquiry root on a feature branch',
+      () {
+        _initRepo(tmp.path);
+        _git(tmp.path, ['checkout', '-q', '-b', '209-canonical-root']);
+
+        final ctx = CycleContext.resolve(tmp.path);
+
+        // project root may be a symlink-resolved path on macOS; compare basenames.
+        expect(Directory(ctx.projectRoot).existsSync(), isTrue);
+        expect(ctx.branch, equals('209-canonical-root'));
+        expect(ctx.isIdle, isFalse);
+        expect(
+          ctx.inquiryRoot,
+          equals(p.join(ctx.projectRoot, 'cleanrooms', '209-canonical-root')),
+        );
+        expect(ctx.inquiryCliRoot, equals(ctx.projectRoot));
+      },
+    );
+
+    test('rejects a branch name containing a path separator', () {
+      _initRepo(tmp.path);
+      _git(tmp.path, ['checkout', '-q', '-b', 'feature/foo']);
+
+      expect(
+        () => CycleContext.resolve(tmp.path),
+        throwsA(isA<CycleResolutionException>()),
+      );
+    });
+
+    test('detached HEAD resolves to derived IDLE (no inquiry root)', () {
+      _initRepo(tmp.path);
+      final head =
+          Process.runSync('git', [
+                'rev-parse',
+                'HEAD',
+              ], workingDirectory: tmp.path).stdout
+              as String;
+      _git(tmp.path, ['checkout', '-q', head.trim()]);
+
+      final ctx = CycleContext.resolve(tmp.path);
+      expect(ctx.isIdle, isTrue);
+      expect(ctx.branch, isNull);
+      expect(ctx.inquiryRoot, isNull);
+    });
+  });
+}

--- a/code/cli/test/effect_executor_test.dart
+++ b/code/cli/test/effect_executor_test.dart
@@ -1,14 +1,23 @@
 import 'dart:io';
 
+import 'package:inquiry_cli/modules/ape/inquiry_state.dart';
 import 'package:inquiry_cli/modules/fsm/effect_executor.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
   late Directory tempDir;
+  late String stateFilePath;
+
+  const branch = '145-test-branch';
 
   setUp(() {
     tempDir = Directory.systemTemp.createTempSync('effect_executor_test_');
     Directory('${tempDir.path}/.inquiry').createSync(recursive: true);
+    _initGitRepo(tempDir.path, branch: branch);
+    final cycleDir = Directory(p.join(tempDir.path, 'cleanrooms', branch))
+      ..createSync(recursive: true);
+    stateFilePath = p.join(cycleDir.path, kStateFileName);
   });
 
   tearDown(() {
@@ -18,8 +27,7 @@ void main() {
   group('EffectExecutor', () {
     group('update_state', () {
       test('writes new state and issue to state.yaml', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: IDLE\nissue: null\n');
+        File(stateFilePath).writeAsStringSync('state: IDLE\nissue: null\n');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.updateState(
@@ -28,39 +36,39 @@ void main() {
           promptFragmentId: 'idle_to_analyze',
         );
 
-        final content =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
+        final content = File(stateFilePath).readAsStringSync();
         expect(content, contains('state: ANALYZE'));
         expect(content, contains('issue: "145"'));
         expect(content, contains('prompt_fragment_id: idle_to_analyze'));
       });
 
       test('preserves issue when not provided', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: ANALYZE\nissue: "145"\n');
+        File(stateFilePath).writeAsStringSync('state: ANALYZE\nissue: "145"\n');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.updateState('PLAN', promptFragmentId: 'analyze_to_plan');
 
-        final content =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
+        final content = File(stateFilePath).readAsStringSync();
         expect(content, contains('state: PLAN'));
         expect(content, contains('issue: "145"'));
         expect(content, contains('prompt_fragment_id: analyze_to_plan'));
       });
 
-      test('clears issue when transitioning to IDLE', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: EVOLUTION\nissue: "145"\n');
+      test('marks cycle completed when transitioning to IDLE', () {
+        File(
+          stateFilePath,
+        ).writeAsStringSync('state: EVOLUTION\nissue: "145"\n');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.updateState('IDLE');
 
-        final content =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
-        expect(content, contains('state: IDLE'));
-        expect(content, contains('issue: null'));
-        expect(content, contains('prompt_fragment_id: null'));
+        // IDLE is derived: the cycle file is marked completed, not rewritten to
+        // a persisted IDLE record. load() maps completed -> derived IDLE.
+        final raw = InquiryState.loadFrom(stateFilePath);
+        expect(raw.status, 'completed');
+        final derived = InquiryState.load(tempDir.path);
+        expect(derived.state, 'IDLE');
+        expect(derived.issue, isNull);
       });
     });
 
@@ -73,8 +81,9 @@ void main() {
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.resetMutations();
 
-        final content =
-            File('${tempDir.path}/.inquiry/mutations.md').readAsStringSync();
+        final content = File(
+          '${tempDir.path}/.inquiry/mutations.md',
+        ).readAsStringSync();
         expect(content, contains('# Mutations'));
         expect(content, contains('Notes for DARWIN'));
         expect(content, isNot(contains('old observation')));
@@ -105,39 +114,41 @@ void main() {
       });
 
       test('captures current state in snapshot', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: ANALYZE\nissue: "99"\n');
+        File(stateFilePath).writeAsStringSync('state: ANALYZE\nissue: "99"\n');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.snapshotMetrics();
 
-        final content =
-            File('${tempDir.path}/.inquiry/metrics_snapshot.yaml')
-                .readAsStringSync();
+        final content = File(
+          '${tempDir.path}/.inquiry/metrics_snapshot.yaml',
+        ).readAsStringSync();
         expect(content, contains('state: ANALYZE'));
         expect(content, contains('issue: "99"'));
       });
     });
 
     group('close_cycle', () {
-      test('resets state to IDLE and clears issue', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: EVOLUTION\nissue: "145"\n');
+      test('marks cycle completed and derives IDLE', () {
+        File(
+          stateFilePath,
+        ).writeAsStringSync('state: EVOLUTION\nissue: "145"\n');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.closeCycle();
 
-        final content =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
-        expect(content, contains('state: IDLE'));
-        expect(content, contains('issue: null'));
+        final raw = InquiryState.loadFrom(stateFilePath);
+        expect(raw.status, 'completed');
+        final derived = InquiryState.load(tempDir.path);
+        expect(derived.state, 'IDLE');
+        expect(derived.issue, isNull);
       });
     });
 
     group('collect_metrics', () {
       test('appends cycle entry to metrics.yaml', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: EVOLUTION\nissue: "145"\n');
+        File(
+          stateFilePath,
+        ).writeAsStringSync('state: EVOLUTION\nissue: "145"\n');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.collectMetrics();
@@ -151,16 +162,19 @@ void main() {
       });
 
       test('appends to existing metrics.yaml', () {
-        File('${tempDir.path}/.inquiry/metrics.yaml')
-            .writeAsStringSync('cycles:\n  - issue: "100"\n');
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: EVOLUTION\nissue: "145"\n');
+        File(
+          '${tempDir.path}/.inquiry/metrics.yaml',
+        ).writeAsStringSync('cycles:\n  - issue: "100"\n');
+        File(
+          stateFilePath,
+        ).writeAsStringSync('state: EVOLUTION\nissue: "145"\n');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.collectMetrics();
 
-        final content =
-            File('${tempDir.path}/.inquiry/metrics.yaml').readAsStringSync();
+        final content = File(
+          '${tempDir.path}/.inquiry/metrics.yaml',
+        ).readAsStringSync();
         expect(content, contains('issue: "100"'));
         expect(content, contains('issue: "145"'));
       });
@@ -168,10 +182,10 @@ void main() {
 
     group('executeAll', () {
       test('executes multiple effects in order', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: IDLE\nissue: null\n');
-        File('${tempDir.path}/.inquiry/mutations.md')
-            .writeAsStringSync('# Mutations\n- old stuff\n');
+        File(stateFilePath).writeAsStringSync('state: IDLE\nissue: null\n');
+        File(
+          '${tempDir.path}/.inquiry/mutations.md',
+        ).writeAsStringSync('# Mutations\n- old stuff\n');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         final executed = executor.executeAll(
@@ -181,23 +195,25 @@ void main() {
           promptFragmentId: 'idle_to_analyze',
         );
 
-        expect(executed, containsAll(['update_state', 'reset_mutations', 'snapshot_metrics']));
+        expect(
+          executed,
+          containsAll(['update_state', 'reset_mutations', 'snapshot_metrics']),
+        );
 
         // State updated
-        final stateContent =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
+        final stateContent = File(stateFilePath).readAsStringSync();
         expect(stateContent, contains('state: ANALYZE'));
         expect(stateContent, contains('prompt_fragment_id: idle_to_analyze'));
 
         // Mutations reset
-        final mutContent =
-            File('${tempDir.path}/.inquiry/mutations.md').readAsStringSync();
+        final mutContent = File(
+          '${tempDir.path}/.inquiry/mutations.md',
+        ).readAsStringSync();
         expect(mutContent, isNot(contains('old stuff')));
       });
 
       test('skips unknown effects gracefully', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: IDLE\nissue: null\n');
+        File(stateFilePath).writeAsStringSync('state: IDLE\nissue: null\n');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         final executed = executor.executeAll(
@@ -214,10 +230,7 @@ void main() {
 
     group('openAnalysisContext', () {
       test('creates analyze bootstrap with confirmations.md', () {
-        const branch = '145-test-branch';
-        _initGitRepo(tempDir.path, branch: branch);
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: ANALYZE\nissue: "145"\n');
+        File(stateFilePath).writeAsStringSync('state: ANALYZE\nissue: "145"\n');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.openAnalysisContext();
@@ -235,10 +248,7 @@ void main() {
       });
 
       test('creates methodology-neutral confirmations bootstrap', () {
-        const branch = '145-test-branch';
-        _initGitRepo(tempDir.path, branch: branch);
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: ANALYZE\nissue: "145"\n');
+        File(stateFilePath).writeAsStringSync('state: ANALYZE\nissue: "145"\n');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.openAnalysisContext();
@@ -255,108 +265,80 @@ void main() {
 
     group('APE auto-activation', () {
       test('writes ape field when transitioning to ANALYZE', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: IDLE\nissue: null\n');
+        File(stateFilePath).writeAsStringSync('state: IDLE\nissue: null\n');
 
         // Copy APE assets so _resolveInitialState can find them
         final apesDir = Directory('${tempDir.path}/assets/apes');
         apesDir.createSync(recursive: true);
-        File('assets/apes/socrates.yaml')
-            .copySync('${apesDir.path}/socrates.yaml');
+        File(
+          'assets/apes/socrates.yaml',
+        ).copySync('${apesDir.path}/socrates.yaml');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.updateState('ANALYZE', issue: '145');
 
-        final content =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
+        final content = File(stateFilePath).readAsStringSync();
         expect(content, contains('state: ANALYZE'));
         expect(content, contains('ape:'));
         expect(content, contains('name: socrates'));
         expect(content, contains('state: clarification'));
       });
 
-      test('activates dewey when transitioning to IDLE', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: EVOLUTION\nissue: "145"\n');
-
-        final apesDir = Directory('${tempDir.path}/assets/apes');
-        apesDir.createSync(recursive: true);
-        File('assets/apes/dewey.yaml').copySync('${apesDir.path}/dewey.yaml');
-
-        final executor = EffectExecutor(workingDirectory: tempDir.path);
-        executor.updateState('IDLE');
-
-        final content =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
-        expect(content, contains('state: IDLE'));
-        expect(content, contains('name: dewey'));
-        expect(content, contains('state: evaluate_scope'));
-      });
-
       test('activates descartes when transitioning to PLAN', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: ANALYZE\nissue: "145"\n');
+        File(stateFilePath).writeAsStringSync('state: ANALYZE\nissue: "145"\n');
 
         final apesDir = Directory('${tempDir.path}/assets/apes');
         apesDir.createSync(recursive: true);
-        File('assets/apes/descartes.yaml')
-            .copySync('${apesDir.path}/descartes.yaml');
+        File(
+          'assets/apes/descartes.yaml',
+        ).copySync('${apesDir.path}/descartes.yaml');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.updateState('PLAN');
 
-        final content =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
+        final content = File(stateFilePath).readAsStringSync();
         expect(content, contains('name: descartes'));
         expect(content, contains('state: decomposition'));
       });
 
       test('activates basho when transitioning to EXECUTE', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: PLAN\nissue: "145"\n');
+        File(stateFilePath).writeAsStringSync('state: PLAN\nissue: "145"\n');
 
         final apesDir = Directory('${tempDir.path}/assets/apes');
         apesDir.createSync(recursive: true);
-        File('assets/apes/basho.yaml')
-            .copySync('${apesDir.path}/basho.yaml');
+        File('assets/apes/basho.yaml').copySync('${apesDir.path}/basho.yaml');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.updateState('EXECUTE');
 
-        final content =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
+        final content = File(stateFilePath).readAsStringSync();
         expect(content, contains('name: basho'));
         expect(content, contains('state: implement'));
       });
 
       test('activates darwin when transitioning to EVOLUTION', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: END\nissue: "145"\n');
+        File(stateFilePath).writeAsStringSync('state: END\nissue: "145"\n');
 
         final apesDir = Directory('${tempDir.path}/assets/apes');
         apesDir.createSync(recursive: true);
-        File('assets/apes/darwin.yaml')
-            .copySync('${apesDir.path}/darwin.yaml');
+        File('assets/apes/darwin.yaml').copySync('${apesDir.path}/darwin.yaml');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.updateState('EVOLUTION');
 
-        final content =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
+        final content = File(stateFilePath).readAsStringSync();
         expect(content, contains('name: darwin'));
         expect(content, contains('state: observe'));
       });
 
       test('graceful fallback when APE YAML not found', () {
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync('state: IDLE\nissue: null\n');
+        File(stateFilePath).writeAsStringSync('state: IDLE\nissue: null\n');
 
         // No APE assets copied
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.updateState('ANALYZE', issue: '145');
 
-        final content =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
+        final content = File(stateFilePath).readAsStringSync();
         expect(content, contains('state: ANALYZE'));
         expect(content, contains('name: socrates'));
         // initialState is null when YAML not found — still writes the name
@@ -365,20 +347,17 @@ void main() {
       test('preserves APE sub-state when same APE continues (EXECUTE→END)', () {
         final apesDir = Directory('${tempDir.path}/assets/apes');
         apesDir.createSync(recursive: true);
-        File('assets/apes/basho.yaml')
-            .copySync('${apesDir.path}/basho.yaml');
+        File('assets/apes/basho.yaml').copySync('${apesDir.path}/basho.yaml');
 
         // basho is at _DONE in EXECUTE
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync(
-              'state: EXECUTE\nissue: "145"\nape:\n  name: basho\n  state: _DONE\n',
-            );
+        File(stateFilePath).writeAsStringSync(
+          'state: EXECUTE\nissue: "145"\nape:\n  name: basho\n  state: _DONE\n',
+        );
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.updateState('END');
 
-        final content =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
+        final content = File(stateFilePath).readAsStringSync();
         expect(content, contains('name: basho'));
         expect(content, contains('state: _DONE'));
       });
@@ -386,18 +365,18 @@ void main() {
       test('re-initializes socrates when ANALYZE continues from _DONE', () {
         final apesDir = Directory('${tempDir.path}/assets/apes');
         apesDir.createSync(recursive: true);
-        File('assets/apes/socrates.yaml')
-            .copySync('${apesDir.path}/socrates.yaml');
+        File(
+          'assets/apes/socrates.yaml',
+        ).copySync('${apesDir.path}/socrates.yaml');
 
-        File('${tempDir.path}/.inquiry/state.yaml').writeAsStringSync(
+        File(stateFilePath).writeAsStringSync(
           'state: ANALYZE\nissue: "145"\nape:\n  name: socrates\n  state: _DONE\n',
         );
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.updateState('ANALYZE');
 
-        final content =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
+        final content = File(stateFilePath).readAsStringSync();
         expect(content, contains('name: socrates'));
         expect(content, contains('state: clarification'));
         expect(content, isNot(contains('state: _DONE')));
@@ -406,20 +385,19 @@ void main() {
       test('re-initializes APE when transitioning to state with different APE', () {
         final apesDir = Directory('${tempDir.path}/assets/apes');
         apesDir.createSync(recursive: true);
-        File('assets/apes/descartes.yaml')
-            .copySync('${apesDir.path}/descartes.yaml');
+        File(
+          'assets/apes/descartes.yaml',
+        ).copySync('${apesDir.path}/descartes.yaml');
 
         // socrates is active in ANALYZE, transitioning to PLAN activates descartes
-        File('${tempDir.path}/.inquiry/state.yaml')
-            .writeAsStringSync(
-              'state: ANALYZE\nissue: "145"\nape:\n  name: socrates\n  state: _DONE\n',
-            );
+        File(stateFilePath).writeAsStringSync(
+          'state: ANALYZE\nissue: "145"\nape:\n  name: socrates\n  state: _DONE\n',
+        );
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
         executor.updateState('PLAN');
 
-        final content =
-            File('${tempDir.path}/.inquiry/state.yaml').readAsStringSync();
+        final content = File(stateFilePath).readAsStringSync();
         expect(content, contains('name: descartes'));
         expect(content, contains('state: decomposition'));
       });

--- a/code/cli/test/effect_executor_test.dart
+++ b/code/cli/test/effect_executor_test.dart
@@ -146,6 +146,36 @@ void main() {
       });
     });
 
+    group('block', () {
+      test('pause_analysis effect marks cycle blocked and derives IDLE', () {
+        File(
+          stateFilePath,
+        ).writeAsStringSync('state: ANALYZE\nissue: "145"\nstatus: active\n');
+
+        final executor = EffectExecutor(workingDirectory: tempDir.path);
+        executor.executeAll(effects: ['pause_analysis'], newState: 'IDLE');
+
+        final raw = InquiryState.loadFrom(stateFilePath);
+        expect(raw.status, 'blocked');
+        final derived = InquiryState.load(tempDir.path);
+        expect(derived.state, 'IDLE');
+      });
+
+      test('pause_plan effect marks cycle blocked and derives IDLE', () {
+        File(
+          stateFilePath,
+        ).writeAsStringSync('state: PLAN\nissue: "145"\nstatus: active\n');
+
+        final executor = EffectExecutor(workingDirectory: tempDir.path);
+        executor.executeAll(effects: ['pause_plan'], newState: 'IDLE');
+
+        final raw = InquiryState.loadFrom(stateFilePath);
+        expect(raw.status, 'blocked');
+        final derived = InquiryState.load(tempDir.path);
+        expect(derived.state, 'IDLE');
+      });
+    });
+
     group('collect_metrics', () {
       test('appends cycle entry to metrics.yaml', () {
         File(

--- a/code/cli/test/effect_executor_test.dart
+++ b/code/cli/test/effect_executor_test.dart
@@ -261,6 +261,56 @@ void main() {
         expect(content, contains('title: "Confirmations"'));
         expect(content, isNot(contains('author: socrates')));
       });
+
+      test('writes issue.md mirror with fetched body', () {
+        File(stateFilePath).writeAsStringSync('state: ANALYZE\nissue: "145"\n');
+
+        final executor = EffectExecutor(
+          workingDirectory: tempDir.path,
+          issueBodyProvider: (issue, _) => 'Body for issue $issue',
+        );
+        executor.openAnalysisContext();
+
+        final issueFile = File('${tempDir.path}/cleanrooms/$branch/issue.md');
+        expect(issueFile.existsSync(), isTrue);
+        final content = issueFile.readAsStringSync();
+        expect(content, contains('Body for issue 145'));
+        expect(content, contains('#145'));
+      });
+
+      test('issue.md is non-fatal when body fetch returns null', () {
+        File(stateFilePath).writeAsStringSync('state: ANALYZE\nissue: "145"\n');
+
+        final executor = EffectExecutor(
+          workingDirectory: tempDir.path,
+          issueBodyProvider: (issue, _) => null,
+        );
+
+        expect(executor.openAnalysisContext, returnsNormally);
+
+        // Analyze bootstrap still created despite missing body.
+        expect(
+          File(
+            '${tempDir.path}/cleanrooms/$branch/analyze/index.md',
+          ).existsSync(),
+          isTrue,
+        );
+      });
+
+      test('does not clobber an existing issue.md', () {
+        File(stateFilePath).writeAsStringSync('state: ANALYZE\nissue: "145"\n');
+        final issueFile = File('${tempDir.path}/cleanrooms/$branch/issue.md')
+          ..createSync(recursive: true);
+        issueFile.writeAsStringSync('CUSTOM CONTENT');
+
+        final executor = EffectExecutor(
+          workingDirectory: tempDir.path,
+          issueBodyProvider: (issue, _) => 'Body for issue $issue',
+        );
+        executor.openAnalysisContext();
+
+        expect(issueFile.readAsStringSync(), 'CUSTOM CONTENT');
+      });
     });
 
     group('APE auto-activation', () {

--- a/code/cli/test/effect_executor_test.dart
+++ b/code/cli/test/effect_executor_test.dart
@@ -74,7 +74,9 @@ void main() {
 
     group('reset_mutations', () {
       test('resets mutations.md to empty template', () {
-        File('${tempDir.path}/.inquiry/mutations.md').writeAsStringSync(
+        File(
+          '${tempDir.path}/cleanrooms/$branch/mutations.md',
+        ).writeAsStringSync(
           '# Mutations\n\nNotes for DARWIN.\n- old observation\n- another one\n',
         );
 
@@ -82,7 +84,7 @@ void main() {
         executor.resetMutations();
 
         final content = File(
-          '${tempDir.path}/.inquiry/mutations.md',
+          '${tempDir.path}/cleanrooms/$branch/mutations.md',
         ).readAsStringSync();
         expect(content, contains('# Mutations'));
         expect(content, contains('Notes for DARWIN'));
@@ -94,7 +96,7 @@ void main() {
         executor.resetMutations();
 
         expect(
-          File('${tempDir.path}/.inquiry/mutations.md').existsSync(),
+          File('${tempDir.path}/cleanrooms/$branch/mutations.md').existsSync(),
           isTrue,
         );
       });
@@ -184,7 +186,7 @@ void main() {
       test('executes multiple effects in order', () {
         File(stateFilePath).writeAsStringSync('state: IDLE\nissue: null\n');
         File(
-          '${tempDir.path}/.inquiry/mutations.md',
+          '${tempDir.path}/cleanrooms/$branch/mutations.md',
         ).writeAsStringSync('# Mutations\n- old stuff\n');
 
         final executor = EffectExecutor(workingDirectory: tempDir.path);
@@ -207,7 +209,7 @@ void main() {
 
         // Mutations reset
         final mutContent = File(
-          '${tempDir.path}/.inquiry/mutations.md',
+          '${tempDir.path}/cleanrooms/$branch/mutations.md',
         ).readAsStringSync();
         expect(mutContent, isNot(contains('old stuff')));
       });

--- a/code/cli/test/fsm_state_test.dart
+++ b/code/cli/test/fsm_state_test.dart
@@ -1,10 +1,14 @@
 import 'dart:io';
 
+import 'package:inquiry_cli/modules/ape/inquiry_state.dart';
 import 'package:inquiry_cli/modules/fsm/commands/state.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
   late Directory tempDir;
+
+  const branch = '145-test-branch';
 
   setUp(() {
     tempDir = Directory.systemTemp.createTempSync('fsm_state_test_');
@@ -14,7 +18,7 @@ void main() {
     tempDir.deleteSync(recursive: true);
   });
 
-  /// Creates a minimal test workspace with .inquiry/state.yaml and
+  /// Creates a minimal test workspace with a cycle-local `.iq.state.yaml` and
   /// assets/fsm/transition_contract.yaml.
   void setupWorkspace({
     required String state,
@@ -22,7 +26,8 @@ void main() {
     String? apeName,
     String? apeState,
   }) {
-    // .inquiry/state.yaml
+    // Cycle-local state lives at cleanrooms/<branch>/.iq.state.yaml.
+    _initGitRepo(tempDir.path, branch: branch);
     Directory('${tempDir.path}/.inquiry').createSync(recursive: true);
     final buf = StringBuffer();
     buf.writeln('state: $state');
@@ -34,8 +39,10 @@ void main() {
     } else {
       buf.writeln('ape: null');
     }
-    File('${tempDir.path}/.inquiry/state.yaml')
-        .writeAsStringSync(buf.toString());
+    final stateFile = File(
+      p.join(tempDir.path, 'cleanrooms', branch, kStateFileName),
+    )..createSync(recursive: true);
+    stateFile.writeAsStringSync(buf.toString());
 
     // Copy real contract from project assets
     final contractSource = File('assets/fsm/transition_contract.yaml');
@@ -56,7 +63,14 @@ void main() {
     // Copy state instruction YAMLs
     final statesDir = Directory('${tempDir.path}/assets/fsm/states');
     statesDir.createSync(recursive: true);
-    for (final name in ['idle', 'analyze', 'plan', 'execute', 'end', 'evolution']) {
+    for (final name in [
+      'idle',
+      'analyze',
+      'plan',
+      'execute',
+      'end',
+      'evolution',
+    ]) {
       final src = File('assets/fsm/states/$name.yaml');
       if (src.existsSync()) {
         src.copySync('${statesDir.path}/$name.yaml');
@@ -66,30 +80,33 @@ void main() {
 
   group('FsmStateCommand', () {
     group('JSON output structure', () {
-      test('returns state, task, transitions, apes, and instructions', () async {
-        setupWorkspace(state: 'ANALYZE', issue: '145');
+      test(
+        'returns state, task, transitions, apes, and instructions',
+        () async {
+          setupWorkspace(state: 'ANALYZE', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
-        final result = await command.execute();
-        final json = result.toJson();
+          final command = FsmStateCommand(
+            FsmStateInput(workingDirectory: tempDir.path),
+          );
+          final result = await command.execute();
+          final json = result.toJson();
 
-        expect(json['state'], equals('ANALYZE'));
-        expect(json['issue'], equals('145'));
-        expect(json['transitions'], isList);
-        expect(json['apes'], isList);
-        expect(json['instructions'], isA<String>());
-        expect(json['operational_contract']['required_artifacts'], isList);
-        expect(json['operational_contract']['interaction'], isA<Map>());
-      });
+          expect(json['state'], equals('ANALYZE'));
+          expect(json['issue'], equals('145'));
+          expect(json['transitions'], isList);
+          expect(json['apes'], isList);
+          expect(json['instructions'], isA<String>());
+          expect(json['operational_contract']['required_artifacts'], isList);
+          expect(json['operational_contract']['interaction'], isA<Map>());
+        },
+      );
 
       test('returns operational contract sourced from state assets', () async {
         setupWorkspace(state: 'EXECUTE', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final json = result.toJson();
         final operationalContract =
@@ -98,7 +115,9 @@ void main() {
         expect(operationalContract, isNotNull);
         expect(
           operationalContract!['instructions'],
-          contains('Implement the plan phase by phase under its formal constraints.'),
+          contains(
+            'Implement the plan phase by phase under its formal constraints.',
+          ),
         );
         expect(
           operationalContract['constraints'],
@@ -113,9 +132,9 @@ void main() {
       test('IDLE state has no task', () async {
         setupWorkspace(state: 'IDLE');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final json = result.toJson();
 
@@ -128,9 +147,9 @@ void main() {
       test('ANALYZE includes complete_analysis and block', () async {
         setupWorkspace(state: 'ANALYZE', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final transitions = result.toJson()['transitions'] as List;
         final events = transitions.map((t) => t['event']).toList();
@@ -143,9 +162,9 @@ void main() {
       test('IDLE includes start_analyze only', () async {
         setupWorkspace(state: 'IDLE');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final transitions = result.toJson()['transitions'] as List;
         final events = transitions.map((t) => t['event']).toList();
@@ -157,9 +176,9 @@ void main() {
       test('each transition has event only', () async {
         setupWorkspace(state: 'PLAN', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final transitions = result.toJson()['transitions'] as List;
 
@@ -174,9 +193,9 @@ void main() {
       test('ANALYZE has socrates running', () async {
         setupWorkspace(state: 'ANALYZE', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final apes = result.toJson()['apes'] as List;
 
@@ -188,9 +207,9 @@ void main() {
       test('IDLE has dewey active', () async {
         setupWorkspace(state: 'IDLE');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final apes = result.toJson()['apes'] as List;
 
@@ -201,9 +220,9 @@ void main() {
       test('PLAN has descartes running', () async {
         setupWorkspace(state: 'PLAN', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final apes = result.toJson()['apes'] as List;
 
@@ -214,9 +233,9 @@ void main() {
       test('EXECUTE has basho running', () async {
         setupWorkspace(state: 'EXECUTE', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final apes = result.toJson()['apes'] as List;
 
@@ -227,9 +246,9 @@ void main() {
       test('EVOLUTION has darwin running', () async {
         setupWorkspace(state: 'EVOLUTION', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final apes = result.toJson()['apes'] as List;
 
@@ -242,9 +261,9 @@ void main() {
       test('ANALYZE instructions describe the mission', () async {
         setupWorkspace(state: 'ANALYZE', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
 
         expect(result.toJson()['instructions'], contains('Investigate'));
@@ -262,29 +281,32 @@ void main() {
         );
       });
 
-      test('IDLE instructions describe TRIAGE issue creation and DONE handoff', () async {
-        setupWorkspace(state: 'IDLE');
+      test(
+        'IDLE instructions describe TRIAGE issue creation and DONE handoff',
+        () async {
+          setupWorkspace(state: 'IDLE');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
-        final result = await command.execute();
+          final command = FsmStateCommand(
+            FsmStateInput(workingDirectory: tempDir.path),
+          );
+          final result = await command.execute();
 
-        expect(result.toJson()['instructions'], contains('TRIAGE'));
-        expect(result.toJson()['instructions'], contains('DONE'));
-        expect(result.toJson()['instructions'], contains('create_or_select'));
-        expect(result.toJson()['instructions'], contains('issue-create'));
-        expect(result.toJson()['instructions'], contains('gh issue create'));
-        expect(result.toJson()['instructions'], contains('issue-start'));
-        expect(result.toJson()['instructions'], contains('start_analyze'));
-      });
+          expect(result.toJson()['instructions'], contains('TRIAGE'));
+          expect(result.toJson()['instructions'], contains('DONE'));
+          expect(result.toJson()['instructions'], contains('create_or_select'));
+          expect(result.toJson()['instructions'], contains('issue-create'));
+          expect(result.toJson()['instructions'], contains('gh issue create'));
+          expect(result.toJson()['instructions'], contains('issue-start'));
+          expect(result.toJson()['instructions'], contains('start_analyze'));
+        },
+      );
 
       test('EVOLUTION instructions own darwin repository procedure', () async {
         setupWorkspace(state: 'EVOLUTION', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
 
         expect(
@@ -294,7 +316,10 @@ void main() {
         expect(result.toJson()['instructions'], contains('gh issue list'));
         expect(result.toJson()['instructions'], contains('gh issue comment'));
         expect(result.toJson()['instructions'], contains('gh issue create'));
-        expect(result.toJson()['instructions'], contains('.inquiry/metrics.yaml'));
+        expect(
+          result.toJson()['instructions'],
+          contains('.inquiry/metrics.yaml'),
+        );
       });
     });
 
@@ -308,16 +333,23 @@ void main() {
 
         final statesDir = Directory('${tempDir.path}/assets/fsm/states');
         statesDir.createSync(recursive: true);
-        for (final name in ['idle', 'analyze', 'plan', 'execute', 'end', 'evolution']) {
+        for (final name in [
+          'idle',
+          'analyze',
+          'plan',
+          'execute',
+          'end',
+          'evolution',
+        ]) {
           final src = File('assets/fsm/states/$name.yaml');
           if (src.existsSync()) {
             src.copySync('${statesDir.path}/$name.yaml');
           }
         }
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
 
         expect(result.toJson()['state'], equals('IDLE'));
@@ -329,9 +361,9 @@ void main() {
       test('returns formatted text output', () async {
         setupWorkspace(state: 'ANALYZE', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final text = result.toText();
 
@@ -349,9 +381,9 @@ void main() {
           apeState: 'clarification',
         );
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final json = result.toJson();
 
@@ -369,9 +401,9 @@ void main() {
           apeState: 'decomposition',
         );
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final ape = result.toJson()['ape'] as Map<String, dynamic>;
         final transitions = ape['transitions'] as List;
@@ -383,9 +415,9 @@ void main() {
       test('omits ape field when no APE active', () async {
         setupWorkspace(state: 'IDLE');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final json = result.toJson();
 
@@ -400,9 +432,9 @@ void main() {
           apeState: '_DONE',
         );
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final ape = result.toJson()['ape'] as Map<String, dynamic>;
 
@@ -417,9 +449,9 @@ void main() {
       test('ANALYZE has completion_authority: user', () async {
         setupWorkspace(state: 'ANALYZE', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final json = result.toJson();
 
@@ -429,9 +461,9 @@ void main() {
       test('PLAN has completion_authority: user', () async {
         setupWorkspace(state: 'PLAN', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final json = result.toJson();
 
@@ -441,9 +473,9 @@ void main() {
       test('END has completion_authority: automatic', () async {
         setupWorkspace(state: 'END', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final json = result.toJson();
 
@@ -453,9 +485,9 @@ void main() {
       test('EVOLUTION has completion_authority: automatic', () async {
         setupWorkspace(state: 'EVOLUTION', issue: '145');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final json = result.toJson();
 
@@ -465,9 +497,9 @@ void main() {
       test('IDLE has completion_authority: user', () async {
         setupWorkspace(state: 'IDLE');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final json = result.toJson();
 
@@ -476,33 +508,37 @@ void main() {
     });
 
     group('END transition filtering by config.yaml', () {
-      test('END with evolution disabled shows only pr_ready_no_evolution',
-          () async {
-        setupWorkspace(state: 'END', issue: '145');
-        // config.yaml with evolution.enabled: false
-        File('${tempDir.path}/.inquiry/config.yaml')
-            .writeAsStringSync('evolution:\n  enabled: false\n');
+      test(
+        'END with evolution disabled shows only pr_ready_no_evolution',
+        () async {
+          setupWorkspace(state: 'END', issue: '145');
+          // config.yaml with evolution.enabled: false
+          File(
+            '${tempDir.path}/.inquiry/config.yaml',
+          ).writeAsStringSync('evolution:\n  enabled: false\n');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
-        final result = await command.execute();
-        final transitions = result.toJson()['transitions'] as List;
-        final events = transitions.map((t) => t['event']).toList();
+          final command = FsmStateCommand(
+            FsmStateInput(workingDirectory: tempDir.path),
+          );
+          final result = await command.execute();
+          final transitions = result.toJson()['transitions'] as List;
+          final events = transitions.map((t) => t['event']).toList();
 
-        expect(events, contains('pr_ready_no_evolution'));
-        expect(events, isNot(contains('pr_ready')));
-      });
+          expect(events, contains('pr_ready_no_evolution'));
+          expect(events, isNot(contains('pr_ready')));
+        },
+      );
 
       test('END with evolution enabled shows only pr_ready', () async {
         setupWorkspace(state: 'END', issue: '145');
         // config.yaml with evolution.enabled: true
-        File('${tempDir.path}/.inquiry/config.yaml')
-            .writeAsStringSync('evolution:\n  enabled: true\n');
+        File(
+          '${tempDir.path}/.inquiry/config.yaml',
+        ).writeAsStringSync('evolution:\n  enabled: true\n');
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        );
         final result = await command.execute();
         final transitions = result.toJson()['transitions'] as List;
         final events = transitions.map((t) => t['event']).toList();
@@ -511,21 +547,40 @@ void main() {
         expect(events, isNot(contains('pr_ready_no_evolution')));
       });
 
-      test('END without config.yaml defaults to pr_ready_no_evolution',
-          () async {
-        setupWorkspace(state: 'END', issue: '145');
-        // No config.yaml file
+      test(
+        'END without config.yaml defaults to pr_ready_no_evolution',
+        () async {
+          setupWorkspace(state: 'END', issue: '145');
+          // No config.yaml file
 
-        final command = FsmStateCommand(FsmStateInput(
-          workingDirectory: tempDir.path,
-        ));
-        final result = await command.execute();
-        final transitions = result.toJson()['transitions'] as List;
-        final events = transitions.map((t) => t['event']).toList();
+          final command = FsmStateCommand(
+            FsmStateInput(workingDirectory: tempDir.path),
+          );
+          final result = await command.execute();
+          final transitions = result.toJson()['transitions'] as List;
+          final events = transitions.map((t) => t['event']).toList();
 
-        expect(events, contains('pr_ready_no_evolution'));
-        expect(events, isNot(contains('pr_ready')));
-      });
+          expect(events, contains('pr_ready_no_evolution'));
+          expect(events, isNot(contains('pr_ready')));
+        },
+      );
     });
   });
+}
+
+void _initGitRepo(String root, {required String branch}) {
+  void git(List<String> args) {
+    final result = Process.runSync('git', args, workingDirectory: root);
+    if (result.exitCode != 0) {
+      throw StateError('git ${args.join(' ')} failed: ${result.stderr}');
+    }
+  }
+
+  git(['init']);
+  git(['config', 'user.email', 'test@test.com']);
+  git(['config', 'user.name', 'Test']);
+  File('$root/.gitkeep').writeAsStringSync('');
+  git(['add', '.']);
+  git(['commit', '-m', 'init']);
+  git(['checkout', '-b', branch]);
 }

--- a/code/cli/test/fsm_transition_integration_test.dart
+++ b/code/cli/test/fsm_transition_integration_test.dart
@@ -86,6 +86,40 @@ void main() {
       },
     );
 
+    test('IDLE→ANALYZE bootstraps the full cycle', () async {
+      const branch = '51-idle-execution-guardrails';
+
+      final output = await StateTransitionCommand(
+        StateTransitionInput(
+          currentState: null,
+          event: 'start_analyze',
+          workingDirectory: tempDir.path,
+        ),
+        branchProvider: (_) async => branch,
+      ).execute();
+
+      expect(output.allowed, isTrue);
+      expect(output.nextState, 'ANALYZE');
+
+      final cycleDir = p.join(tempDir.path, 'cleanrooms', branch);
+      expect(
+        File(p.join(cycleDir, 'analyze', 'index.md')).existsSync(),
+        isTrue,
+      );
+      expect(
+        File(p.join(cycleDir, 'analyze', 'confirmations.md')).existsSync(),
+        isTrue,
+      );
+      expect(File(p.join(cycleDir, 'issue.md')).existsSync(), isTrue);
+
+      final state = InquiryState.loadFrom(p.join(cycleDir, kStateFileName));
+      expect(state.state, 'ANALYZE');
+      expect(state.status, 'active');
+
+      // The freshly created cycle resolves as active (not derived IDLE).
+      expect(InquiryState.load(tempDir.path).state, 'ANALYZE');
+    });
+
     test('full cycle uses transition command on each step', () async {
       String current = 'IDLE';
       final branch = '51-idle-execution-guardrails';

--- a/code/cli/test/fsm_transition_integration_test.dart
+++ b/code/cli/test/fsm_transition_integration_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
+import 'package:inquiry_cli/modules/ape/inquiry_state.dart';
 import 'package:inquiry_cli/modules/fsm/commands/transition.dart';
 
 void main() {
@@ -22,56 +23,68 @@ void main() {
       }
     });
 
-    test('incident replay is prevented: IDLE cannot go_execute directly', () async {
-      _writeState(tempDir.path, 'IDLE');
+    test(
+      'incident replay is prevented: IDLE cannot go_execute directly',
+      () async {
+        _writeState(tempDir.path, 'IDLE');
 
-      final command = StateTransitionCommand(
-        StateTransitionInput(
-          currentState: null,
-          event: 'go_execute',
-          workingDirectory: tempDir.path,
-        ),
-        branchProvider: (_) async => 'main',
-      );
+        final command = StateTransitionCommand(
+          StateTransitionInput(
+            currentState: null,
+            event: 'go_execute',
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => 'main',
+        );
 
-      final output = await command.execute();
-      expect(output.allowed, isFalse);
-      expect(output.exitCode, 64);
-    });
+        final output = await command.execute();
+        expect(output.allowed, isFalse);
+        expect(output.exitCode, 64);
+      },
+    );
 
-    test('IDLE leaves only after the explicit-start handoff is prepared',
-        () async {
-      _writeState(tempDir.path, 'IDLE', issue: '51');
+    test(
+      'IDLE leaves only after the explicit-start handoff is prepared',
+      () async {
+        _writeState(tempDir.path, 'IDLE', issue: '51');
 
-      final blocked = await StateTransitionCommand(
-        StateTransitionInput(
-          currentState: null,
-          event: 'start_analyze',
-          workingDirectory: tempDir.path,
-        ),
-        branchProvider: (_) async => 'main',
-      ).execute();
+        final blocked = await StateTransitionCommand(
+          StateTransitionInput(
+            currentState: null,
+            event: 'start_analyze',
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => 'main',
+        ).execute();
 
-      expect(blocked.allowed, isFalse);
-      expect(blocked.nextState, isNull);
-      expect(
-        File(p.join(tempDir.path, '.inquiry', 'state.yaml')).readAsStringSync(),
-        contains('state: IDLE'),
-      );
+        expect(blocked.allowed, isFalse);
+        expect(blocked.nextState, isNull);
+        expect(
+          File(
+            p.join(
+              tempDir.path,
+              'cleanrooms',
+              '51-idle-execution-guardrails',
+              kStateFileName,
+            ),
+          ).readAsStringSync(),
+          contains('state: IDLE'),
+        );
 
-      final allowed = await StateTransitionCommand(
-        StateTransitionInput(
-          currentState: null,
-          event: 'start_analyze',
-          workingDirectory: tempDir.path,
-        ),
-        branchProvider: (_) async => '51-idle-execution-guardrails',
-      ).execute();
+        final allowed = await StateTransitionCommand(
+          StateTransitionInput(
+            currentState: null,
+            event: 'start_analyze',
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => '51-idle-execution-guardrails',
+        ).execute();
 
-      expect(allowed.allowed, isTrue);
-      expect(allowed.nextState, 'ANALYZE');
-      expect(allowed.promptFragmentId, 'idle_to_analyze');
-    });
+        expect(allowed.allowed, isTrue);
+        expect(allowed.nextState, 'ANALYZE');
+        expect(allowed.promptFragmentId, 'idle_to_analyze');
+      },
+    );
 
     test('full cycle uses transition command on each step', () async {
       String current = 'IDLE';
@@ -134,22 +147,28 @@ void main() {
 }
 
 void _writeState(String root, String state, {String? issue}) {
-  final file = File(p.join(root, '.inquiry', 'state.yaml'));
+  final r = Process.runSync('git', [
+    'rev-parse',
+    '--abbrev-ref',
+    'HEAD',
+  ], workingDirectory: root);
+  final branch = r.exitCode == 0 ? r.stdout.toString().trim() : '';
+  if (branch.isEmpty || branch == 'HEAD') return;
+  final file = File(p.join(root, 'cleanrooms', branch, kStateFileName));
   file.createSync(recursive: true);
   final issueLine = issue != null ? 'issue: "$issue"' : 'issue: null';
-  file.writeAsStringSync('state: $state\n$issueLine\n');
+  file.writeAsStringSync(
+    'version: 1\nstate: $state\n$issueLine\nstatus: active\n',
+  );
 }
 
 void _copyContractFromWorkspace(String root) {
   final source = File(
-    p.join(
-      Directory.current.path,
-      'assets',
-      'fsm',
-      'transition_contract.yaml',
-    ),
+    p.join(Directory.current.path, 'assets', 'fsm', 'transition_contract.yaml'),
   );
-  final destination = File(p.join(root, 'assets', 'fsm', 'transition_contract.yaml'));
+  final destination = File(
+    p.join(root, 'assets', 'fsm', 'transition_contract.yaml'),
+  );
   destination.createSync(recursive: true);
   destination.writeAsStringSync(source.readAsStringSync());
 }

--- a/code/cli/test/fsm_transition_test.dart
+++ b/code/cli/test/fsm_transition_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
+import 'package:inquiry_cli/modules/ape/inquiry_state.dart';
 import 'package:inquiry_cli/modules/fsm/commands/transition.dart';
 
 void main() {
@@ -39,129 +40,137 @@ void main() {
       expect(output.message, contains('forbidden'));
     });
 
-    test('returns prompt descriptor for ANALYZE -> PLAN after boundary commit',
-        () async {
-      const branch = '51-idle-execution-guardrails';
-      _initGitRepo(tempDir.path, branch: branch);
-      _writeState(tempDir.path, 'ANALYZE', issue: '51');
-      _writeAnalyzeIndex(tempDir.path, branch);
-      _writeConfirmations(tempDir.path, branch);
-      _writeDiagnosis(tempDir.path, branch, 'diagnosis draft');
-      final commitsBefore = _commitCount(tempDir.path);
+    test(
+      'returns prompt descriptor for ANALYZE -> PLAN after boundary commit',
+      () async {
+        const branch = '51-idle-execution-guardrails';
+        _initGitRepo(tempDir.path, branch: branch);
+        _writeState(tempDir.path, 'ANALYZE', issue: '51');
+        _writeAnalyzeIndex(tempDir.path, branch);
+        _writeConfirmations(tempDir.path, branch);
+        _writeDiagnosis(tempDir.path, branch, 'diagnosis draft');
+        final commitsBefore = _commitCount(tempDir.path);
 
-      final input = StateTransitionInput(
-        currentState: null,
-        event: 'complete_analysis',
-        workingDirectory: tempDir.path,
-      );
-      final command = StateTransitionCommand(
-        input,
-        branchProvider: (_) async => '51-idle-execution-guardrails',
-      );
-
-      final output = await command.execute();
-
-      expect(output.allowed, isTrue);
-      expect(output.nextState, 'PLAN');
-      expect(output.promptFragmentId, 'analyze_to_plan');
-      expect(output.requiredRole, 'DESCARTES');
-      expect(output.requiredInstructions, ['doc-write']);
-      expect(_commitCount(tempDir.path), commitsBefore + 1);
-
-      // Verify state.yaml was actually updated
-      final stateContent = File(
-        p.join(tempDir.path, '.inquiry', 'state.yaml'),
-      ).readAsStringSync();
-      expect(stateContent, contains('state: PLAN'));
-      expect(stateContent, contains('prompt_fragment_id: analyze_to_plan'));
-    });
-
-    test('fails precheck when ANALYZE corpus lacks confirmations and index',
-        () async {
-      const branch = '51-idle-execution-guardrails';
-      _initGitRepo(tempDir.path, branch: branch);
-      _writeState(tempDir.path, 'ANALYZE', issue: '51');
-      _writeDiagnosis(tempDir.path, branch, 'diagnosis draft');
-
-      final output = await StateTransitionCommand(
-        StateTransitionInput(
+        final input = StateTransitionInput(
           currentState: null,
           event: 'complete_analysis',
           workingDirectory: tempDir.path,
-        ),
-        branchProvider: (_) async => branch,
-      ).execute();
+        );
+        final command = StateTransitionCommand(
+          input,
+          branchProvider: (_) async => '51-idle-execution-guardrails',
+        );
 
-      expect(output.allowed, isFalse);
-      expect(output.message, contains('ERROR_PRECONDITION'));
-    });
+        final output = await command.execute();
 
-    test('fails closed when ANALYZE -> PLAN cannot create boundary commit',
-        () async {
-      const branch = '51-idle-execution-guardrails';
+        expect(output.allowed, isTrue);
+        expect(output.nextState, 'PLAN');
+        expect(output.promptFragmentId, 'analyze_to_plan');
+        expect(output.requiredRole, 'DESCARTES');
+        expect(output.requiredInstructions, ['doc-write']);
+        expect(_commitCount(tempDir.path), commitsBefore + 1);
 
-      _initGitRepo(tempDir.path, branch: branch);
-      _writeAnalyzeIndex(tempDir.path, branch);
-      _writeConfirmations(tempDir.path, branch);
-      _writeDiagnosis(tempDir.path, branch, 'diagnosis already committed');
-      _git(
-        tempDir.path,
-        ['add', '--', p.posix.join('cleanrooms', branch, 'analyze')],
-      );
-      _git(
-        tempDir.path,
-        [
+        // Verify state was actually updated
+        final stateContent = File(
+          _cycleStatePath(tempDir.path, branch),
+        ).readAsStringSync();
+        expect(stateContent, contains('state: PLAN'));
+        expect(stateContent, contains('prompt_fragment_id: analyze_to_plan'));
+      },
+    );
+
+    test(
+      'fails precheck when ANALYZE corpus lacks confirmations and index',
+      () async {
+        const branch = '51-idle-execution-guardrails';
+        _initGitRepo(tempDir.path, branch: branch);
+        _writeState(tempDir.path, 'ANALYZE', issue: '51');
+        _writeDiagnosis(tempDir.path, branch, 'diagnosis draft');
+
+        final output = await StateTransitionCommand(
+          StateTransitionInput(
+            currentState: null,
+            event: 'complete_analysis',
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => branch,
+        ).execute();
+
+        expect(output.allowed, isFalse);
+        expect(output.message, contains('ERROR_PRECONDITION'));
+      },
+    );
+
+    test(
+      'fails closed when ANALYZE -> PLAN cannot create boundary commit',
+      () async {
+        const branch = '51-idle-execution-guardrails';
+
+        _initGitRepo(tempDir.path, branch: branch);
+        _writeAnalyzeIndex(tempDir.path, branch);
+        _writeConfirmations(tempDir.path, branch);
+        _writeDiagnosis(tempDir.path, branch, 'diagnosis already committed');
+        _git(tempDir.path, [
+          'add',
+          '--',
+          p.posix.join('cleanrooms', branch, 'analyze'),
+        ]);
+        _git(tempDir.path, [
           'commit',
           '-m',
           'analysis ready',
           '--only',
           '--',
           p.posix.join('cleanrooms', branch, 'analyze'),
-        ],
-      );
-      _writeState(tempDir.path, 'ANALYZE', issue: '51');
-      final commitsBefore = _commitCount(tempDir.path);
+        ]);
+        _writeState(tempDir.path, 'ANALYZE', issue: '51');
+        final commitsBefore = _commitCount(tempDir.path);
 
-      final output = await StateTransitionCommand(
-        StateTransitionInput(
+        final output = await StateTransitionCommand(
+          StateTransitionInput(
+            currentState: null,
+            event: 'complete_analysis',
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => branch,
+        ).execute();
+
+        expect(output.allowed, isFalse);
+        expect(output.nextState, isNull);
+        expect(output.message, contains('commit'));
+        expect(_commitCount(tempDir.path), commitsBefore);
+
+        final stateContent = File(
+          _cycleStatePath(tempDir.path, branch),
+        ).readAsStringSync();
+        expect(stateContent, contains('state: ANALYZE'));
+      },
+    );
+
+    test(
+      'fails precheck when commitment needs issue/branch and issue missing',
+      () async {
+        const branch = '51-idle-execution-guardrails';
+        _initGitRepo(tempDir.path, branch: branch);
+        _writeState(tempDir.path, 'PLAN');
+
+        final input = StateTransitionInput(
           currentState: null,
-          event: 'complete_analysis',
+          event: 'approve_plan',
           workingDirectory: tempDir.path,
-        ),
-        branchProvider: (_) async => branch,
-      ).execute();
+        );
+        final command = StateTransitionCommand(
+          input,
+          branchProvider: (_) async => '51-idle-execution-guardrails',
+        );
 
-      expect(output.allowed, isFalse);
-      expect(output.nextState, isNull);
-      expect(output.message, contains('commit'));
-      expect(_commitCount(tempDir.path), commitsBefore);
+        final output = await command.execute();
 
-      final stateContent = File(
-        p.join(tempDir.path, '.inquiry', 'state.yaml'),
-      ).readAsStringSync();
-      expect(stateContent, contains('state: ANALYZE'));
-    });
-
-    test('fails precheck when commitment needs issue/branch and issue missing',
-        () async {
-      _writeState(tempDir.path, 'PLAN');
-
-      final input = StateTransitionInput(
-        currentState: null,
-        event: 'approve_plan',
-        workingDirectory: tempDir.path,
-      );
-      final command = StateTransitionCommand(
-        input,
-        branchProvider: (_) async => '51-idle-execution-guardrails',
-      );
-
-      final output = await command.execute();
-
-      expect(output.allowed, isFalse);
-      expect(output.exitCode, 7);
-      expect(output.message, contains('ERROR_PRECONDITION_ISSUE_FIRST'));
-    });
+        expect(output.allowed, isFalse);
+        expect(output.exitCode, 7);
+        expect(output.message, contains('ERROR_PRECONDITION_ISSUE_FIRST'));
+      },
+    );
 
     test('blocks IDLE to ANALYZE without issue context', () async {
       _writeState(tempDir.path, 'IDLE');
@@ -182,27 +191,31 @@ void main() {
       expect(output.message, contains('ERROR_PRECONDITION_ISSUE_FIRST'));
     });
 
-    test('blocks IDLE to ANALYZE when issue is ready but branch is not',
-        () async {
-      _writeState(tempDir.path, 'IDLE', issue: '152');
+    test(
+      'blocks IDLE to ANALYZE when issue is ready but branch is not',
+      () async {
+        _initGitRepo(tempDir.path, branch: '152-feature-branch');
+        _writeState(tempDir.path, 'IDLE', issue: '152');
 
-      final input = StateTransitionInput(
-        currentState: null,
-        event: 'start_analyze',
-        workingDirectory: tempDir.path,
-      );
-      final command = StateTransitionCommand(
-        input,
-        branchProvider: (_) async => 'main',
-      );
+        final input = StateTransitionInput(
+          currentState: null,
+          event: 'start_analyze',
+          workingDirectory: tempDir.path,
+        );
+        final command = StateTransitionCommand(
+          input,
+          branchProvider: (_) async => 'main',
+        );
 
-      final output = await command.execute();
+        final output = await command.execute();
 
-      expect(output.allowed, isFalse);
-      expect(output.message, contains('ERROR_PRECONDITION_BRANCH_POLICY'));
-    });
+        expect(output.allowed, isFalse);
+        expect(output.message, contains('ERROR_PRECONDITION_BRANCH_POLICY'));
+      },
+    );
 
     test('allows IDLE to ANALYZE with issue and feature branch', () async {
+      _initGitRepo(tempDir.path, branch: '152-feature-branch');
       _writeState(tempDir.path, 'IDLE');
 
       final input = StateTransitionInput(
@@ -226,6 +239,7 @@ void main() {
     });
 
     test('blocks commitment transition on main branch', () async {
+      _initGitRepo(tempDir.path, branch: '51-idle-execution-guardrails');
       _writeState(tempDir.path, 'PLAN', issue: '51');
 
       final input = StateTransitionInput(
@@ -245,71 +259,81 @@ void main() {
       expect(output.message, contains('ERROR_PRECONDITION_BRANCH_POLICY'));
     });
 
-    test('transitions PLAN -> EXECUTE only after plan boundary commit', () async {
-      const branch = '51-idle-execution-guardrails';
-      _initGitRepo(tempDir.path, branch: branch);
-      _writeState(tempDir.path, 'PLAN', issue: '51');
-      _writePlan(tempDir.path, branch, '# plan\n');
-      final commitsBefore = _commitCount(tempDir.path);
+    test(
+      'transitions PLAN -> EXECUTE only after plan boundary commit',
+      () async {
+        const branch = '51-idle-execution-guardrails';
+        _initGitRepo(tempDir.path, branch: branch);
+        _writeState(tempDir.path, 'PLAN', issue: '51');
+        _writePlan(tempDir.path, branch, '# plan\n');
+        final commitsBefore = _commitCount(tempDir.path);
 
-      final output = await StateTransitionCommand(
-        StateTransitionInput(
-          currentState: null,
-          event: 'approve_plan',
-          workingDirectory: tempDir.path,
-        ),
-        branchProvider: (_) async => branch,
-      ).execute();
+        final output = await StateTransitionCommand(
+          StateTransitionInput(
+            currentState: null,
+            event: 'approve_plan',
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => branch,
+        ).execute();
 
-      expect(output.allowed, isTrue);
-      expect(output.nextState, 'EXECUTE');
-      expect(output.promptFragmentId, 'plan_to_execute');
-      expect(output.requiredInstructions, isEmpty);
-      expect(_commitCount(tempDir.path), commitsBefore + 1);
+        expect(output.allowed, isTrue);
+        expect(output.nextState, 'EXECUTE');
+        expect(output.promptFragmentId, 'plan_to_execute');
+        expect(output.requiredInstructions, isEmpty);
+        expect(_commitCount(tempDir.path), commitsBefore + 1);
 
-      final stateContent = File(
-        p.join(tempDir.path, '.inquiry', 'state.yaml'),
-      ).readAsStringSync();
-      expect(stateContent, contains('state: EXECUTE'));
-      expect(stateContent, contains('prompt_fragment_id: plan_to_execute'));
-    });
+        final stateContent = File(
+          _cycleStatePath(tempDir.path, branch),
+        ).readAsStringSync();
+        expect(stateContent, contains('state: EXECUTE'));
+        expect(stateContent, contains('prompt_fragment_id: plan_to_execute'));
+      },
+    );
 
-    test('fails closed when PLAN -> EXECUTE cannot create boundary commit',
-        () async {
-      const branch = '51-idle-execution-guardrails';
-      final planPath = p.posix.join('cleanrooms', branch, 'plan.md');
+    test(
+      'fails closed when PLAN -> EXECUTE cannot create boundary commit',
+      () async {
+        const branch = '51-idle-execution-guardrails';
+        final planPath = p.posix.join('cleanrooms', branch, 'plan.md');
 
-      _initGitRepo(tempDir.path, branch: branch);
-      _writePlan(tempDir.path, branch, '# committed plan\n');
-      _git(tempDir.path, ['add', '--', planPath]);
-      _git(
-        tempDir.path,
-        ['commit', '-m', 'plan ready', '--only', '--', planPath],
-      );
-      _writeState(tempDir.path, 'PLAN', issue: '51');
-      final commitsBefore = _commitCount(tempDir.path);
+        _initGitRepo(tempDir.path, branch: branch);
+        _writePlan(tempDir.path, branch, '# committed plan\n');
+        _git(tempDir.path, ['add', '--', planPath]);
+        _git(tempDir.path, [
+          'commit',
+          '-m',
+          'plan ready',
+          '--only',
+          '--',
+          planPath,
+        ]);
+        _writeState(tempDir.path, 'PLAN', issue: '51');
+        final commitsBefore = _commitCount(tempDir.path);
 
-      final output = await StateTransitionCommand(
-        StateTransitionInput(
-          currentState: null,
-          event: 'approve_plan',
-          workingDirectory: tempDir.path,
-        ),
-        branchProvider: (_) async => branch,
-      ).execute();
+        final output = await StateTransitionCommand(
+          StateTransitionInput(
+            currentState: null,
+            event: 'approve_plan',
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => branch,
+        ).execute();
 
-      expect(output.allowed, isFalse);
-      expect(output.nextState, isNull);
-      expect(output.message, contains('commit'));
-      expect(_commitCount(tempDir.path), commitsBefore);
+        expect(output.allowed, isFalse);
+        expect(output.nextState, isNull);
+        expect(output.message, contains('commit'));
+        expect(_commitCount(tempDir.path), commitsBefore);
 
-      final stateContent = File(
-        p.join(tempDir.path, '.inquiry', 'state.yaml'),
-      ).readAsStringSync();
-      expect(stateContent, contains('state: PLAN'));
-    });
+        final stateContent = File(
+          _cycleStatePath(tempDir.path, branch),
+        ).readAsStringSync();
+        expect(stateContent, contains('state: PLAN'));
+      },
+    );
 
     test('continuing EXECUTE does not require startup instructions', () async {
+      _initGitRepo(tempDir.path, branch: '51-idle-execution-guardrails');
       _writeState(tempDir.path, 'EXECUTE', issue: '51');
 
       final output = await StateTransitionCommand(
@@ -328,6 +352,7 @@ void main() {
     });
 
     test('routes EXECUTE through END before PR creation', () async {
+      _initGitRepo(tempDir.path, branch: '51-idle-execution-guardrails');
       _writeState(tempDir.path, 'EXECUTE', issue: '51');
 
       final output = await StateTransitionCommand(
@@ -347,6 +372,7 @@ void main() {
     });
 
     test('allows END to create PR and enter EVOLUTION', () async {
+      _initGitRepo(tempDir.path, branch: '51-idle-execution-guardrails');
       _writeState(tempDir.path, 'END', issue: '51');
 
       final output = await StateTransitionCommand(
@@ -366,6 +392,8 @@ void main() {
     });
 
     test('persists --issue flag in state.yaml on transition', () async {
+      const branch = '31-feature-branch';
+      _initGitRepo(tempDir.path, branch: branch);
       _writeState(tempDir.path, 'IDLE');
 
       final input = StateTransitionInput(
@@ -384,9 +412,9 @@ void main() {
       expect(output.allowed, isTrue);
       expect(output.nextState, 'ANALYZE');
 
-      // Verify issue was persisted in state.yaml
+      // Verify issue was persisted in state
       final stateContent = File(
-        p.join(tempDir.path, '.inquiry', 'state.yaml'),
+        _cycleStatePath(tempDir.path, branch),
       ).readAsStringSync();
       expect(stateContent, contains('issue: "31"'));
       expect(stateContent, contains('prompt_fragment_id: idle_to_analyze'));
@@ -417,7 +445,7 @@ void main() {
 
       // Issue should still be there
       final stateContent = File(
-        p.join(tempDir.path, '.inquiry', 'state.yaml'),
+        _cycleStatePath(tempDir.path, branch),
       ).readAsStringSync();
       expect(stateContent, contains('issue: "31"'));
       expect(stateContent, contains('prompt_fragment_id: analyze_to_plan'));
@@ -434,9 +462,7 @@ void _writeDiagnosis(String root, String branch, String content) {
 }
 
 void _writeAnalyzeIndex(String root, String branch) {
-  final file = File(
-    p.join(root, 'cleanrooms', branch, 'analyze', 'index.md'),
-  );
+  final file = File(p.join(root, 'cleanrooms', branch, 'analyze', 'index.md'));
   file.createSync(recursive: true);
   file.writeAsStringSync('# Analyze Phase — Index\n');
 }
@@ -478,21 +504,35 @@ ProcessResult _git(String root, List<String> args) {
   return result;
 }
 
-void _writeState(String root, String state, {String? issue}) {
-  final file = File(p.join(root, '.inquiry', 'state.yaml'));
+void _writeState(String root, String state, {String? issue, String? branch}) {
+  final b = branch ?? _currentBranch(root);
+  if (b == null) return; // IDLE / no cycle — nothing to persist.
+  final file = File(p.join(root, 'cleanrooms', b, kStateFileName));
   file.createSync(recursive: true);
   final issueLine = issue != null ? 'issue: "$issue"' : 'issue: null';
-  file.writeAsStringSync('state: $state\n$issueLine\n');
+  file.writeAsStringSync(
+    'version: 1\nstate: $state\n$issueLine\nstatus: active\n',
+  );
 }
+
+String? _currentBranch(String root) {
+  final r = Process.runSync('git', [
+    'rev-parse',
+    '--abbrev-ref',
+    'HEAD',
+  ], workingDirectory: root);
+  if (r.exitCode != 0) return null;
+  final b = r.stdout.toString().trim();
+  if (b.isEmpty || b == 'HEAD') return null;
+  return b;
+}
+
+String _cycleStatePath(String root, String branch) =>
+    p.join(root, 'cleanrooms', branch, kStateFileName);
 
 void _writeContract(String root) {
   final source = File(
-    p.join(
-      Directory.current.path,
-      'assets',
-      'fsm',
-      'transition_contract.yaml',
-    ),
+    p.join(Directory.current.path, 'assets', 'fsm', 'transition_contract.yaml'),
   );
   final file = File(p.join(root, 'assets', 'fsm', 'transition_contract.yaml'));
   file.createSync(recursive: true);

--- a/code/cli/test/init_command_test.dart
+++ b/code/cli/test/init_command_test.dart
@@ -71,6 +71,14 @@ void main() {
         },
       );
 
+      test('ignores cycle-local state files under cleanrooms/', () async {
+        final command = InitCommand(InitInput(workingDirectory: tempDir.path));
+        await command.execute();
+
+        final content = File('${tempDir.path}/.gitignore').readAsStringSync();
+        expect(content, contains('cleanrooms/**/.iq.state.yaml'));
+      });
+
       test('appends .inquiry/ to existing .gitignore that lacks it', () async {
         File('${tempDir.path}/.gitignore').writeAsStringSync('node_modules/\n');
 
@@ -80,52 +88,52 @@ void main() {
         final content = File('${tempDir.path}/.gitignore').readAsStringSync();
         expect(content, contains('node_modules/'));
         expect(content, contains('.inquiry/'));
+        expect(content, contains('cleanrooms/**/.iq.state.yaml'));
       });
 
-      test('does not modify .gitignore if .inquiry/ already present', () async {
-        final original = 'node_modules/\n.inquiry/\nbuild/\n';
-        File('${tempDir.path}/.gitignore').writeAsStringSync(original);
+      test(
+        'does not modify .gitignore if all entries already present',
+        () async {
+          final original =
+              'node_modules/\n.inquiry/\ncleanrooms/**/.iq.state.yaml\nbuild/\n';
+          File('${tempDir.path}/.gitignore').writeAsStringSync(original);
 
+          final command = InitCommand(
+            InitInput(workingDirectory: tempDir.path),
+          );
+          await command.execute();
+
+          final content = File('${tempDir.path}/.gitignore').readAsStringSync();
+          expect(content, equals(original));
+        },
+      );
+    });
+
+    // ─── Cycle-local model: init no longer scaffolds repo-level runtime ──
+
+    group('cycle-local model', () {
+      test('does not create repo-level .inquiry/state.yaml', () async {
         final command = InitCommand(InitInput(workingDirectory: tempDir.path));
         await command.execute();
 
-        final content = File('${tempDir.path}/.gitignore').readAsStringSync();
-        expect(content, equals(original));
+        expect(
+          File('${tempDir.path}/.inquiry/state.yaml').existsSync(),
+          isFalse,
+        );
+      });
+
+      test('does not create repo-level .inquiry/mutations.md', () async {
+        final command = InitCommand(InitInput(workingDirectory: tempDir.path));
+        await command.execute();
+
+        expect(
+          File('${tempDir.path}/.inquiry/mutations.md').existsSync(),
+          isFalse,
+        );
       });
     });
 
-    // ─── Step 4: .inquiry/state.yaml ──────────────────────────────────────
-
-    group('.inquiry/state.yaml', () {
-      test('creates .inquiry/state.yaml with initial IDLE state and ape: null', () async {
-        final command = InitCommand(InitInput(workingDirectory: tempDir.path));
-        await command.execute();
-
-        final stateFile = File('${tempDir.path}/.inquiry/state.yaml');
-        expect(stateFile.existsSync(), isTrue);
-
-        final content = stateFile.readAsStringSync();
-        expect(content, contains('state: IDLE'));
-        expect(content, contains('issue: null'));
-        expect(content, contains('ape: null'));
-      });
-
-      test('skips .inquiry/state.yaml if already exists', () async {
-        Directory('${tempDir.path}/.inquiry').createSync();
-        File(
-          '${tempDir.path}/.inquiry/state.yaml',
-        ).writeAsStringSync('state: ANALYZE\nissue: "042-something"\n');
-
-        final command = InitCommand(InitInput(workingDirectory: tempDir.path));
-        await command.execute();
-
-        final content = File(
-          '${tempDir.path}/.inquiry/state.yaml',
-        ).readAsStringSync();
-        expect(content, contains('state: ANALYZE'));
-        expect(content, contains('042-something'));
-      });
-    });
+    // ─── Step 4: .inquiry/state.yaml — removed (cycle-local model) ────────
 
     // ─── Step 5: .inquiry/config.yaml ─────────────────────────────────────
 
@@ -160,34 +168,7 @@ void main() {
 
     // ─── Step 6: .inquiry/mutations.md ──────────────────────────────────
 
-    group('.inquiry/mutations.md', () {
-      test('creates .inquiry/mutations.md with header template', () async {
-        final command = InitCommand(InitInput(workingDirectory: tempDir.path));
-        await command.execute();
-
-        final mutationsFile = File('${tempDir.path}/.inquiry/mutations.md');
-        expect(mutationsFile.existsSync(), isTrue);
-
-        final content = mutationsFile.readAsStringSync();
-        expect(content, contains('# Mutations'));
-        expect(content, contains('Notes for DARWIN'));
-      });
-
-      test('skips .inquiry/mutations.md if already exists', () async {
-        Directory('${tempDir.path}/.inquiry').createSync();
-        File(
-          '${tempDir.path}/.inquiry/mutations.md',
-        ).writeAsStringSync('# Mutations\n\n- My custom note\n');
-
-        final command = InitCommand(InitInput(workingDirectory: tempDir.path));
-        await command.execute();
-
-        final content = File(
-          '${tempDir.path}/.inquiry/mutations.md',
-        ).readAsStringSync();
-        expect(content, contains('My custom note'));
-      });
-    });
+    // ─── Step 6: .inquiry/mutations.md — removed (cycle-local model) ──────
 
     // ─── Idempotency ──────────────────────────────────────────────────
 
@@ -197,38 +178,24 @@ void main() {
 
         await command.execute();
         // Capture state after first run
-        final stateAfterFirst = File(
-          '${tempDir.path}/.inquiry/state.yaml',
-        ).readAsStringSync();
         final gitignoreAfterFirst = File(
           '${tempDir.path}/.gitignore',
         ).readAsStringSync();
         final configAfterFirst = File(
           '${tempDir.path}/.inquiry/config.yaml',
         ).readAsStringSync();
-        final mutationsAfterFirst = File(
-          '${tempDir.path}/.inquiry/mutations.md',
-        ).readAsStringSync();
 
         await command.execute();
         // Verify state unchanged after second run
-        final stateAfterSecond = File(
-          '${tempDir.path}/.inquiry/state.yaml',
-        ).readAsStringSync();
         final gitignoreAfterSecond = File(
           '${tempDir.path}/.gitignore',
         ).readAsStringSync();
         final configAfterSecond = File(
           '${tempDir.path}/.inquiry/config.yaml',
         ).readAsStringSync();
-        final mutationsAfterSecond = File(
-          '${tempDir.path}/.inquiry/mutations.md',
-        ).readAsStringSync();
 
-        expect(stateAfterSecond, equals(stateAfterFirst));
         expect(gitignoreAfterSecond, equals(gitignoreAfterFirst));
         expect(configAfterSecond, equals(configAfterFirst));
-        expect(mutationsAfterSecond, equals(mutationsAfterFirst));
         expect(Directory('${tempDir.path}/cleanrooms').existsSync(), isTrue);
       });
     });
@@ -250,32 +217,37 @@ void main() {
 
       setUp(() {
         // Minimal assets tree with an agent file
-        assetsRoot = Directory.systemTemp.createTempSync('inquiry_assets_test_');
+        assetsRoot = Directory.systemTemp.createTempSync(
+          'inquiry_assets_test_',
+        );
         final agentDir = Directory(p.join(assetsRoot.path, 'assets', 'agents'));
         agentDir.createSync(recursive: true);
-        File(p.join(agentDir.path, 'inquiry.agent.md'))
-            .writeAsStringSync('---\nname: inquiry\n---\nTest agent content.');
+        File(
+          p.join(agentDir.path, 'inquiry.agent.md'),
+        ).writeAsStringSync('---\nname: inquiry\n---\nTest agent content.');
       });
 
       tearDown(() {
         if (assetsRoot.existsSync()) assetsRoot.deleteSync(recursive: true);
       });
 
-      test('writes inquiry.agent.md to .github/agents/ when assets provided',
-          () async {
-        final assets = Assets(root: assetsRoot.path);
-        final command = InitCommand(
-          InitInput(workingDirectory: tempDir.path),
-          assets: assets,
-        );
-        await command.execute();
+      test(
+        'writes inquiry.agent.md to .github/agents/ when assets provided',
+        () async {
+          final assets = Assets(root: assetsRoot.path);
+          final command = InitCommand(
+            InitInput(workingDirectory: tempDir.path),
+            assets: assets,
+          );
+          await command.execute();
 
-        final agentFile = File(
-          p.join(tempDir.path, '.github', 'agents', 'inquiry.agent.md'),
-        );
-        expect(agentFile.existsSync(), isTrue);
-        expect(agentFile.readAsStringSync(), contains('Test agent content.'));
-      });
+          final agentFile = File(
+            p.join(tempDir.path, '.github', 'agents', 'inquiry.agent.md'),
+          );
+          expect(agentFile.existsSync(), isTrue);
+          expect(agentFile.readAsStringSync(), contains('Test agent content.'));
+        },
+      );
 
       test('creates .github/agents/ directory if missing', () async {
         final assets = Assets(root: assetsRoot.path);
@@ -291,28 +263,30 @@ void main() {
         );
       });
 
-      test('overwrites existing inquiry.agent.md on re-init (idempotent)',
-          () async {
-        // Write stale content first
-        final agentDir = Directory(
-          p.join(tempDir.path, '.github', 'agents'),
-        )..createSync(recursive: true);
-        File(p.join(agentDir.path, 'inquiry.agent.md'))
-            .writeAsStringSync('stale content');
+      test(
+        'overwrites existing inquiry.agent.md on re-init (idempotent)',
+        () async {
+          // Write stale content first
+          final agentDir = Directory(p.join(tempDir.path, '.github', 'agents'))
+            ..createSync(recursive: true);
+          File(
+            p.join(agentDir.path, 'inquiry.agent.md'),
+          ).writeAsStringSync('stale content');
 
-        final assets = Assets(root: assetsRoot.path);
-        final command = InitCommand(
-          InitInput(workingDirectory: tempDir.path),
-          assets: assets,
-        );
-        await command.execute();
+          final assets = Assets(root: assetsRoot.path);
+          final command = InitCommand(
+            InitInput(workingDirectory: tempDir.path),
+            assets: assets,
+          );
+          await command.execute();
 
-        final content = File(
-          p.join(tempDir.path, '.github', 'agents', 'inquiry.agent.md'),
-        ).readAsStringSync();
-        expect(content, contains('Test agent content.'));
-        expect(content, isNot(contains('stale content')));
-      });
+          final content = File(
+            p.join(tempDir.path, '.github', 'agents', 'inquiry.agent.md'),
+          ).readAsStringSync();
+          expect(content, contains('Test agent content.'));
+          expect(content, isNot(contains('stale content')));
+        },
+      );
 
       test('skips agent deploy silently when assets is null', () async {
         final command = InitCommand(

--- a/code/cli/test/inquiry_state_test.dart
+++ b/code/cli/test/inquiry_state_test.dart
@@ -1,23 +1,27 @@
 import 'dart:io';
 
 import 'package:inquiry_cli/modules/ape/inquiry_state.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
+
+import 'support/cycle_fixture.dart';
 
 void main() {
   late Directory tmpDir;
+  late String stateFile;
 
   setUp(() {
     tmpDir = Directory.systemTemp.createTempSync('inquiry_state_test_');
-    Directory('${tmpDir.path}/.inquiry').createSync(recursive: true);
+    stateFile = p.join(tmpDir.path, kStateFileName);
   });
 
   tearDown(() {
     tmpDir.deleteSync(recursive: true);
   });
 
-  group('InquiryState.load', () {
-    test('returns IDLE when state.yaml is missing', () {
-      final state = InquiryState.load(tmpDir.path);
+  group('InquiryState.loadFrom', () {
+    test('returns IDLE when state file is missing', () {
+      final state = InquiryState.loadFrom(stateFile);
       expect(state.state, equals('IDLE'));
       expect(state.issue, isNull);
       expect(state.apeName, isNull);
@@ -25,17 +29,18 @@ void main() {
     });
 
     test('reads basic state and issue', () {
-      File('${tmpDir.path}/.inquiry/state.yaml')
-          .writeAsStringSync('state: ANALYZE\nissue: "145"\nape: null\n');
+      File(
+        stateFile,
+      ).writeAsStringSync('state: ANALYZE\nissue: "145"\nape: null\n');
 
-      final state = InquiryState.load(tmpDir.path);
+      final state = InquiryState.loadFrom(stateFile);
       expect(state.state, equals('ANALYZE'));
       expect(state.issue, equals('145'));
       expect(state.apeName, isNull);
     });
 
     test('reads state with ape field', () {
-      File('${tmpDir.path}/.inquiry/state.yaml').writeAsStringSync(
+      File(stateFile).writeAsStringSync(
         'state: ANALYZE\n'
         'issue: "145"\n'
         'prompt_fragment_id: analyze_continue\n'
@@ -44,7 +49,7 @@ void main() {
         '  state: clarification\n',
       );
 
-      final state = InquiryState.load(tmpDir.path);
+      final state = InquiryState.loadFrom(stateFile);
       expect(state.state, equals('ANALYZE'));
       expect(state.issue, equals('145'));
       expect(state.promptFragmentId, equals('analyze_continue'));
@@ -53,36 +58,53 @@ void main() {
     });
 
     test('reads integer issue as string', () {
-      File('${tmpDir.path}/.inquiry/state.yaml')
-          .writeAsStringSync('state: PLAN\nissue: 99\nape: null\n');
+      File(stateFile).writeAsStringSync('state: PLAN\nissue: 99\nape: null\n');
 
-      final state = InquiryState.load(tmpDir.path);
+      final state = InquiryState.loadFrom(stateFile);
       expect(state.issue, equals('99'));
     });
 
     test('handles null issue', () {
-      File('${tmpDir.path}/.inquiry/state.yaml')
-          .writeAsStringSync('state: IDLE\nissue: null\nape: null\n');
+      File(
+        stateFile,
+      ).writeAsStringSync('state: IDLE\nissue: null\nape: null\n');
 
-      final state = InquiryState.load(tmpDir.path);
+      final state = InquiryState.loadFrom(stateFile);
       expect(state.issue, isNull);
     });
 
-    test('backward compat: reads old format without ape field', () {
-      File('${tmpDir.path}/.inquiry/state.yaml')
-          .writeAsStringSync('state: PLAN\nissue: "42"\n');
+    test('reads new schema fields: version, status, timestamps', () {
+      File(stateFile).writeAsStringSync(
+        'version: 1\n'
+        'state: PLAN\n'
+        'issue: "42"\n'
+        'status: active\n'
+        'created_at: "2026-01-01T00:00:00.000Z"\n'
+        'updated_at: "2026-01-02T00:00:00.000Z"\n',
+      );
 
-      final state = InquiryState.load(tmpDir.path);
+      final state = InquiryState.loadFrom(stateFile);
+      expect(state.version, equals(1));
+      expect(state.status, equals('active'));
+      expect(state.createdAt, equals('2026-01-01T00:00:00.000Z'));
+      expect(state.updatedAt, equals('2026-01-02T00:00:00.000Z'));
+    });
+
+    test('backward compat: reads old format without ape field', () {
+      File(stateFile).writeAsStringSync('state: PLAN\nissue: "42"\n');
+
+      final state = InquiryState.loadFrom(stateFile);
       expect(state.state, equals('PLAN'));
       expect(state.issue, equals('42'));
       expect(state.promptFragmentId, isNull);
       expect(state.apeName, isNull);
       expect(state.apeState, isNull);
+      expect(state.version, equals(1));
     });
   });
 
-  group('InquiryState.save', () {
-    test('writes full format with ape field', () {
+  group('InquiryState.saveTo', () {
+    test('writes full format with ape field and schema metadata', () {
       const state = InquiryState(
         state: 'ANALYZE',
         issue: '145',
@@ -90,38 +112,52 @@ void main() {
         apeName: 'socrates',
         apeState: 'clarification',
       );
-      state.save(tmpDir.path);
+      state.saveTo(stateFile);
 
-      final content =
-          File('${tmpDir.path}/.inquiry/state.yaml').readAsStringSync();
+      final content = File(stateFile).readAsStringSync();
+      expect(content, contains('version: 1'));
       expect(content, contains('state: ANALYZE'));
       expect(content, contains('issue: "145"'));
       expect(content, contains('prompt_fragment_id: analyze_continue'));
+      expect(content, contains('status: active'));
       expect(content, contains('ape:'));
       expect(content, contains('  name: socrates'));
       expect(content, contains('  state: clarification'));
+      expect(content, contains('created_at:'));
+      expect(content, contains('updated_at:'));
     });
 
     test('writes ape: null when no APE', () {
       const state = InquiryState(state: 'IDLE');
-      state.save(tmpDir.path);
+      state.saveTo(stateFile);
 
-      final content =
-          File('${tmpDir.path}/.inquiry/state.yaml').readAsStringSync();
+      final content = File(stateFile).readAsStringSync();
       expect(content, contains('state: IDLE'));
       expect(content, contains('issue: null'));
       expect(content, contains('ape: null'));
     });
 
-    test('creates .inquiry directory when missing', () {
-      Directory('${tmpDir.path}/.inquiry').deleteSync(recursive: true);
+    test('creates parent directory when missing', () {
+      final nested = p.join(tmpDir.path, 'cleanrooms', 'x', kStateFileName);
 
       const state = InquiryState(state: 'IDLE');
-      state.save(tmpDir.path);
+      state.saveTo(nested);
 
-      final file = File('${tmpDir.path}/.inquiry/state.yaml');
+      final file = File(nested);
       expect(file.existsSync(), isTrue);
       expect(file.readAsStringSync(), contains('state: IDLE'));
+    });
+
+    test('preserves created_at across saves', () {
+      const original = InquiryState(
+        state: 'PLAN',
+        issue: '7',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      );
+      original.saveTo(stateFile);
+
+      final content = File(stateFile).readAsStringSync();
+      expect(content, contains('created_at: "2026-01-01T00:00:00.000Z"'));
     });
 
     test('roundtrips correctly', () {
@@ -132,14 +168,53 @@ void main() {
         apeName: 'basho',
         apeState: 'implement',
       );
-      original.save(tmpDir.path);
+      original.saveTo(stateFile);
 
-      final loaded = InquiryState.load(tmpDir.path);
+      final loaded = InquiryState.loadFrom(stateFile);
       expect(loaded.state, equals('EXECUTE'));
       expect(loaded.issue, equals('200'));
       expect(loaded.promptFragmentId, equals('plan_to_execute'));
       expect(loaded.apeName, equals('basho'));
       expect(loaded.apeState, equals('implement'));
+    });
+  });
+
+  group('InquiryState cycle-local resolution', () {
+    test('load returns IDLE outside a git repository', () {
+      final state = InquiryState.load(tmpDir.path);
+      expect(state.state, equals('IDLE'));
+    });
+
+    test('stateFileFor resolves cleanrooms/<branch>/.iq.state.yaml', () {
+      final expected = setupCycle(tmpDir.path, branch: '209-foo');
+      final resolved = InquiryState.stateFileFor(tmpDir.path);
+      expect(resolved, isNotNull);
+      expect(p.equals(resolved!, expected), isTrue);
+    });
+
+    test('save then load roundtrips via cycle-local path', () {
+      final expected = setupCycle(tmpDir.path, branch: '209-foo');
+      const state = InquiryState(state: 'ANALYZE', issue: '209');
+      state.save(tmpDir.path);
+
+      expect(File(expected).existsSync(), isTrue);
+      final loaded = InquiryState.load(tmpDir.path);
+      expect(loaded.state, equals('ANALYZE'));
+      expect(loaded.issue, equals('209'));
+    });
+
+    test('load returns IDLE when cycle status is completed', () {
+      setupCycle(tmpDir.path, branch: '209-foo');
+      const state = InquiryState(state: 'EVOLUTION', status: 'completed');
+      state.save(tmpDir.path);
+
+      final loaded = InquiryState.load(tmpDir.path);
+      expect(loaded.state, equals('IDLE'));
+    });
+
+    test('save throws when no cycle resolves (IDLE is derived)', () {
+      const state = InquiryState(state: 'ANALYZE');
+      expect(() => state.save(tmpDir.path), throwsA(isA<StateError>()));
     });
   });
 
@@ -174,6 +249,14 @@ void main() {
       expect(copy.apeState, equals('assumptions'));
       expect(copy.promptFragmentId, equals('analyze_continue'));
       expect(copy.apeName, equals('socrates'));
+    });
+
+    test('copies with new status', () {
+      const original = InquiryState(state: 'EVOLUTION', status: 'active');
+      final copy = original.copyWith(status: 'completed');
+
+      expect(copy.status, equals('completed'));
+      expect(copy.state, equals('EVOLUTION'));
     });
 
     test('clearApe removes ape fields', () {

--- a/code/cli/test/inquiry_state_test.dart
+++ b/code/cli/test/inquiry_state_test.dart
@@ -212,6 +212,15 @@ void main() {
       expect(loaded.state, equals('IDLE'));
     });
 
+    test('load returns IDLE when cycle status is blocked', () {
+      setupCycle(tmpDir.path, branch: '209-foo');
+      const state = InquiryState(state: 'ANALYZE', status: 'blocked');
+      state.save(tmpDir.path);
+
+      final loaded = InquiryState.load(tmpDir.path);
+      expect(loaded.state, equals('IDLE'));
+    });
+
     test('save throws when no cycle resolves (IDLE is derived)', () {
       const state = InquiryState(state: 'ANALYZE');
       expect(() => state.save(tmpDir.path), throwsA(isA<StateError>()));

--- a/code/cli/test/support/cycle_fixture.dart
+++ b/code/cli/test/support/cycle_fixture.dart
@@ -1,0 +1,41 @@
+/// Test support: build a resolvable cycle (git repo + branch + cleanroom) so
+/// that `CycleContext.resolve` / `InquiryState.load`/`save` operate against a
+/// real cycle-local `.iq.state.yaml`.
+library;
+
+import 'dart:io';
+
+import 'package:inquiry_cli/modules/ape/inquiry_state.dart';
+import 'package:path/path.dart' as p;
+
+ProcessResult _git(String root, List<String> args) {
+  final r = Process.runSync('git', args, workingDirectory: root);
+  if (r.exitCode != 0) {
+    throw StateError('git ${args.join(' ')} failed: ${r.stderr}');
+  }
+  return r;
+}
+
+/// Initializes a git repository at [root] on [branch] with a cleanroom dir.
+///
+/// Returns the resolved cycle-local state file path
+/// (`<root>/cleanrooms/<branch>/.iq.state.yaml`).
+String setupCycle(String root, {required String branch}) {
+  _git(root, ['init', '-q']);
+  _git(root, ['config', 'user.email', 'test@example.com']);
+  _git(root, ['config', 'user.name', 'Test']);
+  // An initial commit is required so `git rev-parse --abbrev-ref HEAD` reports
+  // the branch name rather than the unborn-branch sentinel `HEAD`.
+  File(p.join(root, '.gitkeep')).writeAsStringSync('');
+  _git(root, ['add', '.gitkeep']);
+  _git(root, ['commit', '-q', '-m', 'init']);
+  _git(root, ['checkout', '-q', '-b', branch]);
+  final cleanroom = Directory(p.join(root, 'cleanrooms', branch));
+  cleanroom.createSync(recursive: true);
+  return p.join(cleanroom.path, kStateFileName);
+}
+
+/// Resolves the cycle-local state file path for a [root] on [branch] without
+/// creating the cleanroom directory.
+String cycleStateFile(String root, String branch) =>
+    p.join(root, 'cleanrooms', branch, kStateFileName);

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More targets coming soon.</p>
-      <span class="badge">v0.5.3</span>
+      <span class="badge">v0.6.0</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">
@@ -110,7 +110,7 @@
       <h2>Commands</h2>
       <ul class="commands">
         <li class="cmd"><code>iq</code><span class="desc">Print ASCII banner + version</span></li>
-        <li class="cmd"><code>iq init</code><span class="desc">Scaffold <code>.inquiry/</code> (state, config, mutations)</span></li>
+        <li class="cmd"><code>iq init</code><span class="desc">Scaffold repo-scoped Inquiry files (<code>.inquiry/config.yaml</code>, ignore rules, agent)</span></li>
         <li class="cmd"><code>iq doctor</code><span class="desc">Verify prerequisites</span></li>
         <li class="cmd"><code>iq target get</code><span class="desc">Deploy agent + skills to AI tool</span></li>
         <li class="cmd"><code>iq fsm transition</code><span class="desc">Execute a deterministic FSM transition</span></li>

--- a/code/vscode/package.json
+++ b/code/vscode/package.json
@@ -19,6 +19,7 @@
   },
   "main": "./out/extension.js",
   "activationEvents": [
+    "workspaceContains:cleanrooms/",
     "workspaceContains:.inquiry/"
   ],
   "contributes": {

--- a/code/vscode/src/commands.ts
+++ b/code/vscode/src/commands.ts
@@ -33,6 +33,7 @@ export async function addMutation(apeFolderPath: string): Promise<void> {
 
   const mutationsPath = path.join(apeFolderPath, 'mutations.md');
   const entry = formatMutation(text, true);
+  fs.mkdirSync(apeFolderPath, { recursive: true });
   fs.appendFileSync(mutationsPath, entry, 'utf-8');
   vscode.window.showInformationMessage('Inquiry: Mutation note added');
 }

--- a/code/vscode/src/cycle.ts
+++ b/code/vscode/src/cycle.ts
@@ -37,3 +37,17 @@ export function resolveMutationsDir(workspaceFolder: string): string {
   }
   return path.join(workspaceFolder, 'cleanrooms', branch);
 }
+
+/**
+ * Resolve the cycle-local FSM state file for the given workspace folder.
+ * Returns `<workspaceFolder>/cleanrooms/<branch>/.iq.state.yaml` on a valid
+ * branch, or null when no cycle resolves (no git repo / unborn / detached /
+ * slashed branch) — the caller derives IDLE in that case.
+ */
+export function resolveStatePath(workspaceFolder: string): string | null {
+  const branch = resolveBranch(workspaceFolder);
+  if (branch === null) {
+    return null;
+  }
+  return path.join(workspaceFolder, 'cleanrooms', branch, '.iq.state.yaml');
+}

--- a/code/vscode/src/cycle.ts
+++ b/code/vscode/src/cycle.ts
@@ -1,0 +1,39 @@
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+const BRANCH_DENYLIST = new Set(['', 'HEAD']);
+
+/**
+ * Resolve the current git branch for the given workspace folder.
+ * Returns null when not in a git repo, on an unborn/detached HEAD,
+ * or when the branch name contains a path separator (not a valid cycle slug).
+ */
+export function resolveBranch(workspaceFolder: string): string | null {
+  let branch: string;
+  try {
+    branch = execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd: workspaceFolder,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+  if (BRANCH_DENYLIST.has(branch) || branch.includes('/')) {
+    return null;
+  }
+  return branch;
+}
+
+/**
+ * Resolve the directory that holds the cycle-local mutations.md.
+ * On a valid branch, returns `<workspaceFolder>/cleanrooms/<branch>`.
+ * Otherwise falls back to the project-scoped `<workspaceFolder>/.inquiry`.
+ */
+export function resolveMutationsDir(workspaceFolder: string): string {
+  const branch = resolveBranch(workspaceFolder);
+  if (branch === null) {
+    return path.join(workspaceFolder, '.inquiry');
+  }
+  return path.join(workspaceFolder, 'cleanrooms', branch);
+}

--- a/code/vscode/src/extension.ts
+++ b/code/vscode/src/extension.ts
@@ -6,6 +6,7 @@ import { withGuard } from './command-guard';
 import { inquiryInit } from './init';
 import { installInquiryCli } from './installer';
 import { getInquiryBinDir, shellExec } from './guard';
+import { resolveMutationsDir } from './cycle';
 
 export function activate(context: vscode.ExtensionContext): void {
   // Inject inquiry bin dir into terminal PATH so `inquiry` and `iq` work
@@ -54,7 +55,7 @@ export function activate(context: vscode.ExtensionContext): void {
       withGuard(workspaceFolder, {}, () => toggleEvolution(inquiryFolderPath)),
     ),
     vscode.commands.registerCommand('inquiry.addMutation', () =>
-      withGuard(workspaceFolder, {}, () => addMutation(inquiryFolderPath)),
+      withGuard(workspaceFolder, {}, () => addMutation(resolveMutationsDir(workspaceFolder))),
     ),
   );
 }

--- a/code/vscode/src/parsers.ts
+++ b/code/vscode/src/parsers.ts
@@ -13,6 +13,12 @@ export function parseState(content: string): ApeState {
     if (!doc?.state || typeof doc.state !== 'string') {
       return { ...DEFAULT_STATE };
     }
+    // A completed or blocked cycle is no longer active: the FSM derives IDLE
+    // (IDLE is never persisted). Mirror the CLI's InquiryState.load().
+    const status = doc.status;
+    if (status === 'completed' || status === 'blocked') {
+      return { ...DEFAULT_STATE };
+    }
     return {
       phase: doc.state,
       task: String(doc.issue ?? ''),

--- a/code/vscode/src/status-bar.ts
+++ b/code/vscode/src/status-bar.ts
@@ -1,8 +1,8 @@
 import type * as vscode from 'vscode';
 import type { ApeState, StatusBarData } from './types';
 import { parseState } from './parsers';
+import { resolveStatePath } from './cycle';
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
 
 const PHASE_ICONS: Record<string, string> = {
   'IDLE': '$(circle-outline)',
@@ -40,10 +40,14 @@ export function createStatusBar(
     100,
   );
 
-  const stateFile = '.inquiry/state.yaml';
-  const absPath = join(workspaceFolder, stateFile);
+  const stateFilePattern = 'cleanrooms/**/.iq.state.yaml';
 
   async function refresh(): Promise<void> {
+    const absPath = resolveStatePath(workspaceFolder);
+    if (absPath === null) {
+      applyState(item, { phase: 'IDLE', task: '' });
+      return;
+    }
     try {
       const content = await readFile(absPath, 'utf-8');
       const state = parseState(content);
@@ -63,7 +67,7 @@ export function createStatusBar(
     bar.show();
   }
 
-  const pattern = new vs.RelativePattern(workspaceFolder, stateFile);
+  const pattern = new vs.RelativePattern(workspaceFolder, stateFilePattern);
   const watcher = vs.workspace.createFileSystemWatcher(pattern);
 
   watcher.onDidChange(() => refresh());

--- a/code/vscode/test/integration/helpers.ts
+++ b/code/vscode/test/integration/helpers.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { execSync } from 'node:child_process';
 import * as vscode from 'vscode';
 
 export function createTempWorkspace(prefix: string): {
@@ -11,6 +12,33 @@ export function createTempWorkspace(prefix: string): {
   const inquiryPath = path.join(root, '.inquiry');
   fs.mkdirSync(inquiryPath, { recursive: true });
   return { root, inquiryPath };
+}
+
+/**
+ * Create a temp workspace that is a real git repo checked out on `branch`,
+ * with the cycle-local directory `cleanrooms/<branch>` already present.
+ * Returns the resolved path of the cycle FSM state file (`.iq.state.yaml`).
+ */
+export function createCycleWorkspace(
+  prefix: string,
+  branch: string,
+): {
+  root: string;
+  cyclePath: string;
+  statePath: string;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const git = (args: string): void =>
+    void execSync(`git ${args}`, { cwd: root, stdio: 'ignore' });
+  git('init');
+  git('config user.email test@example.com');
+  git('config user.name test');
+  git('commit --allow-empty -m bootstrap');
+  git(`checkout -b ${branch}`);
+  const cyclePath = path.join(root, 'cleanrooms', branch);
+  fs.mkdirSync(cyclePath, { recursive: true });
+  const statePath = path.join(cyclePath, '.iq.state.yaml');
+  return { root, cyclePath, statePath };
 }
 
 export function removeTempWorkspace(root: string): void {

--- a/code/vscode/test/integration/status-bar.test.ts
+++ b/code/vscode/test/integration/status-bar.test.ts
@@ -1,22 +1,21 @@
 import { strict as assert } from 'node:assert';
 import * as fs from 'node:fs';
-import * as path from 'node:path';
 import type * as vscode from 'vscode';
 import { afterEach, beforeEach, describe, it } from 'mocha';
 
 import { createStatusBar } from '../../src/status-bar';
-import { createTempWorkspace, delay, removeTempWorkspace, waitFor } from './helpers';
+import { createCycleWorkspace, delay, removeTempWorkspace, waitFor } from './helpers';
 
 describe('StatusBar integration', function () {
   this.timeout(5000);
 
   let root = '';
-  let inquiryPath = '';
+  let statePath = '';
 
   beforeEach(() => {
-    const temp = createTempWorkspace('inquiry-vscode-status-bar-');
+    const temp = createCycleWorkspace('inquiry-vscode-status-bar-', '209-status-bar');
     root = temp.root;
-    inquiryPath = temp.inquiryPath;
+    statePath = temp.statePath;
   });
 
   afterEach(() => {
@@ -38,7 +37,6 @@ describe('StatusBar integration', function () {
   });
 
   it('updateStatusBar con ApeState actualiza text y tooltip del item', async () => {
-    const statePath = path.join(inquiryPath, 'state.yaml');
     fs.writeFileSync(statePath, 'state: PLAN\nissue: "042"\n', 'utf-8');
     const context = { subscriptions: [] as vscode.Disposable[] } as unknown as vscode.ExtensionContext;
     const [item, watcher] = createStatusBar(context, root) as [vscode.StatusBarItem, vscode.FileSystemWatcher];
@@ -52,8 +50,21 @@ describe('StatusBar integration', function () {
     item.dispose();
   });
 
+  it('status completed deriva IDLE en la barra', async () => {
+    fs.writeFileSync(statePath, 'state: EVOLUTION\nissue: "209"\nstatus: completed\n', 'utf-8');
+    const context = { subscriptions: [] as vscode.Disposable[] } as unknown as vscode.ExtensionContext;
+    const [item, watcher] = createStatusBar(context, root) as [vscode.StatusBarItem, vscode.FileSystemWatcher];
+
+    await waitFor(() => item.text.includes('Inquiry: IDLE'));
+
+    assert.match(item.text, /Inquiry: IDLE/);
+    assert.strictEqual(String(item.tooltip), 'Inquiry: IDLE');
+
+    watcher.dispose();
+    item.dispose();
+  });
+
   it('dispose limpia el item y el watcher', async () => {
-    const statePath = path.join(inquiryPath, 'state.yaml');
     fs.writeFileSync(statePath, 'state: ANALYZE\nissue: "042"\n', 'utf-8');
     const context = { subscriptions: [] as vscode.Disposable[] } as unknown as vscode.ExtensionContext;
     const [item, watcher] = createStatusBar(context, root) as [vscode.StatusBarItem, vscode.FileSystemWatcher];

--- a/code/vscode/test/unit/cycle.test.ts
+++ b/code/vscode/test/unit/cycle.test.ts
@@ -3,7 +3,7 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { resolveBranch, resolveMutationsDir } from '../../src/cycle';
+import { resolveBranch, resolveMutationsDir, resolveStatePath } from '../../src/cycle';
 
 function git(cwd: string, args: string): void {
   execSync(`git ${args}`, { cwd, stdio: 'ignore' });
@@ -55,5 +55,17 @@ describe('cycle resolution', () => {
       resolveMutationsDir(tmpDir),
       path.join(tmpDir, '.inquiry'),
     );
+  });
+
+  it('resolveStatePath points at cleanrooms/<branch>/.iq.state.yaml on a valid branch', () => {
+    initRepo(tmpDir, '209-test-branch');
+    assert.strictEqual(
+      resolveStatePath(tmpDir),
+      path.join(tmpDir, 'cleanrooms', '209-test-branch', '.iq.state.yaml'),
+    );
+  });
+
+  it('resolveStatePath returns null outside a git repo', () => {
+    assert.strictEqual(resolveStatePath(tmpDir), null);
   });
 });

--- a/code/vscode/test/unit/cycle.test.ts
+++ b/code/vscode/test/unit/cycle.test.ts
@@ -1,0 +1,59 @@
+import * as assert from 'assert';
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { resolveBranch, resolveMutationsDir } from '../../src/cycle';
+
+function git(cwd: string, args: string): void {
+  execSync(`git ${args}`, { cwd, stdio: 'ignore' });
+}
+
+function initRepo(dir: string, branch: string): void {
+  git(dir, 'init');
+  git(dir, 'config user.email test@example.com');
+  git(dir, 'config user.name test');
+  git(dir, 'commit --allow-empty -m bootstrap');
+  git(dir, `checkout -b ${branch}`);
+}
+
+describe('cycle resolution', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'iq-cycle-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('resolveBranch returns the current branch in a git repo', () => {
+    initRepo(tmpDir, '209-test-branch');
+    assert.strictEqual(resolveBranch(tmpDir), '209-test-branch');
+  });
+
+  it('resolveBranch returns null outside a git repo', () => {
+    assert.strictEqual(resolveBranch(tmpDir), null);
+  });
+
+  it('resolveBranch returns null for slashed branch names', () => {
+    initRepo(tmpDir, 'feature/nested');
+    assert.strictEqual(resolveBranch(tmpDir), null);
+  });
+
+  it('resolveMutationsDir points at cleanrooms/<branch> on a valid branch', () => {
+    initRepo(tmpDir, '209-test-branch');
+    assert.strictEqual(
+      resolveMutationsDir(tmpDir),
+      path.join(tmpDir, 'cleanrooms', '209-test-branch'),
+    );
+  });
+
+  it('resolveMutationsDir falls back to .inquiry outside a git repo', () => {
+    assert.strictEqual(
+      resolveMutationsDir(tmpDir),
+      path.join(tmpDir, '.inquiry'),
+    );
+  });
+});

--- a/code/vscode/test/unit/state-parser.test.ts
+++ b/code/vscode/test/unit/state-parser.test.ts
@@ -51,4 +51,28 @@ describe('parseState', () => {
     assert.strictEqual(result.phase, 'IDLE');
     assert.strictEqual(result.task, '');
   });
+
+  it('status active conserva la fase', () => {
+    const result: ApeState = parseState(
+      'state: EXECUTE\nissue: "209"\nstatus: active\n',
+    );
+    assert.strictEqual(result.phase, 'EXECUTE');
+    assert.strictEqual(result.task, '209');
+  });
+
+  it('status completed deriva IDLE', () => {
+    const result: ApeState = parseState(
+      'state: EVOLUTION\nissue: "209"\nstatus: completed\n',
+    );
+    assert.strictEqual(result.phase, 'IDLE');
+    assert.strictEqual(result.task, '');
+  });
+
+  it('status blocked deriva IDLE', () => {
+    const result: ApeState = parseState(
+      'state: ANALYZE\nissue: "209"\nstatus: blocked\n',
+    );
+    assert.strictEqual(result.phase, 'IDLE');
+    assert.strictEqual(result.task, '');
+  });
 });


### PR DESCRIPTION
## Summary

Makes `cleanrooms/<slug>` the canonical Inquiry root with **cycle-local state**. Runtime FSM state now lives at `cleanrooms/<branch>/.iq.state.yaml` (gitignored) instead of the legacy `.inquiry/state.yaml`. IDLE is never persisted — it is derived from cycle status (no-cycle / completed / blocked).

Closes #209.

## Changes

- **CLI: cycle-local FSM state** — moved state to `.iq.state.yaml`, added `CycleContext` resolver (behavior-preserving), bootstrap cycle on IDLE→ANALYZE.
- **CLI: cycle lifecycle** — `active` / `completed` / `blocked` status; separated cycle mutations from the CLI config root.
- **CLI: `iq init`** aligned with the cycle-local model.
- **VS Code extension** — driven from cycle resolution.
- **Metrics surfaces** — deferred by design (U3 decision).
- **Release** — bump to `0.6.0` across the three version files + CHANGELOG.

## Validation

- CLI suite: 399 green
- Extension: 74 unit + 13 integration green
- `dart analyze` clean, `dart format` clean
- `version_sync_test`: 3 green
- Packaged smoke: green

## Hypotheses / Decisions

All hypotheses H1–H7 CONFIRMED; decisions U1–U3 DECIDED (see `cleanrooms/209-cleanroom-canonical-inquiry-root/plan.md`).