### PR TITLE
Evidence-verifiability discipline: ANALYZE + PLAN gates + benchmark grading (#244 #245 #246)

### DIFF
--- a/code/cli/assets/apes/descartes.yaml
+++ b/code/cli/assets/apes/descartes.yaml
@@ -29,7 +29,8 @@ base_prompt: |
   Produce a phased plan that is detailed enough to execute mechanically. Structure:
 
   - Phases with checkable sub-steps (`- [ ]`)
-  - Test definitions in pseudocode for each phase
+  - An executable acceptance check for each phase — a real test runner command
+    or a test-file reference, NOT pseudocode (the PLAN handoff gate enforces this)
   - Risk notes where applicable
   - Dependencies between phases
   - Explicit entry criteria, execution steps, and verification for every phase
@@ -41,7 +42,8 @@ base_prompt: |
   - Do not implement anything. Do not create code, tests, or deliverables.
   - Do not suggest transitions or next steps.
   - Iterate until the active planning contract says the plan is ready.
-  - Consider TDD applicability: which phases benefit from RED→GREEN?
+  - Apply TDD where a phase changes behavior: ship a failing (RED) executable
+    test as that phase's acceptance check before EXECUTE makes it pass (GREEN).
 
 states:
   decomposition:
@@ -72,8 +74,10 @@ states:
       - event: back
         to: ordering
     prompt: |
-      FOCUS: Verification. Define test definitions in pseudocode for each phase.
-      Consider TDD applicability: which phases benefit from RED→GREEN?
+      FOCUS: Verification. Give each phase an executable acceptance check — a test
+      runner command or a test-file reference, not pseudocode. The PLAN handoff
+      gate (plan_executable_checks) blocks until every phase carries one.
+      Where a phase changes behavior, write it as a failing (RED) test first.
 
   enumeration:
     description: "Review completeness — nothing omitted"

--- a/code/cli/assets/fsm/states/plan.yaml
+++ b/code/cli/assets/fsm/states/plan.yaml
@@ -17,7 +17,7 @@ constraints:
   - Every plan must include a final verification step that runs the full project test suite (all existing tests, not just phase-specific ones)
   - No code edits (belongs to EXECUTE)
   - Plan must reference diagnosis.md decisions
-  - Each phase must have verification criteria
+  - Each phase must have an executable verification check (a test runner command or test-file reference), not pseudocode; the plan_executable_checks gate enforces this at PLAN handoff
   - If a phase changes a shared interface/type shape, that phase must list both consumer sites and construction sites, plus the search method used to find the constructors
   - Plan must be approved by user before transitioning
 

--- a/code/cli/assets/fsm/transition_contract.yaml
+++ b/code/cli/assets/fsm/transition_contract.yaml
@@ -110,7 +110,7 @@ transitions:
     to: PLAN
     allowed: true
     operations:
-      prechecks: [issue_selected_or_created, diagnosis_exists, diagnosis_structured, diagnosis_evidence_present, index_exists, confirmations_exists]
+      prechecks: [issue_selected_or_created, diagnosis_exists, diagnosis_structured, diagnosis_evidence_present, diagnosis_evidence_verifiable, index_exists, confirmations_exists]
       effects: [generate_plan]
       artifacts: [plan.md]
       commit_policy: commit_analysis_boundary
@@ -441,6 +441,9 @@ preconditions:
     kind: document-structure
   diagnosis_evidence_present:
     description: "diagnosis.md Evidence section contains concrete observed evidence and not only the bootstrap placeholder before PLAN handoff"
+    kind: document-content
+  diagnosis_evidence_verifiable:
+    description: "every diagnosis.md Evidence bullet carries a re-checkable handle (file:line, URL, or inline-code command/test id) so each claim can be reopened and verified"
     kind: document-content
   index_exists:
     description: "index.md exists for current issue analysis corpus"

--- a/code/cli/assets/fsm/transition_contract.yaml
+++ b/code/cli/assets/fsm/transition_contract.yaml
@@ -185,7 +185,7 @@ transitions:
     to: EXECUTE
     allowed: true
     operations:
-      prechecks: [issue_selected, feature_branch_selected, plan_approved]
+      prechecks: [issue_selected, feature_branch_selected, plan_approved, plan_executable_checks]
       effects: [prepare_execute]
       artifacts: [execution_log.md]
       commit_policy: commit_plan_boundary
@@ -231,7 +231,7 @@ transitions:
     to: EXECUTE
     allowed: true
     operations:
-      prechecks: [issue_selected, feature_branch_selected, plan_approved]
+      prechecks: [issue_selected, feature_branch_selected, plan_approved, plan_executable_checks]
       effects: [prepare_execute]
       artifacts: [execution_log.md]
       commit_policy: branch_required
@@ -463,6 +463,9 @@ preconditions:
   plan_approved:
     description: "User approved plan"
     kind: user-approval
+  plan_executable_checks:
+    description: "plan.md verifies phases with executable checks (test runner command or test-file reference), not pseudocode; at least one overall and at least one per phase"
+    kind: document-content
   pr_created:
     description: "Pull request exists for issue branch"
     kind: github

--- a/code/cli/lib/modules/fsm/commands/transition.dart
+++ b/code/cli/lib/modules/fsm/commands/transition.dart
@@ -773,6 +773,30 @@ class StateTransitionCommand
       );
     }
 
