### PR TITLE
fix(doctor): make iq doctor host-aware (stateless), not hardcoded to copilot (#257)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.10.4]
+### Fixed
+- **`iq doctor` was blind to non-default hosts** (#257): doctor hardcoded the Copilot adapter, so after `iq host get --host opencode` (an *exclusive* deploy that cleans other hosts) it reported a misleading failure about Copilot's now-absent skills and never verified the OpenCode deployment at all. Doctor now checks every deploy-capable host, locates each host's agent correctly (Copilot repo-scoped `.github/agents/`, OpenCode global `~/.config/opencode/agent/inquiry.md`), and treats a non-active host as informational ("not deployed (inactive)") rather than a failure — passing when the active host is fully deployed and flagging "no host deployed" only when none is active. Removes the last hardcoded single-default-host assumption from the health path.
+
 ## [0.10.3]
 ### Changed
 - **Single-source agent firmware** (#247 follow-up): the inquiry agent firmware is now assembled from one shared body (`assets/agents/inquiry.body.md`) plus per-host frontmatter (`assets/agents/frontmatter/{copilot,opencode}.yaml`) via a new `AgentBuilder`, instead of two hand-maintained near-duplicate files (`inquiry.agent.md` + `inquiry.opencode.md`). The two had already drifted — the exact-literal output rule (0.10.2) had landed only on Copilot — and a single body makes that class of drift impossible. The only legitimate per-host differences (frontmatter schema and the install hint) are declared per host via `HostAdapter.agentFrontmatterAsset` / `agentSubstitutions`. Deployed filenames are unchanged (`.github/agents/inquiry.agent.md` for Copilot, `~/.config/opencode/agent/inquiry.md` for OpenCode), and the exact-literal rule now ships to both hosts.

--- a/code/cli/lib/modules/global/commands/doctor.dart
+++ b/code/cli/lib/modules/global/commands/doctor.dart
@@ -12,7 +12,7 @@ import 'package:path/path.dart' as p;
 import '../../../assets.dart';
 import '../../../src/version.dart' as version_lib;
 import '../../../src/version_check.dart';
-import '../../../hosts/copilot_adapter.dart';
+import '../../../hosts/all_adapters.dart';
 import '../../../hosts/host_adapter.dart';
 
 /// Function type for running external processes.
@@ -58,21 +58,30 @@ class HostCheck {
   final int totalSkills;
   final String? error;
 
+  /// Whether this host is the active/deployed one (its skills are present).
+  /// Under the exclusive deploy model exactly one host is active at a time; an
+  /// inactive host is not a failure (it was simply not the chosen host).
+  final bool active;
+
   HostCheck({
     required this.hostName,
     required this.agentExists,
     required this.missingSkills,
     required this.totalSkills,
     this.error,
+    this.active = true,
   });
 
-  bool get passed => agentExists && missingSkills.isEmpty && error == null;
+  /// An inactive host never fails the doctor; an active host must be complete.
+  bool get passed =>
+      !active || (agentExists && missingSkills.isEmpty && error == null);
 
   Map<String, dynamic> toJson() => {
     'hostName': hostName,
     'agentExists': agentExists,
     'missingSkills': missingSkills,
     'totalSkills': totalSkills,
+    'active': active,
     if (error != null) 'error': error,
   };
 }
@@ -137,6 +146,9 @@ class DoctorOutput extends Output {
       for (final tc in hostChecks) {
         if (tc.error != null) {
           buffer.writeln('  ✗ ${tc.hostName}: ${tc.error}');
+        } else if (!tc.active) {
+          // Not the active host — informational, not a failure.
+          buffer.writeln('  - ${tc.hostName}: not deployed (inactive)');
         } else if (tc.passed) {
           final deployed = tc.totalSkills - tc.missingSkills.length;
           buffer.writeln(
@@ -157,11 +169,17 @@ class DoctorOutput extends Output {
             // Only suggest host get when agent is already deployed
             if (tc.agentExists) {
               buffer.writeln(
-                "    → Run 'inquiry host get' to deploy skills",
+                "    → Run 'inquiry host get --host ${tc.hostName}' to deploy skills",
               );
             }
           }
         }
+      }
+      if (!hostChecks.any((hc) => hc.active)) {
+        buffer.writeln('  ✗ no host deployed');
+        buffer.writeln(
+          "    → Run 'inquiry host get --host <copilot|opencode>'",
+        );
       }
     }
 
@@ -224,7 +242,7 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
   }) : _runProcess = runProcess ?? Process.run,
        _fileSystem = fileSystemOps ?? RealFileSystemOps(),
        _assets = assets,
-       _activeAdapters = activeAdapters ?? [CopilotAdapter()],
+       _activeAdapters = activeAdapters ?? deployAdapters,
        _workingDirectory = workingDirectory ?? Directory.current.path,
        _versionChecker = versionChecker,
        inquiryVersion = inquiryVersionOverride ?? version_lib.inquiryVersion;
@@ -330,7 +348,9 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
       hostChecks.add(_verifyHost(adapter));
     }
 
-    final hostsPassed = hostChecks.every((hc) => hc.passed);
+    // At least one host must be active (deployed); inactive hosts never fail.
+    final anyActive = hostChecks.any((hc) => hc.active);
+    final hostsPassed = anyActive && hostChecks.every((hc) => hc.passed);
 
     return DoctorOutput(
       checks: checks,
@@ -365,8 +385,12 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
     final homeDir = _fileSystem.homeDirectory();
     final expectedSkills = _getExpectedSkills();
 
-    // Agent is repo-scoped — independent of which adapter is active
-    final agentExists = _verifyRepoAgent();
+    // Agent location is host-specific: hosts that deploy a global agent
+    // (OpenCode) keep it in their agent dir; others (Copilot) are repo-scoped.
+    final agentExists = adapter.deploysAgent
+        ? _fileSystem
+            .fileExists(p.join(adapter.agentDirectory(homeDir), 'inquiry.md'))
+        : _verifyRepoAgent();
 
     // Check skills — adapter-scoped
     final missingSkills = <String>[];
@@ -381,11 +405,19 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
       }
     }
 
