### PR TITLE
feat: OpenCode host support — inquiry agent + skills (#247) [v0.8.0]

### DIFF
--- a/cleanrooms/247-opencode-host-support/analyze/confirmations.md
+++ b/cleanrooms/247-opencode-host-support/analyze/confirmations.md
@@ -1,0 +1,41 @@
+---
+id: confirmations
+title: "Confirmations"
+date: 2026-06-16
+status: active
+tags: [confirmations, findings]
+---
+
+# Confirmations
+
+> Living document. Update as findings are confirmed, revised, or invalidated.
+> Format: ## F<N>: <title> — CONFIRMED|REVISED|INVALIDATED
+
+## F1: OpenCodeAdapter already exists and its paths match OpenCode's real layout — CONFIRMED
+- evidence: `code/cli/lib/hosts/opencode_adapter.dart:10-19` — `baseDirectory` = `~/.config/opencode`, `skillsDirectory` = `~/.config/opencode/skills`, `agentDirectory` = `~/.config/opencode/agents`.
+- evidence (official): https://opencode.ai/docs/skills/ — skills load from `~/.config/opencode/skills/<name>/SKILL.md`; https://opencode.ai/docs/agents/ — global markdown agents load from `~/.config/opencode/agents/` (plural).
+- evidence (runtime): `~/.config/opencode/` exists on this machine with `opencode.jsonc`; `opencode --version` → `1.17.7`.
+
+## F2: OpenCode is registered but excluded from active deploy targets — CONFIRMED
+- evidence: `code/cli/lib/hosts/all_adapters.dart:14` (present in `allAdapters`) vs `:20` `deployAdapters = [CopilotAdapter()]`, comment `// For v0.0.x only Copilot is active (D20).`
+
+## F3: `iq host get` deploys skills only and never deploys the agent — CONFIRMED
+- evidence: `code/cli/lib/hosts/deployer.dart:35` (`deployExclusive` calls only `_deploySkills`), `:46-56` (`_deploySkills` copies `skills/<n>/SKILL.md`), `:42` (`clean()` deletes `agentDirectory` but nothing writes it).
+- evidence: `code/cli/test/deployer_test.dart:91-93` asserts `inquiry.agent.md` is NOT deployed; `:127-129` asserts the agents dir is not created.
+
+## F4: The three skills are OpenCode-compatible as-is — CONFIRMED
+- evidence: `assets/skills/research/SKILL.md:1-3`, `assets/skills/legion/SKILL.md:1-3`, `assets/skills/kritik/SKILL.md:1-3` each have YAML frontmatter with `name` + `description` — exactly the fields required by https://opencode.ai/docs/skills/ ("Only these fields are recognized... Unknown frontmatter fields are ignored").
+
+## F5: The inquiry agent needs format adaptation for OpenCode — CONFIRMED
+- evidence: `assets/agents/inquiry.agent.md:1-4` frontmatter has `name`, `description`, `tools: [vscode, execute, read, agent, edit, search, web, browser, todo]` — but lacks `mode:` (OpenCode needs `mode: subagent|primary` per https://opencode.ai/docs/agents/), and the `tools` values are Copilot/VSCode names. Body references VSCode-only affordances (`Ctrl+Shift+P → Inquiry: Init`).
+
+## F6: OpenCode CLI is installed and usable with default models — CONFIRMED
+- evidence (runtime): `opencode --version` → `1.17.7`; `opencode agent --help` exposes `agent create` / `agent list`; `opencode models` lists default `opencode/*` free models (e.g. `opencode/big-pickle`) — no qwen3-coder required for tests.
+
+## F7: Existing tests encode the single-host contract and will break — CONFIRMED
+- evidence: `code/cli/test/hosts_test.dart:57` `expect(deployAdapters, hasLength(1));` and `:61` `expect(deployAdapters.single.name, equals('copilot'));`.
+
+## F8: OpenCode supports Copilot-style activate/deactivate for a primary agent — CONFIRMED
+- evidence (official): https://opencode.ai/docs/agents/ — primary agents are switched at runtime with `Tab` / `switch_agent` keybind; persistent disable via config `{"agent": {"<name>": {"disable": true}}}` ("Set to `true` to disable the agent").
+- decision (user, 2026-06-16): emit inquiry as `mode: primary` (most faithful to its orchestrator nature); activate/deactivate is covered by Tab/switch_agent + `disable`.
+

--- a/cleanrooms/247-opencode-host-support/analyze/diagnosis.md
+++ b/cleanrooms/247-opencode-host-support/analyze/diagnosis.md
@@ -1,0 +1,40 @@
+---
+id: diagnosis
+title: "Diagnosis"
+date: 2026-06-16
+status: active
+tags: [diagnosis, evidence-first]
+---
+
+# Diagnosis
+
+## Evidence
+- `OpenCodeAdapter` exists with paths matching OpenCode's real layout — `code/cli/lib/hosts/opencode_adapter.dart:10-19`; cross-checked against https://opencode.ai/docs/skills/ and https://opencode.ai/docs/agents/ and runtime (`~/.config/opencode/` present, `opencode 1.17.7`). [F1]
+- OpenCode is in `allAdapters` but NOT in `deployAdapters` (Copilot-only, D20) — `code/cli/lib/hosts/all_adapters.dart:14,20`. [F2]
+- `iq host get` deploys skills only and never the agent; `clean()` deletes the agent dir but nothing writes it — `code/cli/lib/hosts/deployer.dart:35,42,46-56`; asserted by `code/cli/test/deployer_test.dart:91-93,127-129`. [F3]
+- The three skills (`research`, `legion`, `kritik`) already carry `name`+`description` frontmatter, the exact OpenCode SKILL.md schema — `assets/skills/{research,legion,kritik}/SKILL.md:1-3`. [F4]
+- The inquiry agent lacks OpenCode's `mode:` field and uses Copilot/VSCode `tools` names + VSCode-only body affordances — `assets/agents/inquiry.agent.md:1-4`. [F5]
+- OpenCode CLI is installed and usable with default free `opencode/*` models (no qwen needed for tests) — runtime `opencode --version` / `opencode agent --help` / `opencode models`. [F6]
+- Single-host contract is encoded in tests that will break — `code/cli/test/hosts_test.dart:57,61`. [F7]
+- OpenCode supports activate/deactivate for `mode: primary` agents (Tab/`switch_agent` + `disable: true` config) — https://opencode.ai/docs/agents/. [F8]
+
+## Hypotheses
+- The feature is **mostly pre-wired**: the host abstraction, the OpenCode adapter, the skills, and the deploy/clean plumbing already exist. The change is therefore **activation + one missing capability**, not a new subsystem. [licensed by F1,F2,F3]
+- Two blocking gaps remain to satisfy the issue's success condition ("inquiry subagent + research/legion/kritik available in opencode"):
+  1. **Activation gap** — OpenCode is excluded from `deployAdapters`. [F2]
+  2. **Agent-deploy gap** — `host get` deploys skills but not the agent, yet the success condition requires the inquiry subagent present in `~/.config/opencode/agents/`. This requires (a) new deploy logic and (b) emitting the agent in OpenCode's frontmatter schema (`mode:` etc.). [F3,F5]
+- Skills require **no transformation**; they deploy as-is. [F4]
+
+## Constraints
+- Do not change the FSM contract (issue out-of-scope).
+- Keep Copilot's behavior unchanged — `deployer_test.dart:91-93` encodes "host get does not deploy agents" for the Copilot path; any agent-deploy must not regress Copilot.
+- One host active at a time — `deployExclusive` cleans all adapters then deploys to one (`deployer.dart:33-35`). OpenCode must obey the same mutual-exclusion model.
+- Tests are the acceptance gate — `hosts_test.dart:57,61` and the deployer tests must be updated/extended, not bypassed.
+- Verification must use the real `opencode` command with a default model (per user direction); qwen3-coder is not required for tests.
+
+## Decisions (user-confirmed 2026-06-16)
+- **D1 — Agent-deploy scope: OpenCode-only.** `host get` deploys the inquiry agent only when `--host opencode`; Copilot stays skills-only so `deployer_test.dart:91-93` does not regress. [resolves former OQ on scope]
+- **D2 — Agent mode: `primary`.** Emit inquiry with `mode: primary` (faithful to its orchestrator nature). Activate/deactivate is satisfied by OpenCode's Tab/`switch_agent` + `disable` config. [F8] Requires emitting an OpenCode-tailored agent file (add `mode:`; the verbatim Copilot file lacks it).
+
+## Open Questions
+- **`iq doctor` check (optional):** issue lists an optional OpenCode presence check; the doctor command location was not located in this analysis corpus. Scope as optional in PLAN; does not block the success condition.

--- a/cleanrooms/247-opencode-host-support/analyze/index.md
+++ b/cleanrooms/247-opencode-host-support/analyze/index.md
@@ -1,0 +1,15 @@
+# Analyze Phase — Index
+
+**Issue:** #247
+**Branch:** 247-opencode-host-support
+**Phase:** ANALYZE
+**Status:** In progress
+
+---
+
+## Documents
+
+| # | File | Title | Status | Tags |
+|---|------|-------|--------|------|
+| 1 | confirmations.md | Confirmations | active | confirmations, findings |
+| 2 | diagnosis.md | Diagnosis | active | diagnosis, evidence-first |

--- a/cleanrooms/247-opencode-host-support/issue.md
+++ b/cleanrooms/247-opencode-host-support/issue.md
@@ -1,0 +1,33 @@
+---
+id: issue
+issue: "247"
+branch: 247-opencode-host-support
+date: 2026-06-16
+---
+
+# Issue #247
+
+## Goal
+
+Add **OpenCode** as a supported Inquiry host, alongside the current Copilot-only runtime (`docs/architecture.md`: *\"Host: Copilot only at present. Multi-host deferred until reactivation\"*). This unlocks driving the APE FSM with a **local model** — specifically `qwen3-coder:30b` via Ollama (measured ~30 tok/s locally on a 12GB GPU) — using Inquiry as the guiding harness.
+
+## Why
+
+- The gemma4 fullflow benchmark (#242) showed neither H nor F completed IDLE→END, with H bottlenecked on local-model speed. A faster, more capable local coder (qwen3-coder:30b) is the better harness target.
+- OpenCode is open and scriptable, a natural fit for a deterministic FSM driver.
+
+## Scope (to be refined in ANALYZE/PLAN)
+
+- `iq host get --host opencode`: deploy Inquiry skills/agents into OpenCode's config layout.
+- Map the `host` module abstraction (currently Copilot-specific) to a host-agnostic interface; implement an OpenCode adapter under `code/cli/lib/hosts/`.
+- Provider config for local Ollama (`http://localhost:11434/v1`, model `qwen3-coder:30b`).
+- `iq doctor` checks for OpenCode presence/auth analogous to the gh/copilot checks.
+
+## Out of scope
+
+- Changing the FSM contract itself.
+- Multi-host orchestration beyond Copilot + OpenCode.
+
+## Notes
+
+This issue is also being used as a guided walkthrough of the Inquiry CLI itself (ANALYZE → PLAN → EXECUTE) to validate the harness end-to-end on a real feature.

--- a/cleanrooms/247-opencode-host-support/mutations.md
+++ b/cleanrooms/247-opencode-host-support/mutations.md
@@ -1,0 +1,4 @@
+# Mutations
+
+Notes for DARWIN. Write observations about the current cycle here.
+This file is read during EVOLUTION and cleared afterwards.

--- a/cleanrooms/247-opencode-host-support/plan.md
+++ b/cleanrooms/247-opencode-host-support/plan.md
@@ -1,0 +1,84 @@
+---
+id: plan
+title: "Plan — Add OpenCode as an Inquiry host"
+date: 2026-06-16
+status: active
+tags: [plan, descartes, evidence-first]
+---
+
+# Plan — OpenCode host (#247)
+
+Built from `analyze/diagnosis.md`. Decisions honored: **D1** OpenCode-only agent deploy;
+**D2** inquiry emitted as `mode: primary`. Verification per phase is an **executable command**
+(no pseudocode) — RED before EXECUTE makes it pass.
+
+## Shared-interface change (enumerated per PLAN constraint)
+Phase 2 adds a getter to the abstract `HostAdapter`. Implementors to check (search:
+`grep -rn "extends HostAdapter" code/cli/lib code/cli/test`):
+`copilot_adapter.dart`, `claude_adapter.dart`, `codex_adapter.dart`, `opencode_adapter.dart`,
+`gemini_adapter.dart`, plus test fakes in `test/deployer_test.dart:21` and `test/hosts_test.dart`.
+The getter has a default (`false`), so no construction site breaks; only `OpenCodeAdapter` overrides.
+
+---
+
+## Phase 1 — Activate OpenCode as a deploy target
+- [ ] `code/cli/lib/hosts/all_adapters.dart:20` → `deployAdapters = [CopilotAdapter(), OpenCodeAdapter()];`
+- [ ] `code/cli/test/hosts_test.dart:57` → `hasLength(2)`; `:61` → assert names contain `copilot` and `opencode`.
+- **Entry:** diagnosis approved. **Risk:** low.
+- **Verification (executable):** `cd code/cli && dart test test/hosts_test.dart` → green.
+
+## Phase 2 — Host capability flag for global agent deploy (host-agnostic; realizes D1)
+- [ ] `code/cli/lib/hosts/host_adapter.dart`: add `bool get deploysAgent => false;`
+- [ ] `code/cli/lib/hosts/opencode_adapter.dart`: override `bool get deploysAgent => true;`
+- Rationale: D1 (opencode-only) without hardcoding the string `'opencode'` in the deployer.
+- **Verification (executable):** new test asserting `OpenCodeAdapter().deploysAgent == true` &&
+  `CopilotAdapter().deploysAgent == false` → `dart test test/hosts_test.dart` green.
+
+## Phase 3 — Author the OpenCode-tailored inquiry agent asset
+- [ ] Add `code/cli/assets/agents/inquiry.opencode.md` with OpenCode frontmatter:
+      `description:` (reuse from `inquiry.agent.md`), `mode: primary`; body = inquiry scheduler
+      firmware reused from `assets/agents/inquiry.agent.md`, with VSCode-only boot lines
+      (`Ctrl+Shift+P → Inquiry: Init`) replaced by host-agnostic `iq init` instructions.
+- **Risk:** asset bundling — confirm `Assets.loadString('agents/inquiry.opencode.md')` resolves
+  (dev reads from `assets/`; built binary may embed assets → may require rebuild). Verify first.
+- **Verification (executable):** `cd code/cli && dart run bin/main.dart` path that loads the asset,
+  or a unit test: `assets.loadString('agents/inquiry.opencode.md')` contains `mode: primary`.
+
+## Phase 4 — Deploy the agent in the deployer (gated by `deploysAgent`)
+- [ ] `code/cli/lib/hosts/deployer.dart`: in `deployExclusive`, after `_deploySkills(selected)`,
+      call `_deployAgent(selected)` only when `selected.deploysAgent`.
+- [ ] Add `_deployAgent(adapter)`: load `agents/inquiry.opencode.md`, write to
+      `adapter.agentDirectory(homeDir)/inquiry.md` (mkdir -p). `clean()` already wipes
+      `agentDirectory` for all adapters (`deployer.dart:42`) → mutual exclusion preserved.
+- **Verification (executable):**
+  - Copilot unchanged: `dart test test/deployer_test.dart` → existing `:91-93,127-129` still green.
+  - New test: fake adapter with `deploysAgent=true` → `agents/inquiry.md` written; assert content
+    has `mode: primary`.
+
+## Phase 5 — Integration smoke test with the real `opencode` command
+- [ ] Build: `cd code/cli && dart compile exe bin/main.dart -o build/bin/inquiry.exe` (or `scripts/build`).
+- [ ] Run `iq host get --host opencode`.
+- **Verification (executable):**
+  - `test -f ~/.config/opencode/skills/research/SKILL.md` (and legion, kritik).
+  - `test -f ~/.config/opencode/agents/inquiry.md` and `grep -q "mode: primary"` it.
+  - `opencode agent list` → output contains `inquiry`.
+  - (Default `opencode/*` model; no qwen needed, per issue.)
+
+## Phase 6 — (Optional) `iq doctor` OpenCode presence check
+- [ ] Locate the doctor command; add an OpenCode-installed check analogous to gh/copilot.
+- Scope: optional; does not block the success condition. Defer if time-boxed.
+- **Verification:** `iq doctor` lists an OpenCode check; `dart test test/doctor_test.dart` green.
+
+---
+
+## Final verification (mandatory full-suite step)
+- [ ] `cd code/cli && dart test` → **entire** suite green (not only changed tests).
+- [ ] `iq host get --host opencode` then `opencode agent list` shows `inquiry`, and skills present.
+- [ ] `iq host get --host copilot` still deploys skills-only (no Copilot regression).
+
+## Ordering & dependencies
+P1 → P2 → P3 → P4 (needs P2+P3) → P5 (needs P1–P4) → P6 (optional, independent).
+
+## Success condition (from issue #247, user-confirmed)
+`research`, `legion`, `kritik` skills **and** the `inquiry` agent (as `mode: primary`) are
+available in OpenCode after `iq host get --host opencode`, verified via the real `opencode` command.

--- a/cleanrooms/247-opencode-host-support/pre_pr_inspection.md
+++ b/cleanrooms/247-opencode-host-support/pre_pr_inspection.md
@@ -1,0 +1,41 @@
+verdict: BLOCKED
+
+# END Pre-PR Inspection
+
+issue: "247"
+branch: "247-opencode-host-support"
+generated_at: "2026-06-16T23:31:09.904881Z"
+
+## Pass 1 — Consistency
+- WARN: no source/build asset mirror detected under assets/ and build/assets; automatic parity skipped for this repo
+
+## Pass 2 — Completeness
+- FAIL: unchecked plan checkbox remains at cleanrooms/247-opencode-host-support/plan.md:25
+- FAIL: unchecked plan checkbox remains at cleanrooms/247-opencode-host-support/plan.md:26
+- FAIL: unchecked plan checkbox remains at cleanrooms/247-opencode-host-support/plan.md:31
+- FAIL: unchecked plan checkbox remains at cleanrooms/247-opencode-host-support/plan.md:32
+- FAIL: unchecked plan checkbox remains at cleanrooms/247-opencode-host-support/plan.md:38
+- FAIL: unchecked plan checkbox remains at cleanrooms/247-opencode-host-support/plan.md:48
+- FAIL: unchecked plan checkbox remains at cleanrooms/247-opencode-host-support/plan.md:50
+- FAIL: unchecked plan checkbox remains at cleanrooms/247-opencode-host-support/plan.md:59
+- FAIL: unchecked plan checkbox remains at cleanrooms/247-opencode-host-support/plan.md:60
+- FAIL: unchecked plan checkbox remains at cleanrooms/247-opencode-host-support/plan.md:68
+- FAIL: unchecked plan checkbox remains at cleanrooms/247-opencode-host-support/plan.md:75
+- FAIL: unchecked plan checkbox remains at cleanrooms/247-opencode-host-support/plan.md:76
+- FAIL: unchecked plan checkbox remains at cleanrooms/247-opencode-host-support/plan.md:77
+
+## Pass 3 — Traceability
+- PASS: inspection metadata matches active issue "247" and branch "247-opencode-host-support"
+- PASS: overhead summary event counts transition=3, sensor_run=15, block=0, retry=0, phase_timing=2, tool_activity=5, model_activity=1 at cleanrooms/247-opencode-host-support/run_trace.yaml:1
+- PASS: overhead summary found no blocking boundaries before END in cleanrooms/247-opencode-host-support/run_trace.yaml:1
+- PASS: overhead summary found no non-approved gates before END in cleanrooms/247-opencode-host-support/run_trace.yaml:1
+- PASS: overhead summary found no retries before END in cleanrooms/247-opencode-host-support/run_trace.yaml:1
+- PASS: overhead summary shows highest observed phase cost at ANALYZE=3783.008s in cleanrooms/247-opencode-host-support/run_trace.yaml:1
+- PASS: overhead summary estimates model-bound prompt input as [socrates=2382 est_tokens/9526 chars/0.001s assembly] in cleanrooms/247-opencode-host-support/run_trace.yaml:1
+- WARN: overhead summary attributes host-boundary activity as [git=4, gh=1], harness control-path activity as 20 trace events plus 0.001s of local prompt assembly time, and leaves only remote model runtime/caching cost unattributed in local surfaces at cleanrooms/247-opencode-host-support/run_trace.yaml:1
+- WARN: traceability findings include automatic issue/branch metadata review plus a minimal overhead summary from run_trace and metrics_snapshot, including model-bound prompt estimates and remaining remote runtime attribution limits, when END is entered and refreshed again at pr_ready; replace or complement this with concrete issue/plan mapping findings before approval
+
+## Citation Guidance
+
+- Every FAIL must include a repo-relative file:line citation, for example `code/cli/lib/modules/fsm/commands/transition.dart:355`
+- WARN findings should cite file:line when they are grounded in a concrete file-backed observation

--- a/cleanrooms/247-opencode-host-support/run_trace.yaml
+++ b/cleanrooms/247-opencode-host-support/run_trace.yaml
@@ -271,3 +271,45 @@ events:
     outcome: allowed
     prompt_fragment_id: plan_to_execute
     operations_executed: ['update_state']
+  - recorded_at: "2026-06-16T23:31:09.583576Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: EXECUTE
+    sensor_category: runtime
+    gate: issue_selected
+    verdict: APPROVED
+    authority: "cleanrooms/247-opencode-host-support/.iq.state.yaml"
+    prompt_fragment_id: execute_to_end
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T23:31:09.584687Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: EXECUTE
+    sensor_category: runtime
+    gate: feature_branch_selected
+    verdict: APPROVED
+    authority: "git:branch"
+    prompt_fragment_id: execute_to_end
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T23:31:09.975271Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: phase_timing
+    phase: EXECUTE
+    started_at: "2026-06-16T23:25:09.455162Z"
+    ended_at: "2026-06-16T23:31:09.648572Z"
+    duration_seconds: 360.193
+    prompt_fragment_id: execute_to_end
+    operations_executed: ['update_state', 'seed_pre_pr_inspection_template']
+  - recorded_at: "2026-06-16T23:31:09.976273Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: transition
+    from_state: EXECUTE
+    transition_event: finish_execute
+    to_state: END
+    outcome: allowed
+    prompt_fragment_id: execute_to_end
+    operations_executed: ['update_state', 'seed_pre_pr_inspection_template']

--- a/cleanrooms/247-opencode-host-support/run_trace.yaml
+++ b/cleanrooms/247-opencode-host-support/run_trace.yaml
@@ -1,0 +1,273 @@
+events:
+  - recorded_at: "2026-06-16T22:19:19.649135Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: IDLE
+    sensor_category: runtime
+    gate: issue_selected_or_created
+    verdict: APPROVED
+    authority: "cleanrooms/247-opencode-host-support/.iq.state.yaml"
+    prompt_fragment_id: idle_to_analyze
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T22:19:19.650296Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: IDLE
+    sensor_category: runtime
+    gate: feature_branch_selected
+    verdict: APPROVED
+    authority: "git:branch"
+    prompt_fragment_id: idle_to_analyze
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T22:19:20.857295Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: tool_activity
+    phase: ANALYZE
+    transition_event: start_analyze
+    tool_class: gh
+    command_family: issue_view
+    outcome: succeeded
+    authority: "cleanrooms/247-opencode-host-support/issue.md"
+    prompt_fragment_id: idle_to_analyze
+    operations_executed: ['open_analysis_context']
+  - recorded_at: "2026-06-16T22:19:20.916819Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: transition
+    from_state: IDLE
+    transition_event: start_analyze
+    to_state: ANALYZE
+    outcome: allowed
+    prompt_fragment_id: idle_to_analyze
+    operations_executed: ['update_state', 'open_analysis_context', 'reset_mutations', 'snapshot_metrics']
+  - recorded_at: "2026-06-16T22:20:01.886376Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: model_activity
+    phase: ANALYZE
+    ape_name: socrates
+    model_surface: prompt_input
+    prompt_characters: 9526
+    prompt_lines: 150
+    prompt_utf8_bytes: 9536
+    estimated_input_tokens: 2382
+    token_estimate_basis: chars_div_4_ceil
+    assembly_duration_seconds: 0.001
+    sub_state: clarification
+    prompt_fragment_id: idle_to_analyze
+  - recorded_at: "2026-06-16T23:22:22.606629Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: ANALYZE
+    sensor_category: runtime
+    gate: issue_selected_or_created
+    verdict: APPROVED
+    authority: "cleanrooms/247-opencode-host-support/.iq.state.yaml"
+    prompt_fragment_id: analyze_to_plan
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T23:22:22.607679Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: ANALYZE
+    sensor_category: pre_transition
+    gate: diagnosis_exists
+    verdict: APPROVED
+    authority: "cleanrooms/247-opencode-host-support/analyze/diagnosis.md"
+    prompt_fragment_id: analyze_to_plan
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T23:22:22.611408Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: ANALYZE
+    sensor_category: pre_transition
+    gate: diagnosis_structured
+    verdict: APPROVED
+    authority: "cleanrooms/247-opencode-host-support/analyze/diagnosis.md"
+    prompt_fragment_id: analyze_to_plan
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T23:22:22.612722Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: ANALYZE
+    sensor_category: pre_transition
+    gate: diagnosis_evidence_present
+    verdict: APPROVED
+    authority: "assets/fsm/transition_contract.yaml"
+    prompt_fragment_id: analyze_to_plan
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T23:22:22.615085Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: ANALYZE
+    sensor_category: pre_transition
+    gate: index_exists
+    verdict: APPROVED
+    authority: "cleanrooms/247-opencode-host-support/analyze/index.md"
+    prompt_fragment_id: analyze_to_plan
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T23:22:22.616670Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: ANALYZE
+    sensor_category: pre_transition
+    gate: confirmations_exists
+    verdict: APPROVED
+    authority: "cleanrooms/247-opencode-host-support/analyze/confirmations.md"
+    prompt_fragment_id: analyze_to_plan
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T23:22:22.665686Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: tool_activity
+    phase: ANALYZE
+    transition_event: complete_analysis
+    tool_class: git
+    command_family: add
+    outcome: succeeded
+    exit_code: 0
+    authority: "cleanrooms/247-opencode-host-support/analyze"
+    prompt_fragment_id: analyze_to_plan
+    operations_executed: ['validate_transition', 'create_boundary_commit']
+  - recorded_at: "2026-06-16T23:22:22.783660Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: tool_activity
+    phase: ANALYZE
+    transition_event: complete_analysis
+    tool_class: git
+    command_family: commit
+    outcome: succeeded
+    exit_code: 0
+    authority: "cleanrooms/247-opencode-host-support/analyze"
+    prompt_fragment_id: analyze_to_plan
+    operations_executed: ['validate_transition', 'create_boundary_commit']
+  - recorded_at: "2026-06-16T23:22:22.784660Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: ANALYZE
+    sensor_category: pre_transition
+    gate: commit_analysis_boundary
+    verdict: APPROVED
+    authority: "cleanrooms/247-opencode-host-support/analyze"
+    prompt_fragment_id: analyze_to_plan
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T23:22:22.996232Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: phase_timing
+    phase: ANALYZE
+    started_at: "2026-06-16T22:19:19.845682Z"
+    ended_at: "2026-06-16T23:22:22.854152Z"
+    duration_seconds: 3783.008
+    prompt_fragment_id: analyze_to_plan
+    operations_executed: ['update_state']
+  - recorded_at: "2026-06-16T23:22:22.996792Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: transition
+    from_state: ANALYZE
+    transition_event: complete_analysis
+    to_state: PLAN
+    outcome: allowed
+    prompt_fragment_id: analyze_to_plan
+    operations_executed: ['update_state']
+  - recorded_at: "2026-06-16T23:25:09.153651Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: PLAN
+    sensor_category: runtime
+    gate: issue_selected
+    verdict: APPROVED
+    authority: "cleanrooms/247-opencode-host-support/.iq.state.yaml"
+    prompt_fragment_id: plan_to_execute
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T23:25:09.153651Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: PLAN
+    sensor_category: runtime
+    gate: feature_branch_selected
+    verdict: APPROVED
+    authority: "git:branch"
+    prompt_fragment_id: plan_to_execute
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T23:25:09.156092Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: PLAN
+    sensor_category: pre_transition
+    gate: plan_approved
+    verdict: APPROVED
+    authority: "cleanrooms/247-opencode-host-support/plan.md"
+    prompt_fragment_id: plan_to_execute
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T23:25:09.189579Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: tool_activity
+    phase: PLAN
+    transition_event: approve_plan
+    tool_class: git
+    command_family: add
+    outcome: succeeded
+    exit_code: 0
+    authority: "cleanrooms/247-opencode-host-support/plan.md"
+    prompt_fragment_id: plan_to_execute
+    operations_executed: ['validate_transition', 'create_boundary_commit']
+  - recorded_at: "2026-06-16T23:25:09.271671Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: tool_activity
+    phase: PLAN
+    transition_event: approve_plan
+    tool_class: git
+    command_family: commit
+    outcome: succeeded
+    exit_code: 0
+    authority: "cleanrooms/247-opencode-host-support/plan.md"
+    prompt_fragment_id: plan_to_execute
+    operations_executed: ['validate_transition', 'create_boundary_commit']
+  - recorded_at: "2026-06-16T23:25:09.273248Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: sensor_run
+    phase: PLAN
+    sensor_category: pre_transition
+    gate: commit_plan_boundary
+    verdict: APPROVED
+    authority: "cleanrooms/247-opencode-host-support/plan.md"
+    prompt_fragment_id: plan_to_execute
+    operations_executed: ['validate_transition', 'validate_prechecks']
+  - recorded_at: "2026-06-16T23:25:09.456161Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: phase_timing
+    phase: PLAN
+    started_at: "2026-06-16T23:22:22.994693Z"
+    ended_at: "2026-06-16T23:25:09.335406Z"
+    duration_seconds: 166.34
+    prompt_fragment_id: plan_to_execute
+    operations_executed: ['update_state']
+  - recorded_at: "2026-06-16T23:25:09.457162Z"
+    task_id: "247"
+    branch: 247-opencode-host-support
+    event_class: transition
+    from_state: PLAN
+    transition_event: approve_plan
+    to_state: EXECUTE
+    outcome: allowed
+    prompt_fragment_id: plan_to_execute
+    operations_executed: ['update_state']

--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.0]
+### Added
+- **OpenCode host support** (#247): `iq host get --host opencode` now deploys the `research`, `legion`, and `kritik` skills plus the `inquiry` agent (as an OpenCode `mode: primary` agent) into `~/.config/opencode/`. A new `HostAdapter.deploysAgent` capability lets a host opt into agent deployment; OpenCode opts in while Copilot stays skills-only. Verified against the real `opencode` CLI (`opencode agent list` shows `inquiry`).
+
 ## [0.7.7]
 ### Fixed
 - **Issue-linked branch enforcement**: `feature_branch_selected` and boundary commits now require a branch that actually matches the active issue prefix, so `start_analyze` and later phase boundaries no longer accept arbitrary non-main branches as valid explicit-start handoff context

--- a/code/cli/assets/agents/inquiry.opencode.md
+++ b/code/cli/assets/agents/inquiry.opencode.md
@@ -1,0 +1,91 @@
+---
+description: 'Inquiry — a strict FSM scheduler for structured task delivery. Dispatches sub-agents as thinking tools. User approval only at state completion gates.'
+mode: primary
+---
+
+# Inquiry Scheduler — Firmware v0.4.2
+You are a **scheduler**. You operate a dual FSM (main + per-APE). You never think, analyze, plan, or implement yourself — sub-agents do that. You orchestrate via CLI commands only.
+## Invariant (EVERY turn, no exceptions)
+You have NO memory of state between turns. Before responding to ANY user message — even conversational — you MUST:
+
+1. Run `iq fsm state --json`
+2. If the command fails with "not found" or "not recognized": the CLI is not installed. Run `iq init`, or install manually (see `inquiry-install` skill). **Stop here.**
+3. If the command fails with any other error: run `iq doctor` and resolve every failing check before proceeding.
+4. If `.inquiry/` does not exist (state read returns init error): run `iq init`, then re-read state.
+
+You are NOT allowed to respond to task requests without a successful state read. This is non-negotiable.
+
+## Boot (first message of a session only)
+After the Invariant succeeds, on the **first turn** of a new session:
+
+1. Run `iq doctor` — resolve any failing diagnostic before continuing.
+2. Parse the state JSON:
+   - `state`: current FSM state
+   - `issue`: active issue number (null when no cycle is active)
+   - `instructions`: mission description for the current state
+   - `transitions[]`: valid FSM events from this state
+   - `completion_authority`: `"user"` or `"automatic"`
+   - `ape`: active sub-agent `{name, state, transitions[]}` or null
+3. Enter Outer Loop.
+
+## Outer Loop (Main FSM)
+1. Announce state: `[INQUIRY]`
+2. Read `instructions` — this describes what the current state does
+3. If `ape` is active AND `ape.state` is NOT `_DONE`: enter Inner Loop **immediately**
+4. If `ape` is active AND `ape.state` IS `_DONE`: enter Completion Gate
+5. If `ape` is null: follow `instructions` directly — execute the state's actions yourself
+6. After transition: re-run `iq fsm state --json` and loop
+
+## Completion Gate (post-deliverable transition gate)
+This gate fires ONCE per state, ONLY after the sub-agent reaches `_DONE`. It is a post-deliverable transition gate, not the only place where user interaction may occur. It is TWO separate operations with a mandatory pause between them.
+
+**Step A — Mark sub-agent done:**
+```
+iq ape transition --event complete
+```
+This moves the APE to `_DONE`. The deliverable (diagnosis.md, plan.md, etc.) is now produced.
+
+**Step B — User reviews deliverable:**
+Read `completion_authority` from the state JSON:
+- If `"user"`: **STOP.** Present the deliverable summary. Ask ONE yes/no: "Approve [deliverable] and transition?" — then WAIT. Do NOT run the FSM transition until the user explicitly says yes.
+- If `"automatic"`: proceed to Step C immediately.
+
+**Step C — Transition main FSM:**
+```
+iq fsm transition --event <event>
+```
+
+**CRITICAL:** Steps A and C are NEVER executed in the same turn when `completion_authority` is `"user"`. The user MUST see the deliverable and confirm before C runs.
+
+## IDLE Handoff
+- explicit create/select intent only changes TRIAGE routing inside IDLE; issue readiness stays in IDLE/TRIAGE and produces `issue_selected_or_created`
+- `issue_selected_or_created` is a handoff marker, not an `iq ape transition` event; remain in IDLE and wait for explicit start intent
+- only explicit start intent reaches `_DONE`
+- only explicit start intent triggers inquiry-start plus start_analyze
+- `feature_branch_selected` is produced by `inquiry-start`, not by `iq ape transition`
+- `inquiry-start` first produces `feature_branch_selected`, then `iq fsm transition --event start_analyze` may leave IDLE
+
+## ANALYZE Visibility Rule
+ANALYZE must remain visible to the user. While the FSM state is ANALYZE, the scheduler must surface the active dialogue in chat, let the user answer and refine the investigation in real time, and must not hide analysis interaction behind the Completion Gate.
+
+## Inner Loop (Per-APE FSM)
+Dispatch is **unconditional and immediate**. When you enter the Inner Loop, execute steps 1–2 without asking, narrating, or confirming.
+
+1. Run `iq ape prompt --name <ape.name>` to inspect the exact effective sub-agent prompt (APE identity + phase-owned operational contract + inquiry-context). Treat that output as the complete runtime prompt surface; do not invent hidden glue or recover missing procedure from the APE YAML.
+2. **Dispatch** that sub-agent: use the `agent` tool to invoke a generic/current sub-agent path with the prompt as full context. Do NOT set `agentName` from `ape.name`; omit `agentName` unless the runtime explicitly exposes an invocable generic helper that is independent of APE identity. Do NOT perform the sub-agent's work yourself. Do NOT announce what the sub-agent will do. If the active phase contract requires visible interaction, surface that interaction directly in chat instead of hiding it behind a later gate.
+3. Wait for the sub-agent to signal completion (it will announce its sub-phase is done).
+4. When signaled: if the marker is `issue_selected_or_created` or `feature_branch_selected`, handle it per IDLE Handoff and do NOT run `iq ape transition`; otherwise run `iq ape transition --event <event>`.
+5. If `ape.state` becomes `_DONE`: exit Inner Loop, enter Completion Gate.
+6. If `ape.state` is NOT `_DONE`: re-run step 1 (new prompt for new sub-phase) and dispatch again — no confirmation needed.
+
+## Rules
+
+- **NEVER** write to `.inquiry/` directly. All mutations go through `iq` commands.
+- **ALWAYS** run `iq fsm state --json` before acting. You are blind without it.
+- **NEVER** ask "should I dispatch?", "should I start?", or "want me to proceed?". Dispatch is mechanical.
+- **NEVER** narrate the process. Do not say "the next step is..." or "I will now...". Execute.
+- During ANALYZE, keep the investigation visible in chat; do not collapse user interaction into the completion gate.
+- **NEVER** combine `iq ape transition --event complete` and `iq fsm transition` in the same turn when authority is `"user"`.
+- If a command fails, report the error and offer retry.
+- If you are unsure of your state, run `iq fsm state --json`; complete one sub-phase at a time before transitioning.
+- Do not enumerate states, transitions, or sub-agent names from memory. Read them from the CLI output.

--- a/code/cli/lib/hosts/all_adapters.dart
+++ b/code/cli/lib/hosts/all_adapters.dart
@@ -16,5 +16,5 @@ final List<HostAdapter> allAdapters = [
 ];
 
 /// Adapters that receive deploys in the current version.
-/// For v0.0.x only Copilot is active (D20).
-final List<HostAdapter> deployAdapters = [CopilotAdapter()];
+/// Copilot deploys skills; OpenCode deploys skills + the inquiry agent (#247, D1).
+final List<HostAdapter> deployAdapters = [CopilotAdapter(), OpenCodeAdapter()];

--- a/code/cli/lib/hosts/deployer.dart
+++ b/code/cli/lib/hosts/deployer.dart
@@ -33,6 +33,7 @@ class HostDeployer {
     clean();
     final selected = adapters.firstWhere((a) => a.name == hostName);
     _deploySkills(selected);
+    if (selected.deploysAgent) _deployAgent(selected);
   }
 
   /// Removes all deployed files from **all** adapter directories.
@@ -53,6 +54,14 @@ class HostDeployer {
       hostFile.parent.createSync(recursive: true);
       hostFile.writeAsStringSync(content);
     }
+  }
+
+  /// Deploys the inquiry agent (OpenCode-tailored) to the host's agent dir as `inquiry.md`.
+  void _deployAgent(HostAdapter adapter) {
+    final content = assets.loadString('agents/inquiry.opencode.md');
+    final hostFile = File(p.join(adapter.agentDirectory(homeDir), 'inquiry.md'));
+    hostFile.parent.createSync(recursive: true);
+    hostFile.writeAsStringSync(content);
   }
 
   void _deleteDirectory(String path) {

--- a/code/cli/lib/hosts/host_adapter.dart
+++ b/code/cli/lib/hosts/host_adapter.dart
@@ -19,6 +19,12 @@ abstract class HostAdapter {
   /// Whether this host's base directory exists on disk.
   bool exists(String homeDir) => Directory(baseDirectory(homeDir)).existsSync();
 
+  /// Whether `host get` should also deploy the inquiry agent to this host.
+  ///
+  /// Most hosts receive skills only; the inquiry agent is repo-scoped via
+  /// `iq init`. Hosts that expose a global agent directory (OpenCode) opt in.
+  bool get deploysAgent => false;
+
   /// Names of other hosts that make this one redundant.
   ///
   /// When any listed target exists, this adapter should be skipped

--- a/code/cli/lib/hosts/opencode_adapter.dart
+++ b/code/cli/lib/hosts/opencode_adapter.dart
@@ -17,4 +17,7 @@ class OpenCodeAdapter extends HostAdapter {
   @override
   String agentDirectory(String homeDir) =>
       p.join(homeDir, '.config', 'opencode', 'agents');
+
+  @override
+  bool get deploysAgent => true;
 }

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.7.7';
+const String inquiryVersion = '0.8.0';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.7.7
+version: 0.8.0
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/deployer_test.dart
+++ b/code/cli/test/deployer_test.dart
@@ -256,6 +256,55 @@ void main() {
       );
     });
   });
+
+  group('agent deploy (deploysAgent capability)', () {
+    setUp(() {
+      File(p.join(tempDir.path, 'assets', 'agents', 'inquiry.opencode.md'))
+          .writeAsStringSync('---\nmode: primary\n---\n# Inquiry');
+    });
+
+    test('deploys inquiry.md when the host opts in', () {
+      final agentDeployer = HostDeployer(
+        assets: assets,
+        adapters: [_AgentHostAdapter()],
+        homeDir: homeDir.path,
+      );
+
+      agentDeployer.deployExclusive('agenthost');
+
+      final agentFile =
+          File(p.join(homeDir.path, '.agenthost', 'agents', 'inquiry.md'));
+      expect(agentFile.existsSync(), isTrue);
+      expect(agentFile.readAsStringSync(), contains('mode: primary'));
+    });
+
+    test('does not deploy an agent when the host opts out', () {
+      deployer.deployExclusive('fake'); // FakeAdapter.deploysAgent == false
+      expect(
+        Directory(p.join(homeDir.path, '.fake', 'agents')).existsSync(),
+        isFalse,
+      );
+    });
+  });
+}
+
+class _AgentHostAdapter extends HostAdapter {
+  @override
+  String get name => 'agenthost';
+
+  @override
+  String baseDirectory(String homeDir) => p.join(homeDir, '.agenthost');
+
+  @override
+  String skillsDirectory(String homeDir) =>
+      p.join(homeDir, '.agenthost', 'skills');
+
+  @override
+  String agentDirectory(String homeDir) =>
+      p.join(homeDir, '.agenthost', 'agents');
+
+  @override
+  bool get deploysAgent => true;
 }
 
 class _SecondFakeAdapter extends HostAdapter {

--- a/code/cli/test/hosts_test.dart
+++ b/code/cli/test/hosts_test.dart
@@ -53,12 +53,24 @@ void main() {
   });
 
   group('deployAdapters registry', () {
-    test('returns exactly 1 adapter', () {
-      expect(deployAdapters, hasLength(1));
+    test('returns copilot and opencode', () {
+      expect(deployAdapters, hasLength(2));
+      expect(
+        deployAdapters.map((a) => a.name),
+        containsAll(<String>['copilot', 'opencode']),
+      );
+    });
+  });
+
+  group('deploysAgent capability', () {
+    test('opencode opts into agent deploy', () {
+      final opencode = deployAdapters.firstWhere((a) => a.name == 'opencode');
+      expect(opencode.deploysAgent, isTrue);
     });
 
-    test('only contains copilot', () {
-      expect(deployAdapters.single.name, equals('copilot'));
+    test('copilot does not deploy the agent', () {
+      final copilot = deployAdapters.firstWhere((a) => a.name == 'copilot');
+      expect(copilot.deploysAgent, isFalse);
     });
   });
 }

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Currently available for GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.7.7</span>
+      <span class="badge">v0.8.0</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
Closes #247.

## What

Adds **OpenCode** as a deploy target so Inquiry can drive the FSM from OpenCode, with the `inquiry` agent and the `research` / `legion` / `kritik` skills available there.

- `iq host get --host opencode` deploys the 3 skills **and** the `inquiry` agent (as OpenCode `mode: primary`) into `~/.config/opencode/`.
- New `HostAdapter.deploysAgent` capability — OpenCode opts in; **Copilot stays skills-only (no regression)**.
- OpenCode-tailored agent asset `assets/agents/inquiry.opencode.md` (`mode: primary`; VSCode-only boot replaced with `iq init`).

## Decisions (from the #247 ANALYZE/PLAN cleanroom)
- **D1** Agent deploy is OpenCode-scoped (avoids regressing the Copilot contract).
- **D2** Agent emitted as `mode: primary` (faithful to its orchestrator role; activate/deactivate via OpenCode Tab/`switch_agent` + `disable`).

## Verification (evidence, not assertion)
- `dart test` → **440 passing** (incl. updated `hosts_test`/`deployer_test` and `version_sync_test`).
- Real `opencode` CLI: after `iq host get --host opencode`, `opencode agent list` shows **`inquiry (primary)`**; `~/.config/opencode/skills/{research,legion,kritik}/SKILL.md` present.
- `iq host get --host copilot` still deploys skills only (no agent).

## Release
- v0.8.0 (minor — additive feature). Bumps pubspec.yaml, version.dart, site badge; CHANGELOG entry added.

## Process note
This feature was produced by driving Inquiry's own FSM strictly (ANALYZE → PLAN → EXECUTE → END); the cleanroom artifacts (evidence-cited diagnosis, executable-verification plan) are included under `cleanrooms/247-opencode-host-support/`.