### PR TITLE
fix: enforce issue-linked feature branch policy

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.7.7]
+### Fixed
+- **Issue-linked branch enforcement**: `feature_branch_selected` and boundary commits now require a branch that actually matches the active issue prefix, so `start_analyze` and later phase boundaries no longer accept arbitrary non-main branches as valid explicit-start handoff context
+
+## [0.7.6]
+### Fixed
+- **IDLE handoff discipline**: the scheduler firmware now treats `issue_selected_or_created` and `feature_branch_selected` as IDLE handoff markers instead of universal `iq ape transition` events, preventing the harness from misrouting the explicit-start boundary after issue triage
+
 ## [0.7.5]
 ### Fixed
 - **Release publication automation**: `publish-release` now resolves the GitHub release through explicit repo context, so draft publication no longer fails in a clean job without `checkout`

--- a/code/cli/assets/agents/inquiry.agent.md
+++ b/code/cli/assets/agents/inquiry.agent.md
@@ -60,8 +60,10 @@ iq fsm transition --event <event>
 
 ## IDLE Handoff
 - explicit create/select intent only changes TRIAGE routing inside IDLE; issue readiness stays in IDLE/TRIAGE and produces `issue_selected_or_created`
+- `issue_selected_or_created` is a handoff marker, not an `iq ape transition` event; remain in IDLE and wait for explicit start intent
 - only explicit start intent reaches `_DONE`
 - only explicit start intent triggers inquiry-start plus start_analyze
+- `feature_branch_selected` is produced by `inquiry-start`, not by `iq ape transition`
 - `inquiry-start` first produces `feature_branch_selected`, then `iq fsm transition --event start_analyze` may leave IDLE
 
 ## ANALYZE Visibility Rule
@@ -73,7 +75,7 @@ Dispatch is **unconditional and immediate**. When you enter the Inner Loop, exec
 1. Run `iq ape prompt --name <ape.name>` to inspect the exact effective sub-agent prompt (APE identity + phase-owned operational contract + inquiry-context). Treat that output as the complete runtime prompt surface; do not invent hidden glue or recover missing procedure from the APE YAML.
 2. **Dispatch** that sub-agent: use the `agent` tool to invoke a generic/current sub-agent path with the prompt as full context. Do NOT set `agentName` from `ape.name`; omit `agentName` unless the runtime explicitly exposes an invocable generic helper that is independent of APE identity. Do NOT perform the sub-agent's work yourself. Do NOT announce what the sub-agent will do. If the active phase contract requires visible interaction, surface that interaction directly in chat instead of hiding it behind a later gate.
 3. Wait for the sub-agent to signal completion (it will announce its sub-phase is done).
-4. When signaled: `iq ape transition --event <event>` to advance the sub-FSM.
+4. When signaled: if the marker is `issue_selected_or_created` or `feature_branch_selected`, handle it per IDLE Handoff and do NOT run `iq ape transition`; otherwise run `iq ape transition --event <event>`.
 5. If `ape.state` becomes `_DONE`: exit Inner Loop, enter Completion Gate.
 6. If `ape.state` is NOT `_DONE`: re-run step 1 (new prompt for new sub-phase) and dispatch again — no confirmation needed.
 

--- a/code/cli/lib/modules/fsm/commands/transition.dart
+++ b/code/cli/lib/modules/fsm/commands/transition.dart
@@ -403,10 +403,10 @@ class StateTransitionCommand
         reason: boundaryCommitResult.errorMessage!,
         blockingBoundary: 'boundary_commit',
         authoritativeSurface: _boundaryCommitSpec(
-              transition.operations?.commitPolicy ?? 'none',
-              branch: branch,
-              issue: resolvedIssue,
-            )
+          transition.operations?.commitPolicy ?? 'none',
+          branch: branch,
+          issue: resolvedIssue,
+        )
             ?.path ??
             'git:commit',
       );
