### PR TITLE
docs(site): align host status with current state (OpenCode + Copilot)

### DIFF
--- a/code/site/ape-builds-ape.html
+++ b/code/site/ape-builds-ape.html
@@ -147,7 +147,7 @@
         </dd>
         <dt>3. A test matrix across hosts</dt>
         <dd>
-          Single-host MVP today (Copilot). Adapters exist for Claude Code, Codex, Crush, and Gemini per <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/spec/host-specific-agents.md">ADR D20</a>, but aren't wired in. The <em>methodology &gt; model</em> thesis demands comparison across hosts — ideally including a local 7B — to be testable at all.
+          Two hosts wired in today — OpenCode and Copilot. OpenCode unlocks the local-model comparison the thesis demands (e.g. <code>qwen3-coder</code> via Ollama). Adapters for Claude Code, Codex, Crush, and Gemini exist per <a href="https://github.com/ccisnedev/inquiry/blob/main/docs/spec/host-specific-agents.md">ADR D20</a> but aren't wired in yet. The <em>methodology &gt; model</em> thesis demands comparison across hosts to be testable at all.
         </dd>
       </dl>
     </section>

--- a/code/site/install.ps1
+++ b/code/site/install.ps1
@@ -9,7 +9,7 @@
 #   3. Extracts to $env:LOCALAPPDATA\inquiry\
 #   4. Adds inquiry\bin\ to the user PATH
 #   5. Creates `iq.cmd` batch shim
-#   6. Runs `inquiry host get` for the active host (Copilot today)
+#   6. Runs `inquiry host get` for the active host (OpenCode or Copilot)
 #   7. Verifies with `inquiry version`
 
 $ErrorActionPreference = 'Stop'

--- a/code/site/install.sh
+++ b/code/site/install.sh
@@ -10,7 +10,7 @@
 #   3. Extracts to ~/.inquiry/
 #   4. Symlinks to ~/.local/bin (XDG standard, in default PATH)
 #   5. Symlinks `iq` alias
-#   6. Runs `inquiry host get` for the active host (Copilot today)
+#   6. Runs `inquiry host get` for the active host (OpenCode or Copilot)
 #   7. Verifies with `inquiry version`
 
 set -euo pipefail


### PR DESCRIPTION
Brings `site/` present-tense claims in line with the repo after OpenCode host support shipped (v0.8.0) and the v0.9.0 verifiability release.

- **ape-builds-ape.html** (current-state "limitations" section): "Single-host MVP today (Copilot)" → two hosts wired today (OpenCode + Copilot); notes OpenCode unlocks the local-model comparison the *methodology > model* thesis needs. Historical v0.0.x narrative stages untouched.
- **install.ps1 / install.sh**: header comment "Copilot today" → "OpenCode or Copilot".

The `index.html` host reorder + macOS-tab removal + 0.9.0 badge already landed in #249/#250. Agent roster (DEWEY/SOCRATES/DESCARTES/ADA/DARWIN) and other pages audited — no remaining stale host/version claims. `site_test` green.