### PR TITLE
fix: align evolution cycle roots and close #150

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.6.3]
+### Fixed
+- **EVOLUTION cycle-root alignment**: repo-scoped `config.yaml`, metrics files, and repo agent cleanup now resolve from the git root instead of raw cwd, so running Inquiry from nested subdirectories no longer silently skips EVOLUTION or writes cycle artifacts into the wrong tree (#150)
+- **DARWIN mutations contract**: EVOLUTION assets and public docs now point to the canonical cycle-local `cleanrooms/<branch>/mutations.md` instead of the stale repo-level `.inquiry/mutations.md` reference (#150)
+
 ## [0.6.2]
 ### Fixed
 - **PLAN-owned constructor enumeration**: when a plan phase changes a shared interface or type shape, the PLAN contract now requires enumerating construction sites and naming the search strategy used to find them; this fix lives in PLAN, not in DESCARTES (#139)

--- a/code/cli/README.md
+++ b/code/cli/README.md
@@ -27,7 +27,7 @@ curl -fsSL https://inquiry.ccisne.dev/install.sh | bash
 | Command | Purpose |
 |---|---|
 | `iq` | TUI banner with current FSM state |
-| `iq init` | Scaffold `.inquiry/` (state.yaml, config.yaml, mutations.md) |
+| `iq init` | Scaffold `cleanrooms/` and repo-scoped `.inquiry/config.yaml` |
 | `iq doctor` | Verify prerequisites: `inquiry`, `git`, `gh`, `gh auth` |
 | `iq version` | Print CLI version |
 | `iq upgrade` | Download and install latest release |

--- a/code/cli/assets/fsm/states/evolution.yaml
+++ b/code/cli/assets/fsm/states/evolution.yaml
@@ -11,7 +11,7 @@ instructions: |
   - diagnosis.md (what was analyzed)
   - plan.md (what was planned, with checkbox state and deviation annotations)
   - retrospective.md (what went well, what deviated, what surprised, spawn issues)
-  - .inquiry/mutations.md (human observations about APE's process performance during this cycle)
+  - cleanrooms/<branch>/mutations.md (human observations about APE's process performance during this cycle)
   - Commit history (what was actually built)
   - Any deviation notes
 
@@ -48,7 +48,7 @@ constraints:
   - Omit any metric field you cannot reliably determine
 
 allowed_actions:
-  - Review cycle artifacts (diagnosis.md, plan.md, retrospective.md, commit history, .inquiry/mutations.md)
+  - Review cycle artifacts (diagnosis.md, plan.md, retrospective.md, commit history, cleanrooms/<branch>/mutations.md)
   - Search existing issues with gh issue list
   - Comment on matching issues with gh issue comment
   - Create new issues with gh issue create

--- a/code/cli/lib/modules/fsm/commands/state.dart
+++ b/code/cli/lib/modules/fsm/commands/state.dart
@@ -10,6 +10,7 @@ import 'package:yaml/yaml.dart';
 
 import '../../../assets.dart';
 import '../../../fsm_contract.dart';
+import '../../../src/cycle_context.dart';
 import '../../ape/ape_definition.dart';
 import '../../ape/inquiry_state.dart';
 import '../../ape/operational_contract.dart';
@@ -157,7 +158,8 @@ class FsmStateCommand implements Command<FsmStateInput, FsmStateOutput> {
   }
 
   bool _readEvolutionEnabled(String workingDirectory) {
-    final configFile = File(p.join(workingDirectory, '.inquiry', 'config.yaml'));
+    final inquiryCliRoot = _resolveInquiryCliRoot(workingDirectory);
+    final configFile = File(p.join(inquiryCliRoot, '.inquiry', 'config.yaml'));
     if (!configFile.existsSync()) return false;
     try {
       final yaml = loadYaml(configFile.readAsStringSync());
@@ -171,6 +173,14 @@ class FsmStateCommand implements Command<FsmStateInput, FsmStateOutput> {
       // If config is malformed, default to no evolution
     }
     return false;
+  }
+
+  String _resolveInquiryCliRoot(String workingDirectory) {
+    try {
+      return CycleContext.resolve(workingDirectory).inquiryCliRoot;
+    } on CycleResolutionException {
+      return workingDirectory;
+    }
   }
 
   static const _stateApes = <FsmState, List<Map<String, String>>>{

--- a/code/cli/lib/modules/fsm/effect_executor.dart
+++ b/code/cli/lib/modules/fsm/effect_executor.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
+import '../../src/cycle_context.dart';
 import '../../src/git_utils.dart';
 
 import '../ape/ape_definition.dart';
@@ -43,7 +44,18 @@ class EffectExecutor {
   }) : _assets = assets,
        _issueBodyProvider = issueBodyProvider ?? _defaultIssueBodyProvider;
 
-  String get _inquiryDir => p.join(workingDirectory, '.inquiry');
+  late final CycleContext? _cycleContext = _tryResolveCycleContext();
+
+  String get _projectRoot => _cycleContext?.projectRoot ?? workingDirectory;
+
+  String get _inquiryDir => p.join(
+    _cycleContext?.inquiryCliRoot ?? _projectRoot,
+    '.inquiry',
+  );
+
+  String? get _branch => _cycleContext?.branch;
+
+  String? get _cleanroomRoot => _cycleContext?.inquiryRoot;
 
   /// Maps FSM states to their active sub-agent names.
   static const _stateApes = <String, String>{
@@ -125,16 +137,12 @@ class EffectExecutor {
 
   /// Create `cleanrooms/<branch>/analyze/index.md` and `confirmations.md` for ANALYZE phase.
   void openAnalysisContext() {
-    final branch = _getCurrentBranch();
-    if (branch.isEmpty) return;
+    final branch = _branch;
+    final cleanroomRoot = _cleanroomRoot;
+    if (branch == null || cleanroomRoot == null) return;
 
     final issue = InquiryState.load(workingDirectory).issue ?? '';
-    final cleanroomDir = p.join(
-      workingDirectory,
-      'cleanrooms',
-      branch,
-      'analyze',
-    );
+    final cleanroomDir = p.join(cleanroomRoot, 'analyze');
     final dir = Directory(cleanroomDir);
     if (!dir.existsSync()) {
       dir.createSync(recursive: true);
@@ -180,23 +188,26 @@ class EffectExecutor {
       );
     }
 
-    _writeIssueMirror(branch, issue, today);
+    _writeIssueMirror(cleanroomRoot, branch, issue, today);
   }
 
   /// Best-effort `cleanrooms/<branch>/issue.md` mirror of the GitHub issue.
   ///
   /// Idempotent: never clobbers an existing mirror. A failed/empty body fetch
   /// is non-fatal — the mirror is still written with the available metadata.
-  void _writeIssueMirror(String branch, String issue, String today) {
-    final issueFile = File(
-      p.join(workingDirectory, 'cleanrooms', branch, 'issue.md'),
-    );
+  void _writeIssueMirror(
+    String cleanroomRoot,
+    String branch,
+    String issue,
+    String today,
+  ) {
+    final issueFile = File(p.join(cleanroomRoot, 'issue.md'));
     if (issueFile.existsSync()) return;
 
     String? body;
     if (issue.isNotEmpty) {
       try {
-        body = _issueBodyProvider(issue, workingDirectory);
+        body = _issueBodyProvider(issue, _projectRoot);
       } catch (_) {
         body = null;
       }
@@ -246,8 +257,12 @@ class EffectExecutor {
     }
   }
 
-  String _getCurrentBranch() {
-    return getCurrentBranch(workingDirectory);
+  CycleContext? _tryResolveCycleContext() {
+    try {
+      return CycleContext.resolve(workingDirectory);
+    } on CycleResolutionException {
+      return null;
+    }
   }
 
   /// Reset the cycle-local `cleanrooms/<branch>/mutations.md` to empty template.
@@ -267,11 +282,11 @@ class EffectExecutor {
   /// Falls back to repo-level `.inquiry/mutations.md` only when no cycle
   /// resolves (derived IDLE / not a git repo).
   String _mutationsPath() {
-    final branch = _getCurrentBranch();
-    if (branch.isEmpty) {
+    final cleanroomRoot = _cleanroomRoot;
+    if (cleanroomRoot == null) {
       return p.join(_inquiryDir, 'mutations.md');
     }
-    return p.join(workingDirectory, 'cleanrooms', branch, 'mutations.md');
+    return p.join(cleanroomRoot, 'mutations.md');
   }
 
   /// Resolve the initial_state for an APE by loading its YAML definition.

--- a/code/cli/lib/modules/global/commands/init.dart
+++ b/code/cli/lib/modules/global/commands/init.dart
@@ -17,6 +17,7 @@ import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 import 'package:path/path.dart' as p;
 
 import '../../../assets.dart';
+import '../../../src/git_utils.dart';
 
 // ─── Input ──────────────────────────────────────────────────────────────────
 
@@ -69,7 +70,7 @@ class InitCommand implements Command<InitInput, InitOutput> {
 
   @override
   Future<InitOutput> execute() async {
-    final root = input.workingDirectory;
+    final root = _resolveProjectRoot(input.workingDirectory);
     final steps = <String>[];
 
     // Step 1: Create cleanrooms/ at project root if missing
@@ -98,6 +99,10 @@ class InitCommand implements Command<InitInput, InitOutput> {
     }
 
     return InitOutput(message: steps.join('\n'), isCreated: true);
+  }
+
+  String _resolveProjectRoot(String workingDirectory) {
+    return getProjectRoot(workingDirectory) ?? workingDirectory;
   }
 
   void _deployAgent(String root, Assets assets, List<String> steps) {

--- a/code/cli/lib/modules/target/commands/clean.dart
+++ b/code/cli/lib/modules/target/commands/clean.dart
@@ -7,6 +7,7 @@ import 'package:cli_router/cli_router.dart';
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 import 'package:path/path.dart' as p;
 
+import '../../../src/git_utils.dart';
 import '../../../targets/deployer.dart';
 
 // ─── Input ──────────────────────────────────────────────────────────────────
@@ -60,8 +61,9 @@ class TargetCleanCommand
   }
 
   void _cleanRepoScopedAgent() {
+    final projectRoot = getProjectRoot(_workingDirectory) ?? _workingDirectory;
     final agentFile = File(
-      p.join(_workingDirectory, '.github', 'agents', 'inquiry.agent.md'),
+      p.join(projectRoot, '.github', 'agents', 'inquiry.agent.md'),
     );
     if (agentFile.existsSync()) agentFile.deleteSync();
   }

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.6.2';
+const String inquiryVersion = '0.6.3';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.6.2
+version: 0.6.3
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/effect_executor_test.dart
+++ b/code/cli/test/effect_executor_test.dart
@@ -100,6 +100,26 @@ void main() {
           isTrue,
         );
       });
+
+      test('writes mutations.md at repo cleanroom from nested subdir', () {
+        final nestedDir = Directory(
+          p.join(tempDir.path, 'sub', 'deep'),
+        )..createSync(recursive: true);
+
+        final executor = EffectExecutor(workingDirectory: nestedDir.path);
+        executor.resetMutations();
+
+        expect(
+          File('${tempDir.path}/cleanrooms/$branch/mutations.md').existsSync(),
+          isTrue,
+        );
+        expect(
+          File(
+            '${nestedDir.path}/cleanrooms/$branch/mutations.md',
+          ).existsSync(),
+          isFalse,
+        );
+      });
     });
 
     group('snapshot_metrics', () {
@@ -126,6 +146,24 @@ void main() {
         ).readAsStringSync();
         expect(content, contains('state: ANALYZE'));
         expect(content, contains('issue: "99"'));
+      });
+
+      test('writes metrics_snapshot.yaml at repo root from nested subdir', () {
+        final nestedDir = Directory(
+          p.join(tempDir.path, 'sub', 'deep'),
+        )..createSync(recursive: true);
+
+        final executor = EffectExecutor(workingDirectory: nestedDir.path);
+        executor.snapshotMetrics();
+
+        expect(
+          File('${tempDir.path}/.inquiry/metrics_snapshot.yaml').existsSync(),
+          isTrue,
+        );
+        expect(
+          File('${nestedDir.path}/.inquiry/metrics_snapshot.yaml').existsSync(),
+          isFalse,
+        );
       });
     });
 
@@ -342,6 +380,27 @@ void main() {
         executor.openAnalysisContext();
 
         expect(issueFile.readAsStringSync(), 'CUSTOM CONTENT');
+      });
+
+      test('creates analyze bootstrap at repo cleanroom from nested subdir', () {
+        File(stateFilePath).writeAsStringSync('state: ANALYZE\nissue: "145"\n');
+        final nestedDir = Directory(
+          p.join(tempDir.path, 'sub', 'deep'),
+        )..createSync(recursive: true);
+
+        final executor = EffectExecutor(workingDirectory: nestedDir.path);
+        executor.openAnalysisContext();
+
+        expect(
+          File('${tempDir.path}/cleanrooms/$branch/analyze/index.md')
+              .existsSync(),
+          isTrue,
+        );
+        expect(
+          File('${nestedDir.path}/cleanrooms/$branch/analyze/index.md')
+              .existsSync(),
+          isFalse,
+        );
       });
     });
 

--- a/code/cli/test/fsm_state_test.dart
+++ b/code/cli/test/fsm_state_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:inquiry_cli/assets.dart';
 import 'package:inquiry_cli/modules/ape/inquiry_state.dart';
 import 'package:inquiry_cli/modules/fsm/commands/state.dart';
 import 'package:path/path.dart' as p;
@@ -318,6 +319,14 @@ void main() {
         expect(result.toJson()['instructions'], contains('gh issue create'));
         expect(
           result.toJson()['instructions'],
+          contains('cleanrooms/<branch>/mutations.md'),
+        );
+        expect(
+          result.toJson()['instructions'],
+          isNot(contains('.inquiry/mutations.md')),
+        );
+        expect(
+          result.toJson()['instructions'],
           contains('.inquiry/metrics.yaml'),
         );
       });
@@ -538,6 +547,28 @@ void main() {
 
         final command = FsmStateCommand(
           FsmStateInput(workingDirectory: tempDir.path),
+        );
+        final result = await command.execute();
+        final transitions = result.toJson()['transitions'] as List;
+        final events = transitions.map((t) => t['event']).toList();
+
+        expect(events, contains('pr_ready'));
+        expect(events, isNot(contains('pr_ready_no_evolution')));
+      });
+
+      test('END from nested subdir still reads repo-root config.yaml', () async {
+        setupWorkspace(state: 'END', issue: '145');
+        File(
+          '${tempDir.path}/.inquiry/config.yaml',
+        ).writeAsStringSync('evolution:\n  enabled: true\n');
+
+        final nestedDir = Directory(
+          p.join(tempDir.path, 'sub', 'deep'),
+        )..createSync(recursive: true);
+
+        final command = FsmStateCommand(
+          FsmStateInput(workingDirectory: nestedDir.path),
+          assets: Assets(root: tempDir.path),
         );
         final result = await command.execute();
         final transitions = result.toJson()['transitions'] as List;

--- a/code/cli/test/init_command_test.dart
+++ b/code/cli/test/init_command_test.dart
@@ -164,6 +164,25 @@ void main() {
         ).readAsStringSync();
         expect(content, contains('enabled: true'));
       });
+
+      test('initializes repo root when invoked from nested subdir', () async {
+        _initGitRepo(tempDir.path);
+        final nestedDir = Directory(
+          p.join(tempDir.path, 'docs', 'deep'),
+        )..createSync(recursive: true);
+
+        final command = InitCommand(
+          InitInput(workingDirectory: nestedDir.path),
+        );
+        await command.execute();
+
+        expect(File('${tempDir.path}/.inquiry/config.yaml').existsSync(), isTrue);
+        expect(Directory('${tempDir.path}/cleanrooms').existsSync(), isTrue);
+        expect(
+          File('${nestedDir.path}/.inquiry/config.yaml').existsSync(),
+          isFalse,
+        );
+      });
     });
 
     // ─── Step 6: .inquiry/mutations.md ──────────────────────────────────
@@ -304,4 +323,20 @@ void main() {
       });
     });
   });
