### PR TITLE
feat(doctor): fail when OpenCode/Ollama context (num_ctx) is too small (#259 part 1)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.10.5]
+### Added
+- **`iq doctor` verifies OpenCode/Ollama context size** (#259, part 1): when OpenCode is the active host, doctor reads the Ollama models from `opencode.jsonc`, queries each model's effective `num_ctx` (`ollama show <model> --modelfile`; absent ⇒ Ollama's 4096 default), and **fails** if any is below 16384. At 4096 the Inquiry firmware + OpenCode tool schemas (~8K tokens) are silently truncated and the harness never runs (the model hallucinates and never executes `iq fsm state`) — this now surfaces with remediation (bake a `num_ctx 16384`, 32768 recommended, variant). Auto-configuration in `iq host get` is tracked as #259 part 2.
+
 ## [0.10.4]
 ### Fixed
 - **`iq doctor` was blind to non-default hosts** (#257): doctor hardcoded the Copilot adapter, so after `iq host get --host opencode` (an *exclusive* deploy that cleans other hosts) it reported a misleading failure about Copilot's now-absent skills and never verified the OpenCode deployment at all. Doctor now checks every deploy-capable host, locates each host's agent correctly (Copilot repo-scoped `.github/agents/`, OpenCode global `~/.config/opencode/agent/inquiry.md`), and treats a non-active host as informational ("not deployed (inactive)") rather than a failure — passing when the active host is fully deployed and flagging "no host deployed" only when none is active. Removes the last hardcoded single-default-host assumption from the health path.

--- a/code/cli/lib/modules/global/commands/doctor.dart
+++ b/code/cli/lib/modules/global/commands/doctor.dart
@@ -3,6 +3,7 @@
 /// Checks: inquiry version, git, gh, gh auth, .inquiry/ init, host deployment.
 library;
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:cli_router/cli_router.dart';
@@ -194,7 +195,15 @@ abstract class FileSystemOps {
   bool fileExists(String path);
   bool directoryExists(String path);
   String homeDirectory();
+
+  /// Reads a text file, or returns null if it does not exist.
+  String? readFile(String path);
 }
+
+/// Minimum Ollama `num_ctx` for the Inquiry firmware + OpenCode tool schemas to
+/// fit (the assembled prompt measures ~7.3–7.9k tokens; a full cycle approaches
+/// 16k). 32768+ is recommended for long cycles.
+const int kInquiryMinNumCtx = 16384;
 
 /// Production implementation using dart:io.
 class RealFileSystemOps implements FileSystemOps {
@@ -210,6 +219,12 @@ class RealFileSystemOps implements FileSystemOps {
         Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'];
     if (home != null && home.isNotEmpty) return home;
     return Directory.current.path;
+  }
+
+  @override
+  String? readFile(String path) {
+    final f = File(path);
+    return f.existsSync() ? f.readAsStringSync() : null;
   }
 }
 
@@ -352,11 +367,143 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
     final anyActive = hostChecks.any((hc) => hc.active);
     final hostsPassed = anyActive && hostChecks.every((hc) => hc.passed);
 
+    // OpenCode + Ollama context check (only when OpenCode is the active host):
+    // a too-small num_ctx silently truncates the firmware and breaks the harness.
+    var ctxPassed = true;
+    final opencodeActive =
+        hostChecks.any((hc) => hc.hostName == 'opencode' && hc.active);
+    if (opencodeActive) {
+      final ctxCheck = await _checkOllamaContext();
+      if (ctxCheck != null) {
+        checks.add(ctxCheck);
+        if (!ctxCheck.passed) ctxPassed = false;
+      }
+    }
+
     return DoctorOutput(
       checks: checks,
       hostChecks: hostChecks,
-      passed: prereqPassed && hostsPassed,
+      passed: prereqPassed && hostsPassed && ctxPassed,
     );
+  }
+
+  /// Verifies every Ollama model configured for OpenCode has an effective
+  /// `num_ctx >= kInquiryMinNumCtx`. Returns a failing check if any is too
+  /// small, or null when there is nothing to verify (no config / no Ollama
+  /// provider / Ollama not installed).
+  Future<DoctorCheck?> _checkOllamaContext() async {
+    final cfgPath = p.join(
+      _fileSystem.homeDirectory(),
+      '.config',
+      'opencode',
+      'opencode.jsonc',
+    );
+    final raw = _fileSystem.readFile(cfgPath);
+    if (raw == null) return null;
+
+    final models = _ollamaModelsFromConfig(raw);
+    if (models.isEmpty) return null;
+
+    final tooSmall = <String>[];
+    for (final model in models) {
+      final ctx = await _effectiveNumCtx(model);
+      if (ctx == null) continue; // can't determine (Ollama absent) — skip
+      if (ctx < kInquiryMinNumCtx) tooSmall.add('$model (num_ctx=$ctx)');
+    }
+    if (tooSmall.isEmpty) return null;
+
+    return DoctorCheck(
+      name: 'opencode/ollama context',
+      passed: false,
+      error: 'num_ctx < $kInquiryMinNumCtx for: ${tooSmall.join(', ')}',
+      remediation:
+          "Inquiry's prompt needs ~8K tokens; at 4096 it is truncated and the "
+          "harness fails silently. Bake a variant — Modelfile 'FROM <model>\\n"
+          "PARAMETER num_ctx 16384' then 'ollama create <model>-16k -f Modelfile' "
+          "(32768 recommended) — and point opencode.jsonc at it. "
+          "Or run 'iq host get --host opencode' to configure it.",
+    );
+  }
+
+  /// Extracts the Ollama provider model names from opencode.jsonc (JSONC).
+  List<String> _ollamaModelsFromConfig(String raw) {
+    try {
+      final json = jsonDecode(_stripJsonComments(raw)) as Map<String, dynamic>;
+      final provider = json['provider'];
+      if (provider is! Map) return [];
+      final ollama = provider['ollama'];
+      if (ollama is! Map) return [];
+      final models = ollama['models'];
+      if (models is! Map) return [];
+      return models.keys.map((k) => k.toString()).toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// Effective `num_ctx` for an Ollama model: the Modelfile `PARAMETER num_ctx`
+  /// if set, else Ollama's 4096 default. Null if Ollama can't be queried.
+  Future<int?> _effectiveNumCtx(String model) async {
+    try {
+      final res = await _runProcess('ollama', ['show', model, '--modelfile']);
+      if (res.exitCode != 0) return null;
+      final out = res.stdout?.toString() ?? '';
+      final m = RegExp(
+        r'num_ctx\s+(\d+)',
+        caseSensitive: false,
+      ).firstMatch(out);
+      if (m != null) return int.tryParse(m.group(1)!) ?? 4096;
+      return 4096; // Ollama default when unset
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Strips `//` and `/* */` comments from JSONC, respecting string literals.
+  String _stripJsonComments(String s) {
+    final buf = StringBuffer();
+    var i = 0;
+    var inStr = false;
+    var esc = false;
+    while (i < s.length) {
+      final c = s[i];
+      if (inStr) {
+        buf.write(c);
+        if (esc) {
+          esc = false;
+        } else if (c == '\\') {
+          esc = true;
+        } else if (c == '"') {
+          inStr = false;
+        }
+        i++;
+        continue;
+      }
+      if (c == '"') {
+        inStr = true;
+        buf.write(c);
+        i++;
+        continue;
+      }
+      if (c == '/' && i + 1 < s.length && s[i + 1] == '/') {
+        i += 2;
+        while (i < s.length && s[i] != '\n') {
+          i++;
+        }
+        continue;
+      }
+      if (c == '/' && i + 1 < s.length && s[i + 1] == '*') {
+        i += 2;
+        while (i + 1 < s.length && !(s[i] == '*' && s[i + 1] == '/')) {
+          i++;
+        }
+        i += 2;
+        continue;
+      }
+      buf.write(c);
+      i++;
+    }
+    return buf.toString();
   }
 
   /// Discovers expected skills from the asset tree.

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.10.4';
+const String inquiryVersion = '0.10.5';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.10.4
+version: 0.10.5
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/doctor_test.dart
+++ b/code/cli/test/doctor_test.dart
@@ -10,11 +10,16 @@ import 'package:test/test.dart';
 class MockFileSystemOps implements FileSystemOps {
   final Map<String, bool> _files = {};
   final Map<String, bool> _dirs = {};
+  final Map<String, String> _contents = {};
   String _home = '/home/testuser';
 
   void setFileExists(String path, bool exists) => _files[path] = exists;
   void setDirectoryExists(String path, bool exists) => _dirs[path] = exists;
   void setHome(String home) => _home = home;
+  void setFileContents(String path, String content) {
+    _contents[path] = content;
+    _files[path] = true;
+  }
 
   @override
   bool fileExists(String path) => _files[path] ?? false;
@@ -24,6 +29,9 @@ class MockFileSystemOps implements FileSystemOps {
 
   @override
   String homeDirectory() => _home;
+
+  @override
+  String? readFile(String path) => _contents[path];
 }
 
 void main() {
@@ -33,12 +41,32 @@ void main() {
       bool gitFails = false,
       bool ghFails = false,
       bool ghAuthFails = false,
+      Map<String, int?>? ollamaCtx,
     }) {
       return (
         String executable,
         List<String> arguments, {
         String? workingDirectory,
       }) async {
+        // ollama show <model> --modelfile
+        if (executable == 'ollama' && arguments.contains('show')) {
+          final model = arguments.firstWhere(
+            (a) => a != 'show' && a != '--modelfile',
+            orElse: () => '',
+          );
+          final ctx = ollamaCtx?[model];
+          if (ctx == null) {
+            // No num_ctx PARAMETER → Ollama default (4096)
+            return ProcessResult(0, 0, 'FROM $model\n', '');
+          }
+          return ProcessResult(
+            0,
+            0,
+            'FROM $model\nPARAMETER num_ctx $ctx\n',
+            '',
+          );
+        }
+
         // git --version
         if (executable == 'git' && arguments.contains('--version')) {
           if (gitFails) {
@@ -602,6 +630,93 @@ void main() {
         expect(output.hostChecks.first.passed, isTrue);
 
         emptyTempDir.deleteSync(recursive: true);
+      });
+    });
+
+    group('OpenCode/Ollama context check (#259)', () {
+      const jsonc = '''
+{
+  // local Ollama provider
+  "\$schema": "https://opencode.ai/config.json",
+  "provider": { "ollama": { "models": {
+    "qwen3-coder:30b": {},
+    "qwen3-coder:30b-16k": {}
+  } } }
+}
+''';
+
+      // Filesystem where OpenCode is the active/deployed host.
+      MockFileSystemOps opencodeActiveFs() {
+        final fs = MockFileSystemOps()..setHome(homeDir);
+        fs.setDirectoryExists('.inquiry', true);
+        fs.setFileExists(
+          p.join(homeDir, '.config', 'opencode', 'agent', 'inquiry.md'),
+          true,
+        );
+        for (final s in testSkills) {
+          fs.setFileExists(
+            p.join(homeDir, '.config', 'opencode', 'skills', s, 'SKILL.md'),
+            true,
+          );
+        }
+        fs.setFileContents(
+          p.join(homeDir, '.config', 'opencode', 'opencode.jsonc'),
+          jsonc,
+        );
+        return fs;
+      }
+
+      test('FAILS when a configured Ollama model defaults to num_ctx 4096', () async {
+        // 30b-16k is fine; 30b is omitted → fakeRunner emits no num_ctx → 4096.
+        final cmd = makeCmd(
+          fs: opencodeActiveFs(),
+          runProcess: fakeRunner(ollamaCtx: {'qwen3-coder:30b-16k': 16384}),
+        );
+        final output = await cmd.execute();
+
+        expect(output.passed, isFalse);
+        final ctx = output.checks.firstWhere(
+          (c) => c.name == 'opencode/ollama context',
+        );
+        expect(ctx.passed, isFalse);
+        expect(ctx.error, contains('qwen3-coder:30b'));
+        expect(ctx.error, contains('4096'));
+        // the adequate model must NOT be flagged
+        expect(ctx.error, isNot(contains('30b-16k (num_ctx')));
+      });
+
+      test('PASSES when all Ollama models have num_ctx >= 16384', () async {
+        final cmd = makeCmd(
+          fs: opencodeActiveFs(),
+          runProcess: fakeRunner(ollamaCtx: {
+            'qwen3-coder:30b': 16384,
+            'qwen3-coder:30b-16k': 32768,
+          }),
+        );
+        final output = await cmd.execute();
+
+        expect(output.passed, isTrue);
+        expect(
+          output.checks.any((c) => c.name == 'opencode/ollama context'),
+          isFalse,
+        );
+      });
+
+      test('is SKIPPED when OpenCode is not the active host', () async {
+        // Copilot active; OpenCode inactive. A 4096 Ollama model must not fail.
+        final fs = allPassFs(workingDir, homeDir, testSkills);
+        fs.setFileContents(
+          p.join(homeDir, '.config', 'opencode', 'opencode.jsonc'),
+          jsonc,
+        );
+        final cmd = makeCmd(fs: fs, runProcess: fakeRunner(ollamaCtx: {}));
+        final output = await cmd.execute();
+
+        expect(output.passed, isTrue);
+        expect(
+          output.checks.any((c) => c.name == 'opencode/ollama context'),
+          isFalse,
+        );
       });
     });
   });

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.10.4</span>
+      <span class="badge">v0.10.5</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
Part 1 of #259 — the **blocking `iq doctor` check**. (Auto-configuration in `iq host get` is part 2.)

## Why

Driving the Inquiry firmware on OpenCode with an Ollama model at the **default `num_ctx=4096`** silently truncates the assembled prompt (firmware + OpenCode tool schemas ≈ **7.3–7.9K tokens**). The model then hallucinates and **never runs `iq fsm state`** — yet `iq doctor` stayed green, giving the operator no signal. This was diagnosed empirically: a real `agent=inquiry` session at 4096 capped `tokens.input` at 4095 every turn and failed; the same firmware at `num_ctx=16384` investigated and ran `iq fsm state --json`.

## What

When **OpenCode is the active host**, `iq doctor`:
1. reads the Ollama models from `~/.config/opencode/opencode.jsonc`,
2. queries each model's effective `num_ctx` via `ollama show <model> --modelfile` (absent ⇒ Ollama's 4096 default),
3. **fails** if any is `< 16384`, with remediation (bake a `num_ctx 16384`/32768 variant).

Gated on OpenCode being active (won't bother Copilot-only users). Skips cleanly when there's no config / no Ollama provider / Ollama isn't installed.

## Implementation notes

- `FileSystemOps.readFile` added; a **string-aware JSONC comment stripper** (keeps the `//` inside the `$schema` URL intact).
- `num_ctx` read through the existing injectable `ProcessRunner` (mockable).
- `kInquiryMinNumCtx = 16384` (32768 recommended for full cycles — a single measured cycle reached ~16,370 input tokens).

## QA

- `dart analyze` clean; full `dart test` **457 passing** (3 new `doctor_test` cases: fail on default-4096, pass at ≥16384, skip when OpenCode inactive).
- **Verified live** (0.10.5 binary) from a real OpenCode repo:
  ```
  ✗ opencode/ollama context  num_ctx < 16384 for: qwen3-coder:30b (num_ctx=4096), gemma4:12b (num_ctx=4096)
  ✓ opencode: agent + 3 skills deployed
  Some checks failed.
  ```
  `qwen3-coder:30b-16k` correctly passes.