+    // Active = this host's skills are deployed. Under the exclusive deploy
+    // model exactly one host is active; with no expected skills (assets
+    // unavailable) fall back to agent presence.
+    final active = expectedSkills.isEmpty
+        ? agentExists
+        : missingSkills.length < expectedSkills.length;
+
     return HostCheck(
       hostName: adapter.name,
       agentExists: agentExists,
       missingSkills: missingSkills,
       totalSkills: expectedSkills.length,
+      active: active,
     );
   }
 

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.10.3';
+const String inquiryVersion = '0.10.4';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.10.3
+version: 0.10.4
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/doctor_test.dart
+++ b/code/cli/test/doctor_test.dart
@@ -269,7 +269,7 @@ void main() {
       expect(json['checks'], isList);
       expect((json['checks'] as List).length, 5);
       expect(json['hostChecks'], isList);
-      expect((json['hostChecks'] as List).length, 1);
+      expect((json['hostChecks'] as List).length, 2);
 
       final firstCheck = (json['checks'] as List).first as Map<String, dynamic>;
       expect(firstCheck, containsPair('name', 'inquiry'));
@@ -322,14 +322,22 @@ void main() {
 
         expect(output.passed, isTrue);
         expect(output.exitCode, 0);
-        expect(output.hostChecks.length, 1);
-        expect(output.hostChecks.first.passed, isTrue);
-        expect(output.hostChecks.first.agentExists, isTrue);
-        expect(output.hostChecks.first.missingSkills, isEmpty);
+        expect(output.hostChecks.length, 2);
+        final copilot =
+            output.hostChecks.firstWhere((h) => h.hostName == 'copilot');
+        expect(copilot.active, isTrue);
+        expect(copilot.passed, isTrue);
+        expect(copilot.agentExists, isTrue);
+        expect(copilot.missingSkills, isEmpty);
+        // OpenCode is simply not the active host — not a failure.
+        final opencode =
+            output.hostChecks.firstWhere((h) => h.hostName == 'opencode');
+        expect(opencode.active, isFalse);
 
         final text = output.toText()!;
         expect(text, contains('Checking hosts...'));
         expect(text, contains('✓ copilot: agent + 9 skills deployed'));
+        expect(text, contains('- opencode: not deployed (inactive)'));
         expect(text, contains('All checks passed.'));
       });
 