+}
+
+void _initGitRepo(String root) {
+  void git(List<String> args) {
+    final result = Process.runSync('git', args, workingDirectory: root);
+    if (result.exitCode != 0) {
+      throw StateError('git ${args.join(' ')} failed: ${result.stderr}');
+    }
+  }
+
+  git(['init', '-q']);
+  git(['config', 'user.email', 'test@example.com']);
+  git(['config', 'user.name', 'test']);
+  File(p.join(root, 'README.md')).writeAsStringSync('# test\n');
+  git(['add', '.']);
+  git(['commit', '-q', '-m', 'init']);
 }

--- a/code/cli/test/target_commands_test.dart
+++ b/code/cli/test/target_commands_test.dart
@@ -164,6 +164,28 @@ void main() {
           reason: 'iq target clean must remove repo-scoped agent');
     });
 
+    test('removes repo-scoped agent when invoked from nested subdir', () async {
+      _initGitRepo(tempDir.path);
+      final agentFile = File(
+        p.join(tempDir.path, '.github', 'agents', 'inquiry.agent.md'),
+      );
+      agentFile.parent.createSync(recursive: true);
+      agentFile.writeAsStringSync('# APE Agent');
+
+      final nestedDir = Directory(p.join(tempDir.path, 'sub', 'deep'))
+        ..createSync(recursive: true);
+
+      final command = TargetCleanCommand(
+        TargetCleanInput(),
+        deployer: deployer,
+        workingDirectory: nestedDir.path,
+      );
+
+      await command.execute();
+
+      expect(agentFile.existsSync(), isFalse);
+    });
+
     test('does not fail if .github/agents/inquiry.agent.md does not exist',
         () async {
       final command = TargetCleanCommand(
@@ -175,4 +197,20 @@ void main() {
       await expectLater(command.execute(), completes);
     });
   });
