### PR TITLE
Fix release publication for clean jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="v${{ needs.check-version.outputs.version }}"
-          ASSETS=$(gh release view "$TAG" --json assets --jq '.assets[].name')
+          ASSETS=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')
           echo "$ASSETS"
 
           for asset in inquiry-windows-x64.zip inquiry-linux-x64.tar.gz; do
@@ -204,4 +204,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="v${{ needs.check-version.outputs.version }}"
-          gh release edit "$TAG" --draft=false --latest
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false --latest

--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.7.5]
+### Fixed
+- **Release publication automation**: `publish-release` now resolves the GitHub release through explicit repo context, so draft publication no longer fails in a clean job without `checkout`
+
 ## [0.7.4]
 ### Fixed
 - **Root version flags**: `iq --version` and `iq -v` now normalize to the `version` command instead of being dropped by root-command routing

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.7.4';
+const String inquiryVersion = '0.7.5';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.7.4
+version: 0.7.5
 
 environment:
   sdk: ^3.8.1

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.7.4</span>
+      <span class="badge">v0.7.5</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Summary
- make publish-release use explicit repository context instead of assuming a checked-out git repo
- bump Inquiry to v0.7.5 and update the public badge/changelog

## Testing
- dart test test/version_test.dart
- dart test test/version_sync_test.dart
- dart analyze
- dart test
- dart compile exe bin/main.dart -o build/bin/inquiry.exe