### PR TITLE
fix(plan): require constructor-site enumeration for type changes

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.6.2]
+### Fixed
+- **PLAN-owned constructor enumeration**: when a plan phase changes a shared interface or type shape, the PLAN contract now requires enumerating construction sites and naming the search strategy used to find them; this fix lives in PLAN, not in DESCARTES (#139)
+
 ## [0.6.1]
 ### Fixed
 - **Windows cycle-root normalization**: `git rev-parse --show-toplevel` paths are now normalized before Inquiry composes cycle-local paths, preventing Windows-only failures in `InquiryState.stateFileFor` and unblocking the Windows release build

--- a/code/cli/assets/fsm/states/plan.yaml
+++ b/code/cli/assets/fsm/states/plan.yaml
@@ -6,6 +6,11 @@ instructions: |
   Design an experimental plan from the diagnosis.
   Divide into phases, order by dependencies,
   define verification criteria for each phase.
+  When a phase changes a shared interface or type shape,
+  enumerate every construction site for that type
+  (object literals, factory returns, dispatchers/adapters),
+  not just consumer/import sites.
+  Name the concrete search strategy that will find those constructors.
   Produce plan.md.
 
 constraints:
@@ -13,6 +18,7 @@ constraints:
   - No code edits (belongs to EXECUTE)
   - Plan must reference diagnosis.md decisions
   - Each phase must have verification criteria
+  - If a phase changes a shared interface/type shape, that phase must list both consumer sites and construction sites, plus the search method used to find the constructors
   - Plan must be approved by user before transitioning
 
 allowed_actions:

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.6.1';
+const String inquiryVersion = '0.6.2';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.6.1
+version: 0.6.2
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/ape_prompt_test.dart
+++ b/code/cli/test/ape_prompt_test.dart
@@ -152,6 +152,8 @@ void main() {
         expect(result.fsmState, equals('PLAN'));
         expect(result.prompt, contains('DESCARTES'));
         expect(result.prompt, contains('scientific method'));
+        expect(result.prompt, contains('enumerate every construction site'));
+        expect(result.prompt, contains('object literals, factory returns'));
       });
 
       test(

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More targets coming soon.</p>
-      <span class="badge">v0.6.1</span>
+      <span class="badge">v0.6.2</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Summary
- move issue #139 handling into the PLAN state contract, not the DESCARTES identity asset
- require PLAN phases that change a shared interface/type shape to enumerate construction sites and name the search strategy used to find them
- add a prompt regression test for the assembled PLAN prompt
- bump the CLI release surfaces to 0.6.2 and record the fix in the changelog

## Why PLAN and not DESCARTES
The gap is operational planning, not methodological identity: this rule belongs to the FSM-owned PLAN contract because it governs what a phase plan must enumerate when type/interface shape changes are introduced.

## Validation
- `dart test` in `code/cli`
- `npm run test:unit` in `code/vscode`
- `npm run test:integration` in `code/vscode`

Fixes #139