### PR TITLE
fix: harden release asset publication for 0.7.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Release workflow — 3-job pattern: check-version → create-release → build (matrix)
+# Release workflow — 4-job pattern: check-version → create-release-draft → build (matrix) → publish-release
 #
 # WORKAROUND (Windows only): Windows Defender on the windows-2025 / windows-latest
 # runner image (20260413.84.1+) quarantines dart.exe from the toolcache after
@@ -55,7 +55,7 @@ jobs:
             echo "should_release=true" >> "$GITHUB_OUTPUT"
           fi
 
-  # ─── Job 2: Create release (published, not draft) ─────────────────
+  # ─── Job 2: Create draft release ──────────────────────────────────
   create-release:
     needs: check-version
     if: needs.check-version.outputs.should_release == 'true'
@@ -69,7 +69,7 @@ jobs:
           git tag "$TAG"
           git push origin "$TAG"
 
-      - name: Create GitHub release
+      - name: Create GitHub release draft
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -77,7 +77,7 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --generate-notes \
-            --latest
+            --draft
 
   # ─── Job 3: Build + upload (matrix: Windows + Linux) ───────────────
   build:
@@ -177,3 +177,31 @@ jobs:
         run: |
           gh release upload "v${{ needs.check-version.outputs.version }}" ${{ matrix.asset }} --clobber
         shell: bash
+
+  # ─── Job 4: Publish release after all assets are present ──────────
+  publish-release:
+    needs: [check-version, create-release, build]
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify release assets before publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ needs.check-version.outputs.version }}"
+          ASSETS=$(gh release view "$TAG" --json assets --jq '.assets[].name')
+          echo "$ASSETS"
+
+          for asset in inquiry-windows-x64.zip inquiry-linux-x64.tar.gz; do
+            if ! echo "$ASSETS" | grep -qx "$asset"; then
+              echo "Missing expected asset: $asset"
+              exit 1
+            fi
+          done
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ needs.check-version.outputs.version }}"
+          gh release edit "$TAG" --draft=false --latest

--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.7.1]
+### Changed
+- **Release publication guardrail**: the release workflow now keeps GitHub releases in draft until both platform archives are uploaded and explicitly verified, so `latest` can no longer point at a partial CLI release
+
+### Fixed
+- **Windows asset resilience for consumers**: the VS Code installer now falls back to the newest published release that actually contains the requested platform asset instead of failing on a transiently incomplete latest release
+
 ## [0.7.0]
 ### Added
 - **Harness observability baseline**: `run_trace.yaml`, END pre-PR inspection, and the new observability/eval specs now give the maintainer durable evidence for transitions, sensor runs, retries, host-boundary tool activity, and model-bound prompt assembly cost

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.7.0';
+const String inquiryVersion = '0.7.1';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.7.0
+version: 0.7.1
 
 environment:
   sdk: ^3.8.1

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More targets coming soon.</p>
-      <span class="badge">v0.7.0</span>
+      <span class="badge">v0.7.1</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">

--- a/code/vscode/CHANGELOG.md
+++ b/code/vscode/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.1] - 2026-06-01
+
+### Fixed
+- `Inquiry: Init` now retries from the newest published CLI release that actually contains the platform asset instead of assuming GitHub `latest` is already complete
+- Auto-install failures are surfaced clearly, installation is rechecked before `iq init`, and the init terminal now runs from the selected workspace root
+
 ## [0.4.0] - 2026-05-30
 
 ### Changed

--- a/code/vscode/package-lock.json
+++ b/code/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inquiry",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inquiry",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.3"

--- a/code/vscode/package.json
+++ b/code/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "inquiry",
   "displayName": "Inquiry — Analyze. Plan. Execute.",
   "publisher": "ccisnedev",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Structured AI-aided development for GitHub Copilot.",
   "license": "MIT",
   "icon": "assets/icon.png",

