### PR TITLE
H: enforce exact-literal output rule in inquiry firmware

### DIFF
--- a/code/cli/assets/agents/inquiry.agent.md
+++ b/code/cli/assets/agents/inquiry.agent.md
@@ -90,3 +90,4 @@ Dispatch is **unconditional and immediate**. When you enter the Inner Loop, exec
 - If a command fails, report the error and offer retry.
 - If you are unsure of your state, run `iq fsm state --json`; complete one sub-phase at a time before transitioning.
 - Do not enumerate states, transitions, or sub-agent names from memory. Read them from the CLI output.
+- If the user requests an exact literal response (for example "respond exactly TOKEN"), output only that literal in the final response and nothing else.

--- a/code/cli/test/firmware_agent_test.dart
+++ b/code/cli/test/firmware_agent_test.dart
@@ -142,5 +142,13 @@ void main() {
       expect(content, contains('NEVER'));
       expect(content, contains('.inquiry/'));
     });
+
+    test('requires exact literal output when explicitly requested', () {
+      expect(
+        content,
+        contains('If the user requests an exact literal response'),
+      );
+      expect(content, contains('output only that literal'));
+    });
   });
 }


### PR DESCRIPTION
## Summary\nHardens Inquiry methodology (H mode) by codifying an explicit exact-literal output rule in the scheduler firmware prompt.\n\nCloses #238\n\n## Changes\n- Added rule in firmware prompt: when user requests exact literal response, output only that literal.\n- Added regression test in firmware asset test suite.\n\n## Validation\n- dart test test/firmware_agent_test.dart\n- Runtime smoke with local gemma4 (--agent inquiry) still runs iq fsm state --json and returns the requested token path in output stream.\n\n## Note\n- This PR improves contract clarity. Model compliance still depends on runtime behavior and may require additional guardrails in orchestration layer for strict enforcement.\n