### PR TITLE
release: v0.9.0 — evidence-verifiability gates

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.9.0]
+### Added
+- **Evidence-verifiability gates** (#244, #245): two new ANALYZE/PLAN handoff prechecks tighten the methodology so trust transfers to the verifier, not the phase.
+  - `diagnosis_evidence_verifiable`: `complete_analysis` blocks unless every `diagnosis.md` Evidence bullet carries a re-checkable handle (a `file:line` reference, a URL, or an inline-code command/test id). Non-emptiness is no longer sufficient.
+  - `plan_executable_checks`: PLAN→EXECUTE (`approve_plan`/`go_execute`) blocks unless `plan.md` verifies its phases with executable checks (a test-runner command or test-file reference) rather than pseudocode — at least one overall and at least one per phase. DESCARTES guidance promotes "Consider TDD" to shipping a failing (RED) test as each phase's acceptance check.
+
+### Changed
+- **Benchmark grades verifiable artifacts** (#246): `benchmark-fullflow-*` `summary.json` now reports a `verifiableArtifacts` block (`diagnosisEvidenceVerifiable`, `planHasExecutableChecks`, `testsGreen`, `verifiable`) as the primary result; tool counts, states, and durations are demoted to a secondary "flow movement" view. A cycle that only emits its success token is not verifiable.
+- **Site**: OpenCode is listed first and marked available; the future "macOS soon" install tab was removed.
+
 ## [0.8.0]
 ### Added
 - **OpenCode host support** (#247): `iq host get --host opencode` now deploys the `research`, `legion`, and `kritik` skills plus the `inquiry` agent (as an OpenCode `mode: primary` agent) into `~/.config/opencode/`. A new `HostAdapter.deploysAgent` capability lets a host opt into agent deployment; OpenCode opts in while Copilot stays skills-only. Verified against the real `opencode` CLI (`opencode agent list` shows `inquiry`).

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.8.0';
+const String inquiryVersion = '0.9.0';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.8.0
+version: 0.9.0
 
 environment:
   sdk: ^3.8.1

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.8.0</span>
+      <span class="badge">v0.9.0</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
Release of the evidence-verifiability work merged in #249 (closed #244/#245/#246).

- Bumps all three version sources to **0.9.0** (pubspec.yaml, version.dart, site badge — `version_sync_test` green).
- CHANGELOG `[0.9.0]`: `diagnosis_evidence_verifiable` (#244), `plan_executable_checks` (#245), benchmark `verifiableArtifacts` grading (#246), site host reorder.

Minor bump: additive gates with new runtime behavior, consistent with 0.8.0 (OpenCode).

Verification: CLI 443 passing, VS Code 79 passing.