@@ -677,7 +677,7 @@ class StateTransitionCommand
     }
 
     if (prechecks.contains('feature_branch_selected')) {
-      if (branch == 'main' || branch == 'master' || branch.isEmpty) {
+      if (!_isIssueLinkedFeatureBranch(branch, issue)) {
         _recordPrecheckSensor(
           executor,
           currentState: currentState,
@@ -687,7 +687,7 @@ class StateTransitionCommand
           issue: issue,
           promptFragmentId: promptFragmentId,
         );
-        return 'ERROR_PRECONDITION_BRANCH_POLICY: Use issue-linked feature branch, not main';
+        return 'ERROR_PRECONDITION_BRANCH_POLICY: Use issue-linked feature branch matching active issue';
       }
       _recordPrecheckSensor(
         executor,
@@ -1036,7 +1036,7 @@ class StateTransitionCommand
       return const _BoundaryCommitResult.success();
     }
 
-    if (branch.isEmpty || branch == 'main' || branch == 'master') {
+    if (!_isIssueLinkedFeatureBranch(branch, issue)) {
       return _BoundaryCommitResult.failure(
         'ERROR_BOUNDARY_COMMIT_BRANCH_POLICY: Cannot create ${spec.label} commit without an issue-linked feature branch',
       );
@@ -1094,6 +1094,29 @@ class StateTransitionCommand
     return const _BoundaryCommitResult.success(
       operationsExecuted: ['create_boundary_commit'],
     );
+  }
+
+  bool _isIssueLinkedFeatureBranch(String branch, String? issue) {
+    final normalizedBranch = branch.trim();
+    if (normalizedBranch.isEmpty ||
+        normalizedBranch == 'main' ||
+        normalizedBranch == 'master') {
+      return false;
+    }
+
+    final normalizedIssue = issue?.trim();
+    if (normalizedIssue == null || normalizedIssue.isEmpty) {
+      return false;
+    }
+
+    final canonicalIssue =
+        int.tryParse(normalizedIssue)?.toString() ?? normalizedIssue;
+    final validPrefixes = <String>{'$canonicalIssue-'};
+    if (canonicalIssue.length < 3) {
+      validPrefixes.add('${canonicalIssue.padLeft(3, '0')}-');
+    }
+
+    return validPrefixes.any(normalizedBranch.startsWith);
   }
 
   _BoundaryCommitSpec? _boundaryCommitSpec(

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.7.5';
+const String inquiryVersion = '0.7.7';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.7.5
+version: 0.7.7
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/firmware_agent_test.dart
+++ b/code/cli/test/firmware_agent_test.dart
@@ -123,6 +123,21 @@ void main() {
       );
     });
 
+    test('does not treat IDLE handoff markers as ape transitions', () {
+      expect(
+        content,
+        contains('`issue_selected_or_created` is a handoff marker, not an `iq ape transition` event'),
+      );
+      expect(
+        content,
+        contains('`feature_branch_selected` is produced by `inquiry-start`, not by `iq ape transition`'),
+      );
+      expect(
+        content,
+        contains('do NOT run `iq ape transition`; otherwise run `iq ape transition --event <event>`'),
+      );
+    });
+
     test('forbids direct writes to .inquiry/', () {
       expect(content, contains('NEVER'));
       expect(content, contains('.inquiry/'));

--- a/code/cli/test/fsm_transition_test.dart
+++ b/code/cli/test/fsm_transition_test.dart
@@ -410,6 +410,29 @@ void main() {
       },
     );
 
+    test(
+      'blocks IDLE to ANALYZE when branch does not match active issue',
+      () async {
+        _initGitRepo(tempDir.path, branch: 't1-pilot-h');
+        _writeState(tempDir.path, 'IDLE', issue: '231');
+
+        final input = StateTransitionInput(
+          currentState: null,
+          event: 'start_analyze',
+          workingDirectory: tempDir.path,
+        );
+        final command = StateTransitionCommand(
+          input,
+          branchProvider: (_) async => 't1-pilot-h',
+        );
+
+        final output = await command.execute();
+
+        expect(output.allowed, isFalse);
+        expect(output.message, contains('ERROR_PRECONDITION_BRANCH_POLICY'));
+      },
+    );
+
     test('allows IDLE to ANALYZE with issue and feature branch', () async {
       _initGitRepo(tempDir.path, branch: '152-feature-branch');
       _writeState(tempDir.path, 'IDLE');
@@ -598,6 +621,30 @@ void main() {
             'authoritative_surface: "cleanrooms/51-idle-execution-guardrails/plan.md"',
           ),
         );
+      },
+    );
+
+    test(
+      'blocks PLAN -> EXECUTE on non-main branch that is not issue-linked',
+      () async {
+        const branch = 't1-pilot-h';
+
+        _initGitRepo(tempDir.path, branch: branch);
+        _writePlan(tempDir.path, branch, '# plan\n');
+        _writeState(tempDir.path, 'PLAN', issue: '231');
+
+        final output = await StateTransitionCommand(
+          StateTransitionInput(
+            currentState: null,
+            event: 'approve_plan',
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => branch,
+        ).execute();
+
+        expect(output.allowed, isFalse);
+        expect(output.nextState, isNull);
+        expect(output.message, contains('ERROR_PRECONDITION_BRANCH_POLICY'));
       },
     );
 

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.7.5</span>
+      <span class="badge">v0.7.7</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Critical analysis
The explicit-start contract already required an issue-linked feature branch, but the runtime only checked that the branch was not main/master.
This let unrelated branches satisfy feature_branch_selected and also allowed later boundary commits to proceed without a branch that matched the active issue.

## TDD
Added focused FSM regression coverage for:
- blocking IDLE -> ANALYZE when the current branch does not match the active issue
- blocking PLAN -> EXECUTE boundary commits when the branch is non-main but not issue-linked

## Execution
- enforced issue-linked branch validation in transition prechecks
- enforced the same validation before boundary commits
- kept support for canonical and zero-padded 3-digit issue prefixes
- bumped the CLI/site version to 0.7.7 and documented the fix in the changelog

## QA
- dart test test/fsm_transition_test.dart test/fsm_transition_integration_test.dart test/version_sync_test.dart test/firmware_agent_test.dart
- dart analyze