### PR TITLE
fix(idle): local-model triage guidance + release v0.10.0 (#236)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.10.0]
+### Fixed
+- **Local-model IDLE triage drift** (#236): hardened IDLE guidance so local models (e.g. gemma4/qwen via Ollama) stop drifting on command/event names. The IDLE state contract, the `issue-create` instruction, and both inquiry agent firmwares (Copilot + OpenCode) now state that `issue_selected_or_created` is a readiness report token (not an `iq fsm transition` event), require using only the events returned by `iq fsm state --json`, and forbid unsupported `gh issue list` flags such as `--no-defaults`.
+
 ## [0.9.0]
 ### Added
 - **Evidence-verifiability gates** (#244, #245): two new ANALYZE/PLAN handoff prechecks tighten the methodology so trust transfers to the verifier, not the phase.

--- a/code/cli/assets/agents/inquiry.agent.md
+++ b/code/cli/assets/agents/inquiry.agent.md
@@ -65,6 +65,7 @@ iq fsm transition --event <event>
 - only explicit start intent triggers inquiry-start plus start_analyze
 - `feature_branch_selected` is produced by `inquiry-start`, not by `iq ape transition`
 - `inquiry-start` first produces `feature_branch_selected`, then `iq fsm transition --event start_analyze` may leave IDLE
+- use only events listed in `iq fsm state --json` for the active state
 
 ## ANALYZE Visibility Rule
 ANALYZE must remain visible to the user. While the FSM state is ANALYZE, the scheduler must surface the active dialogue in chat, let the user answer and refine the investigation in real time, and must not hide analysis interaction behind the Completion Gate.

--- a/code/cli/assets/agents/inquiry.opencode.md
+++ b/code/cli/assets/agents/inquiry.opencode.md
@@ -64,6 +64,7 @@ iq fsm transition --event <event>
 - only explicit start intent triggers inquiry-start plus start_analyze
 - `feature_branch_selected` is produced by `inquiry-start`, not by `iq ape transition`
 - `inquiry-start` first produces `feature_branch_selected`, then `iq fsm transition --event start_analyze` may leave IDLE
+- use only events listed in `iq fsm state --json` for the active state
 
 ## ANALYZE Visibility Rule
 ANALYZE must remain visible to the user. While the FSM state is ANALYZE, the scheduler must surface the active dialogue in chat, let the user answer and refine the investigation in real time, and must not hide analysis interaction behind the Completion Gate.

--- a/code/cli/assets/fsm/states/idle.yaml
+++ b/code/cli/assets/fsm/states/idle.yaml
@@ -9,7 +9,9 @@ instructions: |
   IDLE owns that fast-path routing contract: triage_objective=create_or_select, deterministic_skill=issue-create, allowed_commands=gh issue list, gh issue view, gh issue create, gh issue edit.
   Inquiry CLI injects that routing contract into the assembled prompt as explicit inquiry-context.
   When issue readiness is reached, produce issue_selected_or_created, reset DEWEY, and remain in IDLE.
+  issue_selected_or_created is a readiness report token, not an iq fsm transition event.
   DONE is reached only on explicit start intent; DONE consumes inquiry-start to prepare feature_branch_selected.
+  Use only transition events returned by `iq fsm state --json` for the current state.
   Only after that handoff may IDLE fire start_analyze.
   Run 'iq doctor' as first action to validate environment.
 

--- a/code/cli/assets/instructions/issue-create.md
+++ b/code/cli/assets/instructions/issue-create.md
@@ -48,6 +48,8 @@ gh issue list --state open --search "<keywords>" --limit 20
 ```
 
 Use the results to confirm whether an existing issue already captures the work.
+Use only documented `gh issue list` flags for the installed CLI version.
+Do not append compatibility-breaking flags such as `--no-defaults`.
 
 ### Step 3: Create the Issue if No Match Exists
 

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.9.0';
+const String inquiryVersion = '0.10.0';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.9.0
+version: 0.10.0
 
 environment:
   sdk: ^3.8.1

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.9.0</span>
+      <span class="badge">v0.10.0</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
Closes #236.

Completes the #236 fix on `main` — the original fix lived only on branch `236-local-model-idle-compat` (commit `87a6405`) and never merged.

## Fix
Local models (gemma4/qwen via Ollama) drifted in IDLE triage: unknown FSM event names and unsupported `gh issue list --no-defaults`. Guidance hardened in four places:
- **idle.yaml**: `issue_selected_or_created` is a readiness token (not an `iq fsm transition` event); use only events from `iq fsm state --json`.
- **issue-create.md**: use only documented `gh issue list` flags; no `--no-defaults`.
- **inquiry.agent.md** + **inquiry.opencode.md**: use only events listed in `iq fsm state --json` (firmware kept under its 90-line budget).

## Release v0.10.0
Bumps pubspec.yaml, version.dart, site badge; CHANGELOG `[0.10.0]`. The release workflow will publish the binaries now that Actions write permission is restored.

## Verification
CLI **443 passing**, VS Code **79 passing**.