### PR TITLE
F: add reproducible gemma4 H/F benchmark runner

### DIFF
--- a/code/cli/README.md
+++ b/code/cli/README.md
@@ -39,3 +39,18 @@ curl -fsSL https://inquiry.ccisne.dev/install.sh | bash
 | `iq ape prompt --name <name>` | Assemble sub-agent prompt from YAML + current state |
 | `iq ape state` | Show active APE sub-state and valid transitions |
 | `iq ape transition --event <e>` | Advance the active APE's internal FSM |
+
+## H/F Benchmark (Gemma4)
+
+Use the PowerShell runner to compare Inquiry methodology mode (H) vs freestyle mode (F) with local Copilot CLI routing to Ollama.
+
+```powershell
+./scripts/benchmark-hf-gemma4.ps1 -Workspace . -Model gemma4:latest
+```
+
+The runner executes both modes with equivalent prompts, stores raw JSONL logs under `tmp/`, and writes `summary.json` with:
+
+- model detection in logs
+- evidence that `iq fsm state --json` was executed
+- token compliance (`tokenSeen` and `exactTokenMessageSeen`)
+- pass/fail booleans for standard and strict literal checks

--- a/code/cli/scripts/benchmark-hf-gemma4.ps1
+++ b/code/cli/scripts/benchmark-hf-gemma4.ps1
@@ -1,0 +1,104 @@
+param(
+  [string]$Workspace = ".",
+  [string]$Model = "gemma4:latest",
+  [string]$ProviderBaseUrl = "http://localhost:11434/v1",
+  [string]$OutputDir = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($OutputDir)) {
+  $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+  $OutputDir = Join-Path $PSScriptRoot "..\tmp\hf-benchmark-$stamp"
+}
+
+$OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
+New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+
+$hLog = Join-Path $OutputDir "h.jsonl"
+$fLog = Join-Path $OutputDir "f.jsonl"
+$summaryPath = Join-Path $OutputDir "summary.json"
+
+$hToken = "H_GEMMA4_OK"
+$fToken = "F_GEMMA4_OK"
+
+$hPrompt = "Prueba H: Ejecuta primero iq fsm state --json y responde exactamente $hToken"
+$fPrompt = "Prueba F: Ejecuta primero iq fsm state --json y responde exactamente $fToken"
+
+function Invoke-CopilotRun {
+  param(
+    [string]$ModeName,
+    [string]$Prompt,
+    [string]$Token,
+    [string]$LogPath,
+    [switch]$UseInquiryAgent
+  )
+
+  $env:COPILOT_PROVIDER_BASE_URL = $ProviderBaseUrl
+  $env:COPILOT_MODEL = $Model
+  $env:COPILOT_OFFLINE = "true"
+
+  $args = @(
+    "-C", $Workspace,
+    "--name", "benchmark-$ModeName",
+    "--model", $Model,
+    "--allow-all-tools",
+    "-p", $Prompt,
+    "--output-format", "json",
+    "-s"
+  )
+
+  if ($UseInquiryAgent) {
+    $args = @("-C", $Workspace, "--agent", "inquiry") + $args[2..($args.Count - 1)]
+  }
+
+  & copilot @args | Tee-Object -FilePath $LogPath | Out-Null
+  $exitCode = $LASTEXITCODE
+
+  $text = Get-Content -Raw -Path $LogPath
+  $tokenPattern = [regex]::Escape($Token)
+  $modelPattern = [regex]::Escape('"model":"' + $Model + '"')
+
+  $hasToken = $text -match $tokenPattern
+  $hasExactMessage = $text -match ('"content":"' + $tokenPattern + '"')
+  $hasStateCommand = $text -match [regex]::Escape("iq fsm state --json")
+  $hasModel = $text -match $modelPattern
+
+  $resultObj = [pscustomobject]@{
+    mode = $ModeName
+    exitCode = $exitCode
+    modelSeen = $hasModel
+    stateCommandSeen = $hasStateCommand
+    tokenSeen = $hasToken
+    exactTokenMessageSeen = $hasExactMessage
+    passed = ($exitCode -eq 0 -and $hasModel -and $hasStateCommand -and $hasToken)
+    strictLiteralPassed = ($exitCode -eq 0 -and $hasExactMessage)
+    logPath = $LogPath
+  }
+
+  return $resultObj
+}
+
+Write-Host "Running H benchmark (Inquiry methodology)..."
+$hResult = Invoke-CopilotRun -ModeName "h" -Prompt $hPrompt -Token $hToken -LogPath $hLog -UseInquiryAgent
+
+Write-Host "Running F benchmark (freestyle)..."
+$fResult = Invoke-CopilotRun -ModeName "f" -Prompt $fPrompt -Token $fToken -LogPath $fLog
+
+$summary = [pscustomobject]@{
+  generatedAt = (Get-Date).ToString("o")
+  workspace = (Resolve-Path $Workspace).Path
+  model = $Model
+  providerBaseUrl = $ProviderBaseUrl
+  results = @($hResult, $fResult)
+}
+
+$summary | ConvertTo-Json -Depth 6 | Set-Content -Path $summaryPath -Encoding UTF8
+
+Write-Host ""
+Write-Host "Benchmark summary"
+$summary.results | Format-Table mode, exitCode, modelSeen, stateCommandSeen, tokenSeen, exactTokenMessageSeen, passed, strictLiteralPassed -AutoSize
+Write-Host ""
+Write-Host "Summary JSON: $summaryPath"
+Write-Host "H log: $hLog"
+Write-Host "F log: $fLog"


### PR DESCRIPTION
## Summary\nAdds a reproducible freestyle lane artifact for comparing Inquiry methodology (H) vs freestyle (F) with local gemma4 via Copilot CLI.\n\nCloses #239\n\n## Changes\n- Added scripts/benchmark-hf-gemma4.ps1 to run both H and F with equivalent prompts.\n- Added README section documenting benchmark usage and result semantics.\n\n## Validation\nExecuted locally:\n- ./scripts/benchmark-hf-gemma4.ps1 -Workspace . -Model gemma4:latest\n\nObserved summary:\n- H: passed=True, strictLiteralPassed=True\n- F: passed=True, strictLiteralPassed=True\n- both runs showed iq fsm state --json and model gemma4:latest evidence in logs.\n\n## Notes\n- Script writes raw logs and summary into 	mp/ for auditability and replay.\n- No merge performed in this workflow.\n