--- a/code/vscode/src/extension.ts
+++ b/code/vscode/src/extension.ts
@@ -5,7 +5,7 @@ import { toggleEvolution, addMutation } from './commands';
 import { withGuard } from './command-guard';
 import { inquiryInit } from './init';
 import { installInquiryCli } from './installer';
-import { getInquiryBinDir, shellExec } from './guard';
+import { getInquiryBinDir } from './guard';
 import { resolveMutationsDir } from './cycle';
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -21,25 +21,7 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('inquiry.init', () => {
       const folder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-      return inquiryInit(folder, undefined, async () => {
-        await installInquiryCli();
-        const { isInquiryInstalled, getInquiryBinaryPath, getPlatform, shellExec: se } = require('./guard');
-        if (isInquiryInstalled()) {
-          const terminal = vscode.window.createTerminal('Inquiry Init');
-          terminal.show();
-          terminal.sendText(se(getInquiryBinaryPath(getPlatform()), ['init']));
-          terminal.sendText(se(getInquiryBinaryPath(getPlatform()), ['target', 'get']));
-          const action = await vscode.window.showInformationMessage(
-            'Inquiry initialized. Reload window so Copilot detects the @inquiry agent?',
-            'Reload',
-          );
-          if (action === 'Reload') {
-            await vscode.commands.executeCommand('workbench.action.reloadWindow');
-          }
-        } else {
-          vscode.window.showErrorMessage('Inquiry CLI installation failed. Please install manually.');
-        }
-      });
+      return inquiryInit(folder, undefined, () => installInquiryCli());
     }),
   );
 

--- a/code/vscode/src/init.ts
+++ b/code/vscode/src/init.ts
@@ -1,11 +1,21 @@
 import { isInquiryInstalled, getInquiryBinaryPath, getPlatform, shellExec } from './guard';
 
+export interface InitTerminal {
+  show: () => void;
+  sendText: (text: string) => void;
+}
+
+export interface InitTerminalOptions {
+  name: string;
+  cwd?: string;
+}
+
 export interface InitDeps {
   isInquiryInstalled: () => boolean;
   getInquiryBinaryPath: () => string;
   showErrorMessage: (msg: string) => Thenable<string | undefined>;
   showInformationMessage: (msg: string, ...items: string[]) => Thenable<string | undefined>;
-  createTerminal: (name: string) => { show: () => void; sendText: (text: string) => void };
+  createTerminal: (options: string | InitTerminalOptions) => InitTerminal;
   executeCommand: (command: string, ...args: any[]) => Thenable<unknown>;
 }
 