+}
+
+void _initGitRepo(String root) {
+  void git(List<String> args) {
+    final result = Process.runSync('git', args, workingDirectory: root);
+    if (result.exitCode != 0) {
+      throw StateError('git ${args.join(' ')} failed: ${result.stderr}');
+    }
+  }
+
+  git(['init', '-q']);
+  git(['config', 'user.email', 'test@example.com']);
+  git(['config', 'user.name', 'test']);
+  File(p.join(root, 'README.md')).writeAsStringSync('# test\n');
+  git(['add', '.']);
+  git(['commit', '-q', '-m', 'init']);
 }

--- a/code/site/evolution.html
+++ b/code/site/evolution.html
@@ -40,7 +40,7 @@
     <section aria-labelledby="what-heading">
       <h2 id="what-heading">What DARWIN does</h2>
       <p>
-        After <code>EXECUTE</code> and <code>END</code>, if <code>evolution.enabled</code> is true, DARWIN reads the persisted cycle artifacts — notably <code>cleanrooms/&lt;issue&gt;/analyze/diagnosis.md</code>, <code>cleanrooms/&lt;issue&gt;/plan.md</code>, and <code>.inquiry/mutations.md</code> — and composes one or more mutation proposals. Those proposals are filed as GitHub issues in the Inquiry repository. Each issue describes what DARWIN thinks should change about the framework: new states, modified agent prompts, better preconditions, or deprecated agents.
+        After <code>EXECUTE</code> and <code>END</code>, if <code>evolution.enabled</code> is true, DARWIN reads the persisted cycle artifacts — notably <code>cleanrooms/&lt;branch&gt;/analyze/diagnosis.md</code>, <code>cleanrooms/&lt;branch&gt;/plan.md</code>, and <code>cleanrooms/&lt;branch&gt;/mutations.md</code> — and composes one or more mutation proposals. Those proposals are filed as GitHub issues in the Inquiry repository. Each issue describes what DARWIN thinks should change about the framework: new states, modified agent prompts, better preconditions, or deprecated agents.
       </p>
       <p>
         The proposals aren't applied automatically. They enter the same review flow as any GitHub issue — the maintainer decides whether to accept, reject, or modify. The <a href="agents.html">collapse from nine lore apes to four</a> happened through this mechanism.
