### PR TITLE
fix(plan): recognize python & fenced executable checks (#245) [v0.10.1]

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.10.1]
+### Fixed
+- **PLAN executable-check gate too strict** (#245 follow-up): `plan_executable_checks` rejected valid `python` verification commands and any check written in a fenced code block — it only recognized a fixed runner list inside single-line inline backticks. The detector now recognizes `python -c` / `python -m` / `python file.py` invocations and matches runner commands whether fenced or inline, so plans that verify phases with real Python checks pass the ANALYZE→EXECUTE gate. Found while driving a real conducted Inquiry cycle on a local model.
+
 ## [0.10.0]
 ### Fixed
 - **Local-model IDLE triage drift** (#236): hardened IDLE guidance so local models (e.g. gemma4/qwen via Ollama) stop drifting on command/event names. The IDLE state contract, the `issue-create` instruction, and both inquiry agent firmwares (Copilot + OpenCode) now state that `issue_selected_or_created` is a readiness report token (not an `iq fsm transition` event), require using only the events returned by `iq fsm state --json`, and forbid unsupported `gh issue list` flags such as `--no-defaults`.

--- a/code/cli/lib/modules/fsm/commands/transition.dart
+++ b/code/cli/lib/modules/fsm/commands/transition.dart
@@ -1094,7 +1094,7 @@ class StateTransitionCommand
   /// or a reference to a test file/dir.
   bool _planLineHasExecutableHandle(String line) {
     final runner = RegExp(
-      r'`[^`]*\b(?:dart test|flutter test|npm (?:test|run)|pytest|go test|cargo test|mocha|jest)\b[^`]*`',
+      r'(?:dart test|flutter test|npm (?:test|run)|pytest|python3?\s+(?:-c|-m|[^\s`]+\.py)|go test|cargo test|mocha|jest)',
       caseSensitive: false,
     );
     final testFile = RegExp(

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.10.0';
+const String inquiryVersion = '0.10.1';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.10.0
+version: 0.10.1
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/fsm_transition_test.dart
+++ b/code/cli/test/fsm_transition_test.dart
@@ -624,6 +624,45 @@ void main() {
     );
 
     test(
+      'accepts python checks (fenced or inline) as executable verification',
+      () async {
+        const branch = '51-idle-execution-guardrails';
+        _initGitRepo(tempDir.path, branch: branch);
+        _writeState(tempDir.path, 'PLAN', issue: '51');
+        File(p.join(tempDir.path, 'cleanrooms', branch, 'plan.md'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync(
+            '# Plan\n\n'
+            '## Phase 1 — fix the function\n'
+            '- Step: edit the code\n'
+            '- Verification:\n'
+            '```bash\n'
+            'python -c "import mod; assert mod.f() == 1"\n'
+            '```\n\n'
+            '## Phase 2 — handle edge cases\n'
+            '- Step: add guards\n'
+            '- Verification: `python3 -m pytest tests/`\n',
+          );
+
+        final output = await StateTransitionCommand(
+          StateTransitionInput(
+            currentState: null,
+            event: 'approve_plan',
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => branch,
+        ).execute();
+
+        // The gate must recognize python -c / python -m as executable checks,
+        // whether in a fenced block or inline, and not reject the plan.
+        expect(
+          output.message,
+          isNot(contains('ERROR_PRECONDITION_PLAN_CHECKS_NOT_EXECUTABLE')),
+        );
+      },
+    );
+
+    test(
       'transitions PLAN -> EXECUTE only after plan boundary commit',
       () async {
         const branch = '51-idle-execution-guardrails';

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.10.0</span>
+      <span class="badge">v0.10.1</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
Follow-up bug fix to the #245 `plan_executable_checks` gate (shipped in v0.9.0).

## Bug
The gate only recognized a fixed runner list (`dart test`, `pytest`, …) **inside single-line inline backticks**. It therefore rejected:
- `python -c` / `python -m` verification commands (Python wasn't in the list), and
- any check written in a fenced ```` ```bash ```` block (multi-line, not inline).

Found in the field: while driving a real conducted Inquiry cycle on a local model (qwen3-coder via OpenCode), the agent produced a valid plan whose per-phase verifications were `python -c "..."` in fenced blocks — and the gate blocked `approve_plan`, stalling an otherwise-correct cycle.

## Fix
`_planLineHasExecutableHandle` now recognizes `python -c` / `python -m` / `python file.py` and matches runner commands whether fenced or inline. Pseudocode/prose-only plans are still rejected (the RED test still passes).

## Verification
CLI **444 passing** (new test: a plan with fenced + inline python checks passes the gate; the prose-only RED test still blocks). VS Code **79 passing**.

Patch release **v0.10.1**.