@@ -22,7 +32,8 @@ export async function inquiryInit(
     ?? vscode.window.showInformationMessage.bind(vscode.window);
   const installed = deps?.isInquiryInstalled ?? (() => isInquiryInstalled());
   const binaryPath = deps?.getInquiryBinaryPath ?? (() => getInquiryBinaryPath(getPlatform()));
-  const createTerminal = deps?.createTerminal ?? vscode.window.createTerminal.bind(vscode.window);
+  const createTerminal = deps?.createTerminal
+    ?? ((options: string | InitTerminalOptions) => vscode.window.createTerminal(options as any));
   const executeCommand = deps?.executeCommand ?? vscode.commands.executeCommand.bind(vscode.commands);
 
   if (!workspaceFolder) {
@@ -32,14 +43,25 @@ export async function inquiryInit(
 
   if (!installed()) {
     if (onInstallNeeded) {
-      await onInstallNeeded();
+      try {
+        await onInstallNeeded();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        showErrorMessage(`Inquiry CLI installation failed: ${message}`);
+        return;
+      }
+
+      if (!installed()) {
+        showErrorMessage('Inquiry CLI installation failed. Please install manually.');
+        return;
+      }
     } else {
       showInformationMessage('Inquiry CLI not found. Install it manually or wait for a future update.');
+      return;
     }
-    return;
   }
 
-  const terminal = createTerminal('Inquiry Init');
+  const terminal = createTerminal({ name: 'Inquiry Init', cwd: workspaceFolder });
   terminal.show();
   terminal.sendText(shellExec(binaryPath(), ['init']));
 

--- a/code/vscode/src/installer.ts
+++ b/code/vscode/src/installer.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as os from 'os';
 
 const GITHUB_REPO = 'ccisnedev/inquiry';
-const RELEASES_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+const RELEASES_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases`;
 
 export function getAssetName(platform: string): string {
   if (platform === 'win32') { return 'inquiry-windows-x64.zip'; }
@@ -18,6 +18,36 @@ export function getInstallDir(platform: string): string {
     return path.join(os.homedir(), '.inquiry');
   }
   throw new Error(`Unsupported platform: ${platform}`);
+}
+
+export interface ReleaseAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+export interface ReleaseInfo {
+  tag_name: string;
+  draft?: boolean;
+  prerelease?: boolean;
+  assets?: ReleaseAsset[];
+}
+
+export function selectReleaseForAsset(releases: ReleaseInfo[], assetName: string): ReleaseInfo {
+  const publishedReleases = releases.filter((release) => !release.draft && !release.prerelease);
+  const matchingRelease = publishedReleases.find((release) =>
+    release.assets?.some((asset) => asset.name === assetName),
+  );
+
+  if (matchingRelease) {
+    return matchingRelease;
+  }
+
+  const newestTag = publishedReleases[0]?.tag_name;
+  if (newestTag) {
+    throw new Error(`No ${assetName} asset found in published releases (newest checked: ${newestTag})`);
+  }
+
+  throw new Error(`No published Inquiry releases available for ${assetName}`);
 }
 
 interface CancellationTokenLike {
@@ -160,10 +190,15 @@ export async function installInquiryCli(deps?: Partial<InstallerDeps>): Promise<
 
       // 1. Fetch latest release
       progress.report({ message: 'Fetching latest release...' });
-      const release = await fetchJson(RELEASES_URL);
+      const releases = await fetchJson(RELEASES_URL);
+      if (!Array.isArray(releases)) {
+        throw new Error('Invalid GitHub releases response');
+      }
+
+      const release = selectReleaseForAsset(releases, assetName);
       const asset = release.assets?.find((a: any) => a.name === assetName);
       if (!asset) {
-        throw new Error(`No ${assetName} asset found in release ${release.tag_name}`);
+        throw new Error(`No ${assetName} asset found in selected release ${release.tag_name}`);
       }
       if (cancelled) { throw new Error('Installation cancelled'); }
 

--- a/code/vscode/test/unit/init.test.ts
+++ b/code/vscode/test/unit/init.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { inquiryInit, InitDeps } from '../../src/init';
+import { inquiryInit, InitDeps, InitTerminalOptions } from '../../src/init';
 
 describe('inquiryInit', () => {
   it('shows error when no workspace folder', async () => {
@@ -18,7 +18,7 @@ describe('inquiryInit', () => {
   });
 
   it('runs ONLY inquiry init in terminal — no target get', async () => {
-    let terminalName = '';
+    let terminalOptions: string | InitTerminalOptions | undefined;
     const sentTexts: string[] = [];
     let infoMsg = '';
     const deps: InitDeps = {
@@ -26,8 +26,8 @@ describe('inquiryInit', () => {
       getInquiryBinaryPath: () => '/home/user/.inquiry/bin/inquiry',
       showErrorMessage: () => Promise.resolve(undefined),
       showInformationMessage: (msg) => { infoMsg = msg; return Promise.resolve(undefined); },
-      createTerminal: (name) => {
-        terminalName = name;
+      createTerminal: (options) => {
+        terminalOptions = options;
         return {
           show: () => {},
           sendText: (text) => { sentTexts.push(text); },
@@ -37,7 +37,7 @@ describe('inquiryInit', () => {
     };
 
     await inquiryInit('/workspace', deps);
-    assert.strictEqual(terminalName, 'Inquiry Init');
+    assert.deepStrictEqual(terminalOptions, { name: 'Inquiry Init', cwd: '/workspace' });
     const prefix = process.platform === 'win32' ? '& ' : '';
     const q = '"';
     // Only ONE sendText: iq init — no target get
@@ -66,17 +66,44 @@ describe('inquiryInit', () => {
 
   it('delegates to install flow when CLI missing', async () => {
     let installCalled = false;
+    let installed = false;
+    const sentTexts: string[] = [];
+    const deps: InitDeps = {
+      isInquiryInstalled: () => installed,
+      getInquiryBinaryPath: () => '/usr/bin/inquiry',
+      showErrorMessage: () => Promise.resolve(undefined),
+      showInformationMessage: () => Promise.resolve(undefined),
+      createTerminal: () => ({ show: () => {}, sendText: (text) => { sentTexts.push(text); } }),
+      executeCommand: () => Promise.resolve(undefined),
+    };
+
+    await inquiryInit('/workspace', deps, async () => {
+      installCalled = true;
+      installed = true;
+    });
+    assert.strictEqual(installCalled, true);
+    assert.strictEqual(sentTexts.length, 1);
+  });
+
+  it('shows install error when installer throws', async () => {
+    let errorMsg = '';
     const deps: InitDeps = {
       isInquiryInstalled: () => false,
       getInquiryBinaryPath: () => '/usr/bin/inquiry',
-      showErrorMessage: () => Promise.resolve(undefined),
+      showErrorMessage: (msg) => { errorMsg = msg; return Promise.resolve(undefined); },
       showInformationMessage: () => Promise.resolve(undefined),
       createTerminal: () => ({ show: () => {}, sendText: () => {} }),
       executeCommand: () => Promise.resolve(undefined),
     };
 
-    await inquiryInit('/workspace', deps, async () => { installCalled = true; });
-    assert.strictEqual(installCalled, true);
+    await inquiryInit('/workspace', deps, async () => {
+      throw new Error('No inquiry-windows-x64.zip asset found in release v0.7.0');
+    });
+
+    assert.strictEqual(
+      errorMsg,
+      'Inquiry CLI installation failed: No inquiry-windows-x64.zip asset found in release v0.7.0',
+    );
   });
 
   it('shows info message when CLI missing and no install callback', async () => {

--- a/code/vscode/test/unit/installer.test.ts
+++ b/code/vscode/test/unit/installer.test.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert';
-import * as path from 'path';
-import { getAssetName, getInstallDir, installInquiryCli, InstallerDeps } from '../../src/installer';
+import { getAssetName, getInstallDir, installInquiryCli, InstallerDeps, selectReleaseForAsset } from '../../src/installer';
 
 describe('getAssetName', () => {
   it('returns zip on win32', () => {
@@ -32,6 +31,34 @@ describe('getInstallDir', () => {
   });
 });
 
+describe('selectReleaseForAsset', () => {
+  it('returns the newest published release that includes the asset', () => {
+    const release = selectReleaseForAsset([
+      { tag_name: 'v1.1.0', assets: [] },
+      { tag_name: 'v1.0.0', assets: [{ name: 'inquiry-windows-x64.zip', browser_download_url: 'https://github.com/dl/win.zip' }] },
+    ], 'inquiry-windows-x64.zip');
+
+    assert.strictEqual(release.tag_name, 'v1.0.0');
+  });
+
+  it('ignores draft and prerelease entries when selecting an asset', () => {
+    const release = selectReleaseForAsset([
+      { tag_name: 'v1.2.0', draft: true, assets: [{ name: 'inquiry-windows-x64.zip', browser_download_url: 'https://github.com/dl/draft.zip' }] },
+      { tag_name: 'v1.1.0', prerelease: true, assets: [{ name: 'inquiry-windows-x64.zip', browser_download_url: 'https://github.com/dl/pre.zip' }] },
+      { tag_name: 'v1.0.0', assets: [{ name: 'inquiry-windows-x64.zip', browser_download_url: 'https://github.com/dl/win.zip' }] },
+    ], 'inquiry-windows-x64.zip');
+
+    assert.strictEqual(release.tag_name, 'v1.0.0');
+  });
+
+  it('throws when no published release contains the asset', () => {
+    assert.throws(
+      () => selectReleaseForAsset([{ tag_name: 'v1.1.0', assets: [] }], 'inquiry-windows-x64.zip'),
+      /No inquiry-windows-x64.zip asset found in published releases/,
+    );
+  });
+});
+
 describe('installInquiryCli', () => {
   const tick = () => new Promise(r => setTimeout(r, 0));
 
@@ -39,13 +66,15 @@ describe('installInquiryCli', () => {
     return {
       platform,
       tmpdir: () => (platform === 'win32' ? 'C:\\temp' : '/tmp'),
-      fetchJson: async () => ({
-        tag_name: 'v1.0.0',
-        assets: [
-          { name: 'inquiry-windows-x64.zip', browser_download_url: 'https://github.com/dl/win.zip' },
-          { name: 'inquiry-linux-x64.tar.gz', browser_download_url: 'https://github.com/dl/linux.tar.gz' },
-        ],
-      }),
+      fetchJson: async () => ([
+        {
+          tag_name: 'v1.0.0',
+          assets: [
+            { name: 'inquiry-windows-x64.zip', browser_download_url: 'https://github.com/dl/win.zip' },
+            { name: 'inquiry-linux-x64.tar.gz', browser_download_url: 'https://github.com/dl/linux.tar.gz' },
+          ],
+        },
+      ]),
       downloadFile: async () => {},
       extractZip: async () => {},
       extractTarGz: async () => {},
@@ -114,13 +143,28 @@ describe('installInquiryCli', () => {
     assert.ok(symlinkTargets.some(l => l.includes('iq')));
   });
 
-  it('throws when asset not found in release', async () => {
+  it('falls back to the newest published release that has the platform asset', async () => {
+    let downloadedUrl = '';
     const deps: InstallerDeps = {
       ...baseDeps('win32'),
-      fetchJson: async () => ({ tag_name: 'v1.0.0', assets: [] }),
+      fetchJson: async () => ([
+        { tag_name: 'v1.1.0', assets: [] },
+        { tag_name: 'v1.0.0', assets: [{ name: 'inquiry-windows-x64.zip', browser_download_url: 'https://github.com/dl/fallback.zip' }] },
+      ]),
+      downloadFile: async (url) => { downloadedUrl = url; },
     };
 
-    await assert.rejects(() => installInquiryCli(deps), /No inquiry-windows-x64.zip asset found/);
+    await installInquiryCli(deps);
+    assert.strictEqual(downloadedUrl, 'https://github.com/dl/fallback.zip');
+  });
+
+  it('throws when no published release contains the asset', async () => {
+    const deps: InstallerDeps = {
+      ...baseDeps('win32'),
+      fetchJson: async () => ([{ tag_name: 'v1.1.0', assets: [] }]),
+    };
+
+    await assert.rejects(() => installInquiryCli(deps), /No inquiry-windows-x64.zip asset found in published releases/);
   });
 
   it('rejects on download failure', async () => {
@@ -138,7 +182,7 @@ describe('installInquiryCli', () => {
       ...baseDeps('win32'),
       fetchJson: async () => {
         cancelFn!();
-        return { tag_name: 'v1.0.0', assets: [{ name: 'inquiry-windows-x64.zip', browser_download_url: 'x' }] };
+        return [{ tag_name: 'v1.0.0', assets: [{ name: 'inquiry-windows-x64.zip', browser_download_url: 'x' }] }];
       },
       withProgress: async (_opts, task) => {
         const progress = { report: () => {} };


### PR DESCRIPTION
## Summary
- keep CLI releases as drafts until both platform artifacts upload and verify before marking the release as latest
- harden the VS Code installer and init flow so auto-install falls back to the newest published release that actually contains the platform asset
- bump the CLI/site release line to 0.7.1 and the VS Code extension to 0.4.1, with changelog updates for both surfaces

## Testing
- npm run test:unit
- dart test test/version_sync_test.dart