+    if (prechecks.contains('diagnosis_evidence_verifiable')) {
+      if (!_diagnosisEvidenceIsVerifiable(branch, workingDirectory)) {
+        _recordPrecheckSensor(
+          executor,
+          currentState: currentState,
+          precheck: 'diagnosis_evidence_verifiable',
+          verdict: 'INVALID',
+          branch: branch,
+          issue: issue,
+          promptFragmentId: promptFragmentId,
+        );
+        return 'ERROR_PRECONDITION_DIAGNOSIS_EVIDENCE_UNVERIFIABLE: every diagnosis.md Evidence bullet must carry a re-checkable handle (a file:line reference, a URL, or an inline-code command/test id) so each claim can be reopened and verified';
+      }
+      _recordPrecheckSensor(
+        executor,
+        currentState: currentState,
+        precheck: 'diagnosis_evidence_verifiable',
+        verdict: 'APPROVED',
+        branch: branch,
+        issue: issue,
+        promptFragmentId: promptFragmentId,
+      );
+    }
+
     if (prechecks.contains('index_exists')) {
       if (!_analysisIndexExists(branch, workingDirectory)) {
         _recordPrecheckSensor(
@@ -972,6 +996,41 @@ class StateTransitionCommand
     return normalizedLines.any(
       (line) => line.toLowerCase() != _diagnosisEvidenceBootstrapPlaceholder,
     );
+  }
+
+  bool _diagnosisEvidenceIsVerifiable(String branch, String workingDirectory) {
+    final content = _readDiagnosisContent(branch, workingDirectory);
+    if (content == null) return false;
+
+    final evidenceBody = _diagnosisSectionBody(
+      content,
+      _diagnosisSectionPatterns['Evidence']!,
+    );
+    if (evidenceBody == null) return false;
+
+    final bullets = evidenceBody
+        .split('\n')
+        .map(_normalizeDiagnosisSectionLine)
+        .where((line) => line.isNotEmpty)
+        .where(
+          (line) =>
+              line.toLowerCase() != _diagnosisEvidenceBootstrapPlaceholder,
+        )
+        .toList(growable: false);
+    if (bullets.isEmpty) return false;
+
+    return bullets.every(_evidenceLineHasVerifiableHandle);
+  }
+
+  /// A re-checkable evidence handle: a URL, a `file:line` reference, or an
+  /// inline-code span (a command, test id, or backtick-quoted path).
+  bool _evidenceLineHasVerifiableHandle(String line) {
+    final url = RegExp(r'https?://\S+');
+    final fileLine = RegExp(r'[\w./\\-]+\.[A-Za-z0-9]+:\d+');
+    final inlineCode = RegExp('`[^`]+`');
+    return url.hasMatch(line) ||
+        fileLine.hasMatch(line) ||
+        inlineCode.hasMatch(line);
   }
 
   String? _readDiagnosisContent(String branch, String workingDirectory) {

--- a/code/cli/lib/modules/fsm/commands/transition.dart
+++ b/code/cli/lib/modules/fsm/commands/transition.dart
@@ -869,6 +869,30 @@ class StateTransitionCommand
       );
     }
 
+    if (prechecks.contains('plan_executable_checks')) {
+      if (!_planHasExecutableChecks(branch, workingDirectory)) {
+        _recordPrecheckSensor(
+          executor,
+          currentState: currentState,
+          precheck: 'plan_executable_checks',
+          verdict: 'INVALID',
+          branch: branch,
+          issue: issue,
+          promptFragmentId: promptFragmentId,
+        );
+        return 'ERROR_PRECONDITION_PLAN_CHECKS_NOT_EXECUTABLE: plan.md must verify phases with executable checks (a test runner command or a test-file reference), not pseudocode; provide at least one executable check, and at least one per phase';
+      }
+      _recordPrecheckSensor(
+        executor,
+        currentState: currentState,
+        precheck: 'plan_executable_checks',
+        verdict: 'APPROVED',
+        branch: branch,
+        issue: issue,
+        promptFragmentId: promptFragmentId,
+      );
+    }
+
     if (prechecks.contains('pre_pr_inspection_approved')) {
       PrePrInspectionRunner(
         workingDirectory: workingDirectory,
@@ -950,12 +974,14 @@ class StateTransitionCommand
         return 'git:branch';
       case 'diagnosis_exists':
       case 'diagnosis_structured':
+      case 'diagnosis_evidence_verifiable':
         return p.posix.join('cleanrooms', branch, 'analyze', 'diagnosis.md');
       case 'index_exists':
         return p.posix.join('cleanrooms', branch, 'analyze', 'index.md');
       case 'confirmations_exists':
         return p.posix.join('cleanrooms', branch, 'analyze', 'confirmations.md');
       case 'plan_approved':
+      case 'plan_executable_checks':
         return p.posix.join('cleanrooms', branch, 'plan.md');
       case 'pre_pr_inspection_approved':
         return p.posix.join('cleanrooms', branch, 'pre_pr_inspection.md');
@@ -1044,6 +1070,44 @@ class StateTransitionCommand
       'diagnosis.md',
     );
     final file = File(diagnosisPath);
+    if (!file.existsSync()) return null;
+    return file.readAsStringSync();
+  }
+
+  /// Whether plan.md verifies its work with executable checks rather than
+  /// pseudocode: at least one executable handle overall, and — when the plan
+  /// is organized in phases — at least as many handles as phase headings.
+  bool _planHasExecutableChecks(String branch, String workingDirectory) {
+    final content = _readPlanContent(branch, workingDirectory);
+    if (content == null) return false;
+
+    final lines = content.split('\n');
+    final phaseHeading = RegExp(r'^#{2,4}\s+.*\bphase\b', caseSensitive: false);
+    final phaseCount = lines.where(phaseHeading.hasMatch).length;
+    final handleCount = lines.where(_planLineHasExecutableHandle).length;
+
+    if (handleCount == 0) return false;
+    return handleCount >= phaseCount;
+  }
+
+  /// An executable verification handle: a test-runner command in inline code,
+  /// or a reference to a test file/dir.
+  bool _planLineHasExecutableHandle(String line) {
+    final runner = RegExp(
+      r'`[^`]*\b(?:dart test|flutter test|npm (?:test|run)|pytest|go test|cargo test|mocha|jest)\b[^`]*`',
+      caseSensitive: false,
+    );
+    final testFile = RegExp(
+      r'(?:_test\.\w+|\.test\.\w+|_spec\.\w+|(?:^|[\s/`])test/)',
+      caseSensitive: false,
+    );
+    return runner.hasMatch(line) || testFile.hasMatch(line);
+  }
+
+  String? _readPlanContent(String branch, String workingDirectory) {
+    if (branch.isEmpty) return null;
+    final planPath = p.join(workingDirectory, 'cleanrooms', branch, 'plan.md');
+    final file = File(planPath);
     if (!file.existsSync()) return null;
     return file.readAsStringSync();
   }

--- a/code/cli/scripts/benchmark-fullflow-gemma4.ps1
+++ b/code/cli/scripts/benchmark-fullflow-gemma4.ps1
@@ -8,10 +8,57 @@ param(
   [int]$RunTimeoutSec = 600,
   [int]$RunTimeoutSecH = 0,
   [int]$RunTimeoutSecF = 0,
-  [switch]$NonInteractiveBenchmark
+  [switch]$NonInteractiveBenchmark,
+  [switch]$GradeTests
 )
 
 $ErrorActionPreference = "Stop"
+
+# --- Verifiable-artifact grading (#246) -------------------------------------
+# These grade what the cycle PRODUCED (reopenable evidence, executable plan
+# checks, a green suite) rather than only that the flow moved. Same handle
+# definitions as the ANALYZE/PLAN gates (#244/#245).
+
+function Test-EvidenceVerifiable {
+  param([string]$DiagnosisPath)
+  if (-not (Test-Path $DiagnosisPath)) { return $false }
+  $inEvidence = $false
+  $bullets = @()
+  foreach ($line in (Get-Content -Path $DiagnosisPath)) {
+    if ($line -match '^##?\s+Evidence\b') { $inEvidence = $true; continue }
+    if ($inEvidence -and $line -match '^#{1,6}\s') { break }
+    if ($inEvidence) {
+      $t = $line.Trim()
+      if ($t -match '^[-*]\s+') { $bullets += ($t -replace '^[-*]\s+', '') }
+    }
+  }
+  if ($bullets.Count -eq 0) { return $false }
+  $handle = '(https?://|[\w./\\-]+\.[A-Za-z0-9]+:\d+|`[^`]+`)'
+  foreach ($b in $bullets) { if ($b -notmatch $handle) { return $false } }
+  return $true
+}
+
+function Test-PlanExecutable {
+  param([string]$PlanPath)
+  if (-not (Test-Path $PlanPath)) { return $false }
+  $lines = Get-Content -Path $PlanPath
+  $phaseCount = ($lines | Where-Object { $_ -match '^#{2,4}\s+.*\bphase\b' }).Count
+  $runner = '`[^`]*\b(dart test|flutter test|npm (test|run)|pytest|go test|cargo test|mocha|jest)\b[^`]*`'
+  $testFile = '(_test\.\w+|\.test\.\w+|_spec\.\w+|(^|[\s/`])test/)'
+  $handleCount = ($lines | Where-Object { $_ -match $runner -or $_ -match $testFile }).Count
+  if ($handleCount -eq 0) { return $false }
+  return ($handleCount -ge $phaseCount)
+}
+
+function Test-SuiteGreen {
+  param([string]$CliRoot)
+  try {
+    Push-Location $CliRoot
+    $out = & dart test 2>&1 | Out-String
+    return ($out -match 'All tests passed!')
+  } catch { return $false }
+  finally { Pop-Location }
+}
 
 function Invoke-GhJson {
   param(
@@ -668,6 +715,22 @@ $hResult = Invoke-CopilotRun -ModeName 'h' -Prompt $hPrompt -Token 'FULLFLOW_H_O
 Write-Host "Running F benchmark (freestyle)..."
 $fResult = Invoke-CopilotRun -ModeName 'f' -Prompt $fPrompt -Token 'FULLFLOW_F_OK' -LogPath $fLog -MaxAttempts 2 -RunTimeoutSec $RunTimeoutSecF
 
+# Grade the artifacts the cycle produced — the PRIMARY result (#246).
+$diagnosisForGrading = Join-Path $cleanroomDir 'diagnosis.md'
+$planForGrading = Join-Path (Split-Path $cleanroomDir -Parent) 'plan.md'
+$cliRootForGrading = Split-Path $PSScriptRoot -Parent
+$diagnosisVerifiable = Test-EvidenceVerifiable -DiagnosisPath $diagnosisForGrading
+$planExecutable = Test-PlanExecutable -PlanPath $planForGrading
+$testsGreen = if ($GradeTests) { Test-SuiteGreen -CliRoot $cliRootForGrading } else { $null }
+$verifiableArtifacts = [pscustomobject]@{
+  diagnosisEvidenceVerifiable = $diagnosisVerifiable
+  planHasExecutableChecks = $planExecutable
+  testsGreen = $testsGreen
+  # "verifiable" requires reopenable evidence + an executable plan, and a green
+  # suite when graded. A cycle that only emits its success token is NOT verifiable.
+  verifiable = ($diagnosisVerifiable -and $planExecutable -and ($testsGreen -ne $false))
+}
+
 $summary = [pscustomobject]@{
   generatedAt = (Get-Date).ToString('o')
   workspace = (Resolve-Path $Workspace).Path
@@ -676,13 +739,17 @@ $summary = [pscustomobject]@{
   branch = $BranchName
   model = $Model
   providerBaseUrl = $ProviderBaseUrl
+  verifiableArtifacts = $verifiableArtifacts
   results = @($hResult, $fResult)
 }
 
 $summary | ConvertTo-Json -Depth 8 | Set-Content -Path $summaryPath -Encoding UTF8
 
 Write-Host ""
-Write-Host "Full-flow benchmark summary"
+Write-Host "Verifiable artifacts (primary result):"
+$verifiableArtifacts | Format-List diagnosisEvidenceVerifiable, planHasExecutableChecks, testsGreen, verifiable
+Write-Host ""
+Write-Host "Flow movement (secondary):"
 $summary.results | Format-Table mode, exitCode, reachedIDLE, reachedANALYZE, reachedPLAN, reachedEXECUTE, reachedEND, toolCalls, totalApiDurationMs, sessionDurationMs, premiumRequests -AutoSize
 Write-Host ""
 Write-Host "Summary JSON: $summaryPath"

--- a/code/cli/test/fsm_transition_integration_test.dart
+++ b/code/cli/test/fsm_transition_integration_test.dart
@@ -315,7 +315,7 @@ void _writeDiagnosis(String root, String branch, String content) {
 void _writePlan(String root, String branch, String content) {
   final file = File(p.join(root, 'cleanrooms', branch, 'plan.md'));
   file.createSync(recursive: true);
-  file.writeAsStringSync(content);
+  file.writeAsStringSync('$content\n## Verification\n- `dart test`\n');
 }
 
 void _writePrePrInspection(String root, String branch, {required String verdict}) {

--- a/code/cli/test/fsm_transition_integration_test.dart
+++ b/code/cli/test/fsm_transition_integration_test.dart
@@ -299,7 +299,7 @@ void _writeDiagnosis(String root, String branch, String content) {
     '# Diagnosis\n'
     '\n'
     '## Evidence\n'
-    '$content\n'
+    '- $content (`lib/example.dart:1`)\n'
     '\n'
     '## Hypotheses\n'
     '- Working hypothesis\n'

--- a/code/cli/test/fsm_transition_test.dart
+++ b/code/cli/test/fsm_transition_test.dart
@@ -586,6 +586,44 @@ void main() {
     });
 
     test(
+      'fails precheck when plan verifies phases without executable checks',
+      () async {
+        const branch = '51-idle-execution-guardrails';
+        _initGitRepo(tempDir.path, branch: branch);
+        _writeState(tempDir.path, 'PLAN', issue: '51');
+        File(p.join(tempDir.path, 'cleanrooms', branch, 'plan.md'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '# Plan\n\n'
+            '## Phase 1 — implement the thing\n'
+            '- Step: write the code\n'
+            '- Verification: confirm it works by reading the diff\n',
+          );
+
+        final output = await StateTransitionCommand(
+          StateTransitionInput(
+            currentState: null,
+            event: 'approve_plan',
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => branch,
+        ).execute();
+
+        expect(output.allowed, isFalse);
+        expect(
+          output.message,
+          contains('ERROR_PRECONDITION_PLAN_CHECKS_NOT_EXECUTABLE'),
+        );
+
+        final traceContent = File(
+          p.join(tempDir.path, 'cleanrooms', branch, 'run_trace.yaml'),
+        ).readAsStringSync();
+        expect(traceContent, contains('gate: plan_executable_checks'));
+        expect(traceContent, contains('verdict: INVALID'));
+      },
+    );
+
+    test(
       'transitions PLAN -> EXECUTE only after plan boundary commit',
       () async {
         const branch = '51-idle-execution-guardrails';
@@ -1506,7 +1544,7 @@ void _writeConfirmations(String root, String branch) {
 void _writePlan(String root, String branch, String content) {
   final file = File(p.join(root, 'cleanrooms', branch, 'plan.md'));
   file.createSync(recursive: true);
-  file.writeAsStringSync(content);
+  file.writeAsStringSync('$content\n## Verification\n- `dart test`\n');
 }
 
 void _writePrePrInspection(

--- a/code/cli/test/fsm_transition_test.dart
+++ b/code/cli/test/fsm_transition_test.dart
@@ -234,6 +234,91 @@ void main() {
       },
     );
 
+    test(
+      'fails precheck when diagnosis evidence has no verifiable handle',
+      () async {
+        const branch = '51-idle-execution-guardrails';
+        _initGitRepo(tempDir.path, branch: branch);
+        _writeState(tempDir.path, 'ANALYZE', issue: '51');
+        _writeAnalyzeIndex(tempDir.path, branch);
+        _writeConfirmations(tempDir.path, branch);
+        final diagnosisFile = File(
+          p.join(tempDir.path, 'cleanrooms', branch, 'analyze', 'diagnosis.md'),
+        )..createSync(recursive: true);
+        // Evidence is concrete prose but cites no re-checkable handle
+        // (no file:line, URL, or inline code).
+        diagnosisFile.writeAsStringSync(
+          '# Diagnosis\n\n'
+          '## Evidence\n'
+          '- Observed that the benchmark run did not reach the END state.\n\n'
+          '## Hypotheses\n'
+          '- Working hypothesis\n\n'
+          '## Constraints\n'
+          '- No additional constraints\n\n'
+          '## Open Questions\n'
+          '- None\n',
+        );
+
+        final output = await StateTransitionCommand(
+          StateTransitionInput(
+            currentState: null,
+            event: 'complete_analysis',
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => branch,
+        ).execute();
+
+        expect(output.allowed, isFalse);
+        expect(
+          output.message,
+          contains('ERROR_PRECONDITION_DIAGNOSIS_EVIDENCE_UNVERIFIABLE'),
+        );
+
+        final traceContent = File(
+          p.join(tempDir.path, 'cleanrooms', branch, 'run_trace.yaml'),
+        ).readAsStringSync();
+        expect(traceContent, contains('gate: diagnosis_evidence_verifiable'));
+        expect(traceContent, contains('verdict: INVALID'));
+      },
+    );
+
+    test(
+      'passes when each evidence bullet carries a verifiable handle',
+      () async {
+        const branch = '51-idle-execution-guardrails';
+        _initGitRepo(tempDir.path, branch: branch);
+        _writeState(tempDir.path, 'ANALYZE', issue: '51');
+        _writeAnalyzeIndex(tempDir.path, branch);
+        _writeConfirmations(tempDir.path, branch);
+        final diagnosisFile = File(
+          p.join(tempDir.path, 'cleanrooms', branch, 'analyze', 'diagnosis.md'),
+        )..createSync(recursive: true);
+        diagnosisFile.writeAsStringSync(
+          '# Diagnosis\n\n'
+          '## Evidence\n'
+          '- OpenCode adapter paths match the docs — `lib/hosts/opencode_adapter.dart:10`.\n'
+          '- OpenCode docs confirm the skill path — https://opencode.ai/docs/skills/.\n\n'
+          '## Hypotheses\n'
+          '- Working hypothesis\n\n'
+          '## Constraints\n'
+          '- No additional constraints\n\n'
+          '## Open Questions\n'
+          '- None\n',
+        );
+
+        final output = await StateTransitionCommand(
+          StateTransitionInput(
+            currentState: null,
+            event: 'complete_analysis',
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => branch,
+        ).execute();
+
+        expect(output.allowed, isTrue);
+      },
+    );
+
     test('records retry trace when a blocked ANALYZE handoff is attempted again', () async {
       const branch = '51-idle-execution-guardrails';
       _initGitRepo(tempDir.path, branch: branch);
@@ -1391,7 +1476,7 @@ void _writeDiagnosis(String root, String branch, String content) {
     '# Diagnosis\n'
     '\n'
     '## Evidence\n'
-    '$content\n'
+    '- $content (`lib/example.dart:1`)\n'
     '\n'
     '## Hypotheses\n'
     '- Hypothesis placeholder\n'

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -4,17 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Inquiry — Analyze. Plan. Execute.</title>
-  <meta name="description" content="Inquiry is a philosophical and methodological framework for AI-assisted software work: Analyze. Plan. Execute. Thinking tools made operational for GitHub Copilot.">
+  <meta name="description" content="Inquiry is a philosophical and methodological framework for AI-assisted software work: Analyze. Plan. Execute. Thinking tools made operational for OpenCode and GitHub Copilot.">
   <meta name="theme-color" content="#0a0e1a">
 
   <meta property="og:title" content="Inquiry — Analyze. Plan. Execute.">
-  <meta property="og:description" content="A philosophical and methodological framework for AI-assisted software work. Thinking tools made operational for GitHub Copilot.">
+  <meta property="og:description" content="A philosophical and methodological framework for AI-assisted software work. Thinking tools made operational for OpenCode and GitHub Copilot.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://inquiry.ccisne.dev/">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Inquiry — Analyze. Plan. Execute.">
-  <meta name="twitter:description" content="A philosophical and methodological framework for AI-assisted software work. Thinking tools made operational for GitHub Copilot.">
+  <meta name="twitter:description" content="A philosophical and methodological framework for AI-assisted software work. Thinking tools made operational for OpenCode and GitHub Copilot.">
 
   <link rel="icon" type="image/svg+xml" href="img/favicon.svg">
 
@@ -30,7 +30,7 @@
     <header>
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
-      <p class="secondary-tagline">Currently available for GitHub Copilot. More hosts coming soon.</p>
+      <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
       <span class="badge">v0.8.0</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
@@ -38,7 +38,6 @@
         <div class="os-tabs" role="tablist" aria-label="Operating system">
           <button class="os-tab" role="tab" aria-selected="true" aria-controls="panel-windows" id="tab-windows" onclick="switchTab('windows')">Windows</button>
           <button class="os-tab" role="tab" aria-selected="false" aria-controls="panel-linux" id="tab-linux" onclick="switchTab('linux')">Linux</button>
-          <button class="os-tab" role="tab" aria-selected="false" disabled title="Coming soon">macOS<span class="soon-tag">soon</span></button>
         </div>
         <div id="panel-windows" class="os-panel" role="tabpanel" aria-labelledby="tab-windows">
           <div class="install-block">
@@ -99,7 +98,7 @@
       <pre class="quickstart"><span class="comment"># verify prerequisites (inquiry, git, gh, gh auth)</span>
 <span class="cmd">iq doctor</span>
 
-<span class="comment"># deploy Inquiry skills to your AI host (Copilot today)</span>
+<span class="comment"># deploy Inquiry skills to your AI host (OpenCode or Copilot)</span>
 <span class="cmd">iq host get</span>
 
 <span class="comment"># scaffold .inquiry/ in your repo</span>
@@ -125,6 +124,7 @@
       <h2>Hosts</h2>
       <p>Inquiry deploys host-scoped skills to the global configuration of your AI coding tool. The repo-scoped agent is scaffolded by <code>iq init</code>.</p>
       <ul class="targets">
+        <li class="target-badge"><span class="dot"></span>OpenCode</li>
         <li class="target-badge"><span class="dot"></span>GitHub Copilot</li>
         <li class="target-badge future"><span class="dot"></span>Claude Code</li>
         <li class="target-badge future"><span class="dot"></span>Codex</li>


### PR DESCRIPTION
Closes #244, closes #245, closes #246.

Three evidence-discipline improvements, each with TDD, plus a site docs refresh. The unifying thesis: trust transfers to the verifier, not the phase — so each phase boundary now forces its output into re-checkable evidence.

## #244 — ANALYZE: `diagnosis_evidence_verifiable` gate
`complete_analysis` now blocks unless **every** diagnosis.md Evidence bullet carries a re-checkable handle (a `file:line` reference, a URL, or an inline-code command/test id). Non-emptiness is no longer enough — narration without a reopenable handle is rejected.
- `transition.dart`: `_diagnosisEvidenceIsVerifiable` + handle detection; new precheck → `ERROR_PRECONDITION_DIAGNOSIS_EVIDENCE_UNVERIFIABLE`
- contract: precheck added to `complete_analysis` + description

## #245 — PLAN: `plan_executable_checks` gate
PLAN→EXECUTE (`approve_plan` / `go_execute`) now blocks unless plan.md verifies phases with **executable** checks (a test-runner command or test-file reference), not pseudocode. Heuristic: ≥1 handle overall and ≥1 per phase heading.
- `transition.dart`: `_planHasExecutableChecks` + new precheck → `ERROR_PRECONDITION_PLAN_CHECKS_NOT_EXECUTABLE`
- `descartes.yaml` / `plan.yaml`: pseudocode → executable acceptance check; "Consider TDD" promoted to "ship a failing (RED) test"

## #246 — Benchmark: grade verifiable artifacts
`summary.json` gains a `verifiableArtifacts` block as the **primary** result (`diagnosisEvidenceVerifiable`, `planHasExecutableChecks`, `testsGreen`, `verifiable`); tool counts/states/durations demoted to a secondary "flow movement" view. A cycle that only emits its success token is **not** verifiable.

## Site docs
OpenCode listed first and marked available (tagline, hosts list, meta); removed the future "macOS soon" tab.

## Verification (evidence, not assertion)
- **CLI (Dart): 443 passing** — incl. new RED/GREEN tests for both gates; fixtures updated to carry handles/executable checks.
- **VS Code (TS): 79 passing** (`npm run test:unit`).
- #246 grading functions smoke-tested on good/bad fixtures; the PowerShell script parses clean.

## Notes
- Self-dogfooding: the #247 ANALYZE/PLAN cleanroom already satisfied both new gates by construction.
- No version bump in this PR (gates are additive contract changes); a release can be cut separately.
- #244 scope note: confirmations.md per-finding evidence trace is a documented follow-up within #244.