### PR TITLE
fix(host): OpenCode agent deployed to wrong dir — agent/ not agents/ (#247)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.10.2]
+### Fixed
+- **OpenCode agent deployed to the wrong directory** (#247 follow-up): `iq host get --host opencode` wrote the `inquiry` agent to `~/.config/opencode/agents/` (plural), but OpenCode discovers global agents in `~/.config/opencode/agent/` (singular). The deployed agent was therefore invisible to `opencode agent list`, and `opencode run --agent inquiry` silently **fell back to the default agent** — so the Inquiry firmware never actually ran on the OpenCode host. The adapter now targets the singular `agent/` directory (verified: `opencode agent list` shows `inquiry (primary)` against opencode 1.17.7). This corrects the [0.8.0] note, whose "verified against the real opencode CLI" claim did not hold for current OpenCode. A regression test now pins the singular path.
+
 ## [0.10.1]
 ### Fixed
 - **PLAN executable-check gate too strict** (#245 follow-up): `plan_executable_checks` rejected valid `python` verification commands and any check written in a fenced code block — it only recognized a fixed runner list inside single-line inline backticks. The detector now recognizes `python -c` / `python -m` / `python file.py` invocations and matches runner commands whether fenced or inline, so plans that verify phases with real Python checks pass the ANALYZE→EXECUTE gate. Found while driving a real conducted Inquiry cycle on a local model.

--- a/code/cli/lib/hosts/opencode_adapter.dart
+++ b/code/cli/lib/hosts/opencode_adapter.dart
@@ -14,9 +14,13 @@ class OpenCodeAdapter extends HostAdapter {
   String skillsDirectory(String homeDir) =>
       p.join(homeDir, '.config', 'opencode', 'skills');
 
+  // OpenCode discovers global agents in `~/.config/opencode/agent/` (singular).
+  // A plural `agents/` directory is ignored, so `opencode agent list` never sees
+  // the deployed agent and `opencode run --agent inquiry` silently falls back to
+  // the default agent (#247).
   @override
   String agentDirectory(String homeDir) =>
-      p.join(homeDir, '.config', 'opencode', 'agents');
+      p.join(homeDir, '.config', 'opencode', 'agent');
 
   @override
   bool get deploysAgent => true;

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.10.1';
+const String inquiryVersion = '0.10.2';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.10.1
+version: 0.10.2
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/hosts_test.dart
+++ b/code/cli/test/hosts_test.dart
@@ -1,3 +1,4 @@
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'package:inquiry_cli/hosts/all_adapters.dart';
@@ -59,6 +60,20 @@ void main() {
         deployAdapters.map((a) => a.name),
         containsAll(<String>['copilot', 'opencode']),
       );
+    });
+  });
+
+  group('OpenCode agent directory (regression #247)', () {
+    final opencode = deployAdapters.firstWhere((a) => a.name == 'opencode');
+
+    test('agentDirectory is the SINGULAR ~/.config/opencode/agent', () {
+      // OpenCode reads global agents from `agent/` (singular). A plural
+      // `agents/` is ignored, so the deployed agent is invisible to
+      // `opencode agent list` / `--agent inquiry`. Pin the singular form.
+      final parts = p.split(opencode.agentDirectory('/home/user'));
+      expect(parts.last, 'agent');
+      expect(parts.last, isNot('agents'));
+      expect(parts[parts.length - 2], 'opencode');
     });
   });
 

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.10.1</span>
+      <span class="badge">v0.10.2</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Problem

`iq host get --host opencode` deployed the `inquiry` agent to `~/.config/opencode/**agents**/` (plural), but OpenCode discovers global agents in `~/.config/opencode/**agent**/` (singular). The plural directory is ignored, so:

- `opencode agent list` never showed `inquiry`, and
- `opencode run --agent inquiry` **silently fell back to the default agent**.

Net effect: **the Inquiry firmware never actually ran on the OpenCode host.** Any prior OpenCode "harness" run that relied on `--agent inquiry` was effectively freestyle-with-a-prompt, not the harness. The FSM/CLI/gate layer (driven by `iq fsm transition`) still worked, but the scheduler-firmware + cognitive-operator layer did not.

This was found while preparing a genuinely-conducted H-vs-F experiment on a local model (`qwen3-coder:30b-16k` via OpenCode): the prior run log shows `! agent "inquiry" not found. Falling back to default agent`.

## Fix

- `opencode_adapter.dart`: `agentDirectory` now targets the singular `agent/`.
- Regression test in `hosts_test.dart` pinning the singular path so this can't silently regress.
- `CHANGELOG [0.10.2]` — also corrects the `[0.8.0]` note whose *"verified against the real opencode CLI"* claim did not hold for current OpenCode.
- Version sync bump to `0.10.2` (pubspec / `version.dart` / site badge).

## Verification

- `opencode agent list` now shows `inquiry (primary)` (opencode 1.17.7).
- `dart analyze` clean; full `dart test` suite green (**445 passing**, incl. the new regression test).