@@ -343,14 +351,13 @@ void main() {
 
         expect(output.passed, isFalse);
         expect(output.exitCode, 1);
-        expect(output.hostChecks.first.agentExists, isFalse);
-        expect(output.hostChecks.first.missingSkills,
-            unorderedEquals(testSkills));
+        // No host has skills → none active.
+        expect(output.hostChecks.every((h) => !h.active), isTrue);
 
         final text = output.toText()!;
-        expect(text, contains('✗ copilot: agent not deployed'));
-        expect(text, contains('✗ copilot: missing skills:'));
-        expect(text, contains("Run 'inquiry init' to deploy agent"));
+        expect(text, contains('✗ no host deployed'));
+        expect(text,
+            contains("Run 'inquiry host get --host <copilot|opencode>'"));
         expect(text, contains('Some checks failed.'));
       });
 
@@ -373,8 +380,8 @@ void main() {
         final text = output.toText()!;
         expect(text, contains('✗ inquiry init'));
         expect(text, contains("Run 'inquiry init' to initialize"));
-        expect(text, contains('✗ copilot: agent not deployed'));
-        expect(text, contains("Run 'inquiry init' to deploy agent"));
+        // Nothing deployed → no active host.
+        expect(text, contains('✗ no host deployed'));
       });
 
       test('Scenario D: partial deployment → exit 1', () async {
@@ -408,13 +415,17 @@ void main() {
 
         expect(output.passed, isFalse);
         expect(output.exitCode, 1);
-        expect(output.hostChecks.first.agentExists, isTrue);
-        expect(output.hostChecks.first.missingSkills, ['issue-create']);
+        final copilot =
+            output.hostChecks.firstWhere((h) => h.hostName == 'copilot');
+        expect(copilot.active, isTrue);
+        expect(copilot.agentExists, isTrue);
+        expect(copilot.missingSkills, ['issue-create']);
 
         final text = output.toText()!;
         expect(text, contains('✓ copilot: agent deployed'));
         expect(text, contains('✗ copilot: missing skills: issue-create'));
-        expect(text, contains("Run 'inquiry host get' to deploy skills"));
+        expect(text,
+            contains("Run 'inquiry host get --host copilot' to deploy skills"));
       });
 
       test('HostCheck.toJson() includes all fields', () {
@@ -503,32 +514,76 @@ void main() {
             reason: 'Old global path is no longer valid — must run iq init');
       });
 
-      test('doctor remediation suggests "inquiry init" when agent is missing', () async {
+      test('doctor remediation suggests host get when no host is deployed', () async {
         final fs = MockFileSystemOps()..setHome(homeDir);
         fs.setDirectoryExists('.inquiry', true);
-        // No agent, no skills
+        // No agent, no skills → no active host
 
         final cmd = makeCmd(fs: fs);
         final output = await cmd.execute();
         final text = output.toText()!;
 
-        expect(text, contains("'inquiry init'"),
-          reason: 'Remediation must suggest iq init, not iq host get');
+        expect(text, contains('✗ no host deployed'));
+        expect(text, contains('inquiry host get --host'));
         expect(text, isNot(contains("'inquiry target get'")));
       });
 
-      test('agentExists is adapter-independent — it is repo-scoped', () async {
-        // Agent in repo, skills in copilot adapter
+      test('agent location is host-specific (Copilot repo-scoped, OpenCode global)', () async {
+        // Repo agent + copilot skills present; OpenCode global agent absent.
         final fs = allPassFs(workingDir, homeDir, testSkills);
         final cmd = makeCmd(fs: fs);
 
         final output = await cmd.execute();
 
-        // All hostChecks must have the same agentExists value
-        final allAgentExists =
-            output.hostChecks.map((c) => c.agentExists).toSet();
-        expect(allAgentExists, equals({true}),
-            reason: 'agentExists is repo-scoped — same for all adapters');
+        final copilot =
+            output.hostChecks.firstWhere((h) => h.hostName == 'copilot');
+        final opencode =
+            output.hostChecks.firstWhere((h) => h.hostName == 'opencode');
+        expect(copilot.agentExists, isTrue,
+            reason: 'Copilot agent is repo-scoped (.github/agents/)');
+        expect(opencode.agentExists, isFalse,
+            reason: 'OpenCode agent is global; not deployed in this fixture');
+      });
+
+      test('Scenario E: OpenCode active, Copilot inactive → exit 0 (regression #257)', () async {
+        final fs = MockFileSystemOps()..setHome(homeDir);
+        fs.setDirectoryExists('.inquiry', true);
+        // OpenCode fully deployed: global agent + skills.
+        fs.setFileExists(
+          p.join(homeDir, '.config', 'opencode', 'agent', 'inquiry.md'),
+          true,
+        );
+        for (final skill in testSkills) {
+          fs.setFileExists(
+            p.join(homeDir, '.config', 'opencode', 'skills', skill, 'SKILL.md'),
+            true,
+          );
+        }
+        // Copilot skills cleaned by the exclusive deploy; a repo agent lingers.
+        fs.setFileExists(
+          p.join(workingDir, '.github', 'agents', 'inquiry.agent.md'),
+          true,
+        );
+
+        final cmd = makeCmd(fs: fs);
+        final output = await cmd.execute();
+
+        expect(output.passed, isTrue,
+            reason: 'OpenCode is fully deployed → healthy');
+        expect(output.exitCode, 0);
+        final opencode =
+            output.hostChecks.firstWhere((h) => h.hostName == 'opencode');
+        expect(opencode.active, isTrue);
+        expect(opencode.passed, isTrue);
+        final copilot =
+            output.hostChecks.firstWhere((h) => h.hostName == 'copilot');
+        expect(copilot.active, isFalse,
+            reason: 'Copilot skills cleaned → inactive, not a failure');
+
+        final text = output.toText()!;
+        expect(text, contains('✓ opencode: agent + 9 skills deployed'));
+        expect(text, contains('- copilot: not deployed (inactive)'));
+        expect(text, contains('All checks passed.'));
       });
 
       test('no assets available → hosts still checked, 0 skills expected', () async {

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.10.3</span>
+      <span class="badge">v0.10.4</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
Closes #257.

## Problem

After `iq host get --host opencode`, `iq doctor` reported a failure — but about **Copilot**, and it never verified OpenCode at all:

```
> iq host get --host opencode
> iq doctor
  ✓ copilot: agent deployed
  ✗ copilot: missing skills: kritik, legion, research
Some checks failed.
```

The OpenCode deploy was actually correct; doctor was just blind to it. Root cause: `doctor.dart` hardcoded `CopilotAdapter`, and `host get` is *exclusive* (cleans other hosts) — so switching to OpenCode strips Copilot's skills, which doctor then flags. A leftover single-host-era assumption.

## Fix (design decided in #257: host-aware, stateless — keep one active host, make the CLI honest)

- Doctor checks **every deploy-capable host** (`deployAdapters`), not just Copilot.
- **Agent location is host-specific**: hosts that deploy a global agent (OpenCode → `~/.config/opencode/agent/inquiry.md`) are checked there; others (Copilot) stay repo-scoped (`.github/agents/`). Previously every host was checked at the repo path.
- **`HostCheck.active`**: the active host = the one whose skills are deployed. A non-active host is **informational** (`- copilot: not deployed (inactive)`), not a failure. Doctor passes when the active host is fully deployed; it flags `✗ no host deployed` only when none is active.
- Remediation names the host: `inquiry host get --host <name>`.

No new persisted state — the active host is detected from disk, matching the exclusive deploy model.

## TDD

- Rewrote the host-verification tests for the multi-host model and added **Scenario E** (regression for this bug): OpenCode active + Copilot inactive → `exit 0`, `✓ opencode...`, `- copilot: not deployed (inactive)`, *All checks passed*.

## QA (strict)

- `dart analyze` clean; full `dart test` **454 passing**.
- Verified live (0.10.4 binary) from a real repo with OpenCode deployed:
  ```
  Checking hosts...
    - copilot: not deployed (inactive)
    ✓ opencode: agent + 3 skills deployed
  All checks passed.
  ```
- Version bumped to **0.10.4** (pubspec / version.dart / site / CHANGELOG, in sync).