@@ -59,7 +59,7 @@
         </li>
         <li class="yes">
           <span class="privacy-icon" aria-hidden="true">✓</span>
-          <span>Runtime notes from <code>.inquiry/mutations.md</code> and DARWIN's own synthesis of the cycle</span>
+          <span>Runtime notes from <code>cleanrooms/&lt;branch&gt;/mutations.md</code> and DARWIN's own synthesis of the cycle</span>
         </li>
         <li class="no">
           <span class="privacy-icon" aria-hidden="true">✗</span>
@@ -116,7 +116,7 @@
     <section aria-labelledby="summary-heading">
       <h2 id="summary-heading">Privacy summary</h2>
       <p>
-        The one-paragraph version you can quote anywhere: <strong>EVOLUTION is off by default. When enabled, DARWIN reads only the declared cycle artifacts in <code>cleanrooms/&lt;issue&gt;/</code> plus <code>.inquiry/mutations.md</code>. Proposals are filed as public issues in the Inquiry repository, with your approval before each filing. No telemetry. No analytics. No third-party service. Your source code stays on your machine.</strong>
+        The one-paragraph version you can quote anywhere: <strong>EVOLUTION is off by default. When enabled, DARWIN reads only the declared cycle artifacts in <code>cleanrooms/&lt;branch&gt;/</code>, including <code>cleanrooms/&lt;branch&gt;/mutations.md</code>. Proposals are filed as public issues in the Inquiry repository, with your approval before each filing. No telemetry. No analytics. No third-party service. Your source code stays on your machine.</strong>
       </p>
     </section>
 

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More targets coming soon.</p>
-      <span class="badge">v0.6.2</span>
+      <span class="badge">v0.6.3</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Summary
- resolve repo-scoped EVOLUTION surfaces from the git root instead of raw cwd, so END -> EVOLUTION and cycle artifacts stay stable from nested subdirectories
- align EVOLUTION runtime/docs with the canonical cycle-local mutations path at cleanrooms/<branch>/mutations.md
- add nested-subdir regressions for fsm state, effect executor, init, and target clean, and bump the CLI to 0.6.3

## Validation
- targeted CLI tests: fsm_state_test, effect_executor_test, init_command_test, target_commands_test, fsm_transition_integration_test, ape_prompt_test, version_sync_test
- built packaged CLI with code/cli/scripts/build.ps1

Closes #150