### PR TITLE
docs(site): document the verifiability gates in methodology

### DIFF
--- a/code/site/methodology.html
+++ b/code/site/methodology.html
@@ -54,10 +54,10 @@
           <dd>Bounded issue triage. DEWEY determines whether the situation is ready to become or select a GitHub issue; <code>inquiry-start</code> performs the explicit handoff into ANALYZE.</dd>
 
           <dt><code>ANALYZE</code> · SOCRATES</dt>
-          <dd>Clarifies the problem through dialog. Produces <code>diagnosis.md</code>.</dd>
+          <dd>Clarifies the problem through dialog. Produces <code>diagnosis.md</code>. The handoff gate requires every Evidence bullet to carry a re-checkable handle — a <code>file:line</code>, URL, or inline-code reference — so each claim can be reopened, not just asserted.</dd>
 
           <dt><code>PLAN</code> · DESCARTES</dt>
-          <dd>Divide, order, verify, enumerate. Produces <code>plan.md</code>.</dd>
+          <dd>Divide, order, verify, enumerate. Produces <code>plan.md</code>, where every phase must carry an <em>executable</em> acceptance check (a test-runner command or a test file), not pseudocode.</dd>
 
           <dt><code>EXECUTE</code> · ADA</dt>
           <dd>Programming as explicit construction under a coding manifesto. Produces code and commits.</dd>
@@ -83,6 +83,7 @@
     <span class="key">event</span>: complete_analysis
     <span class="key">prechecks</span>:
       - diagnosis_exists
+      - diagnosis_evidence_verifiable  <span class="comment"># every Evidence bullet has a re-checkable handle</span>
       - issue_linked
     <span class="key">effects</span>:
       - set_state: PLAN


### PR DESCRIPTION
Adds a brief, precise description of the v0.9.0 verifiability gates to the methodology page, closing the doc gap noted after #249/#250.

- **ANALYZE** entry: the handoff gate requires every Evidence bullet to carry a re-checkable handle (`file:line`, URL, or inline-code) so claims can be reopened, not just asserted.
- **PLAN** entry: every phase must carry an *executable* acceptance check (test command or test file), not pseudocode.
- **Transition-contract excerpt**: adds the `diagnosis_evidence_verifiable` precheck to the ANALYZE→PLAN example.

`site_test` green.