### PR TITLE
Support root version flags

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.7.4]
+### Fixed
+- **Root version flags**: `iq --version` and `iq -v` now normalize to the `version` command instead of being dropped by root-command routing
+
 ## [0.7.3]
 ### Changed
 - **EXECUTE cognitive operator**: ADA now replaces BASHŌ as Inquiry's live EXECUTE thinking tool, keeping programming-manifesto cognition separate from the FSM's operational workflow contract

--- a/code/cli/lib/inquiry_cli.dart
+++ b/code/cli/lib/inquiry_cli.dart
@@ -20,6 +20,9 @@ List<String> normalizeInquiryArgs(List<String> args) {
   if (args.length == 1 && (args.first == '--help' || args.first == '-h')) {
     return const ['help'];
   }
+  if (args.length == 1 && (args.first == '--version' || args.first == '-v')) {
+    return const ['version'];
+  }
   return args;
 }
 

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.7.3';
+const String inquiryVersion = '0.7.4';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.7.3
+version: 0.7.4
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/version_test.dart
+++ b/code/cli/test/version_test.dart
@@ -1,5 +1,6 @@
 import 'package:test/test.dart';
 
+import 'package:inquiry_cli/inquiry_cli.dart';
 import 'package:inquiry_cli/modules/global/commands/version.dart';
 
 void main() {
@@ -15,6 +16,13 @@ void main() {
 
     test('version matches expected format', () {
       expect(inquiryVersion, matches(RegExp(r'^\d+\.\d+\.\d+$')));
+    });
+
+    test('normalizes global version flags to the version command', () {
+      expect(normalizeInquiryArgs(const ['--version']), equals(const ['version']));
+      expect(normalizeInquiryArgs(const ['-v']), equals(const ['version']));
+      expect(normalizeInquiryArgs(const ['version']), equals(const ['version']));
+      expect(normalizeInquiryArgs(const ['host', 'get']), equals(const ['host', 'get']));
     });
   });
 }

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.7.3</span>
+      <span class="badge">v0.7.4</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Summary
- normalize root --version and -v flags to the version command
- add focused coverage for root version flag normalization

## Testing
- dart test test/version_test.dart

Closes #170