### PR TITLE
feat(host): iq host get --host opencode auto-configures Ollama num_ctx (#259 part 2)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.10.6]
+### Added
+- **`iq host get --host opencode` auto-configures Ollama context** (#259, part 2): after deploying, for each Ollama model in `opencode.jsonc` whose effective `num_ctx < 16384`, it bakes a `<model>-16k` variant (`ollama create`, additive — never deletes the original) and rewrites `opencode.jsonc` (backup: `opencode.jsonc.bak`) so only adequate models remain selectable — leaving `iq doctor` green. No-op when Ollama isn't installed or no Ollama provider is configured. Completes #259.
+
+### Changed
+- **Shared OpenCode/Ollama helpers** extracted to `hosts/ollama_context.dart` (JSONC model parsing, effective-num_ctx query, the 16384 threshold), now used by both `iq doctor` and `iq host get` so the logic can't drift between the verify and configure paths.
+
 ## [0.10.5]
 ### Added
 - **`iq doctor` verifies OpenCode/Ollama context size** (#259, part 1): when OpenCode is the active host, doctor reads the Ollama models from `opencode.jsonc`, queries each model's effective `num_ctx` (`ollama show <model> --modelfile`; absent ⇒ Ollama's 4096 default), and **fails** if any is below 16384. At 4096 the Inquiry firmware + OpenCode tool schemas (~8K tokens) are silently truncated and the harness never runs (the model hallucinates and never executes `iq fsm state`) — this now surfaces with remediation (bake a `num_ctx 16384`, 32768 recommended, variant). Auto-configuration in `iq host get` is tracked as #259 part 2.

--- a/code/cli/lib/hosts/ollama_context.dart
+++ b/code/cli/lib/hosts/ollama_context.dart
@@ -1,0 +1,104 @@
+/// Shared OpenCode + Ollama context helpers.
+///
+/// Used by both `iq doctor` (verify) and `iq host get` (configure) so the
+/// num_ctx / config-parsing logic lives in exactly one place.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+/// Function type for running external processes (injectable for tests).
+typedef OllamaProcessRunner =
+    Future<ProcessResult> Function(
+      String executable,
+      List<String> arguments, {
+      String? workingDirectory,
+    });
+
+/// Minimum Ollama `num_ctx` for the Inquiry firmware + OpenCode tool schemas to
+/// fit (the assembled prompt measures ~7.3–7.9k tokens; a full cycle approaches
+/// 16k). 32768+ is recommended for long cycles.
+const int kInquiryMinNumCtx = 16384;
+
+/// Ollama's default `num_ctx` when a model's Modelfile does not set it.
+const int kOllamaDefaultNumCtx = 4096;
+
+/// Strips `//` and `/* */` comments from JSONC, respecting string literals
+/// (so the `//` inside a `"$schema": "https://…"` URL is preserved).
+String stripJsonComments(String s) {
+  final buf = StringBuffer();
+  var i = 0;
+  var inStr = false;
+  var esc = false;
+  while (i < s.length) {
+    final c = s[i];
+    if (inStr) {
+      buf.write(c);
+      if (esc) {
+        esc = false;
+      } else if (c == '\\') {
+        esc = true;
+      } else if (c == '"') {
+        inStr = false;
+      }
+      i++;
+      continue;
+    }
+    if (c == '"') {
+      inStr = true;
+      buf.write(c);
+      i++;
+      continue;
+    }
+    if (c == '/' && i + 1 < s.length && s[i + 1] == '/') {
+      i += 2;
+      while (i < s.length && s[i] != '\n') {
+        i++;
+      }
+      continue;
+    }
+    if (c == '/' && i + 1 < s.length && s[i + 1] == '*') {
+      i += 2;
+      while (i + 1 < s.length && !(s[i] == '*' && s[i + 1] == '/')) {
+        i++;
+      }
+      i += 2;
+      continue;
+    }
+    buf.write(c);
+    i++;
+  }
+  return buf.toString();
+}
+
+/// Extracts the Ollama provider model names from opencode.jsonc (JSONC text).
+List<String> ollamaModelsFromConfig(String jsonc) {
+  try {
+    final json = jsonDecode(stripJsonComments(jsonc)) as Map<String, dynamic>;
+    final provider = json['provider'];
+    if (provider is! Map) return [];
+    final ollama = provider['ollama'];
+    if (ollama is! Map) return [];
+    final models = ollama['models'];
+    if (models is! Map) return [];
+    return models.keys.map((k) => k.toString()).toList();
+  } catch (_) {
+    return [];
+  }
+}
+
+/// Effective `num_ctx` for an Ollama model: the Modelfile `PARAMETER num_ctx`
+/// if set, else Ollama's 4096 default. Null if Ollama can't be queried
+/// (not installed / command failed).
+Future<int?> effectiveNumCtx(OllamaProcessRunner run, String model) async {
+  try {
+    final res = await run('ollama', ['show', model, '--modelfile']);
+    if (res.exitCode != 0) return null;
+    final out = res.stdout?.toString() ?? '';
+    final m = RegExp(r'num_ctx\s+(\d+)', caseSensitive: false).firstMatch(out);
+    if (m != null) return int.tryParse(m.group(1)!) ?? kOllamaDefaultNumCtx;
+    return kOllamaDefaultNumCtx;
+  } catch (_) {
+    return null;
+  }
+}

--- a/code/cli/lib/hosts/opencode_ollama_configurator.dart
+++ b/code/cli/lib/hosts/opencode_ollama_configurator.dart
@@ -1,0 +1,134 @@
+/// Configures OpenCode's Ollama models so the Inquiry firmware fits.
+///
+/// Run by `iq host get --host opencode`. For each Ollama model in
+/// `opencode.jsonc` whose effective `num_ctx` is below [kInquiryMinNumCtx], it
+/// bakes a `<model>-16k` variant (`ollama create`, additive — never deletes the
+/// original) and rewrites `opencode.jsonc` (with a `.bak` backup) so only
+/// adequate models are listed. The result leaves `iq doctor` green.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'ollama_context.dart';
+
+/// Minimal file operations (injectable for tests).
+abstract class ConfigFs {
+  String? readFile(String path);
+  void writeFile(String path, String content);
+  void deleteFile(String path);
+}
+
+/// Production implementation using dart:io.
+class RealConfigFs implements ConfigFs {
+  @override
+  String? readFile(String path) {
+    final f = File(path);
+    return f.existsSync() ? f.readAsStringSync() : null;
+  }
+
+  @override
+  void writeFile(String path, String content) {
+    final f = File(path);
+    f.parent.createSync(recursive: true);
+    f.writeAsStringSync(content);
+  }
+
+  @override
+  void deleteFile(String path) {
+    final f = File(path);
+    if (f.existsSync()) f.deleteSync();
+  }
+}
+
+class OpenCodeOllamaConfigurator {
+  final OllamaProcessRunner run;
+  final ConfigFs fs;
+  final String homeDir;
+
+  OpenCodeOllamaConfigurator({
+    required this.run,
+    required this.fs,
+    required this.homeDir,
+  });
+
+  String get _cfgPath =>
+      p.join(homeDir, '.config', 'opencode', 'opencode.jsonc');
+
+  /// Ensures every configured Ollama model has num_ctx >= kInquiryMinNumCtx,
+  /// baking variants and rewriting the config as needed. Returns human-readable
+  /// action lines (empty when there was nothing to do).
+  Future<List<String>> configure() async {
+    final raw = fs.readFile(_cfgPath);
+    if (raw == null) return const [];
+    final models = ollamaModelsFromConfig(raw);
+    if (models.isEmpty) return const [];
+
+    final actions = <String>[];
+    final replacements = <String, String>{};
+
+    for (final model in models) {
+      final ctx = await effectiveNumCtx(run, model);
+      if (ctx == null) {
+        actions.add('skipped $model (could not query Ollama)');
+        continue;
+      }
+      if (ctx >= kInquiryMinNumCtx) continue;
+
+      final variant = '$model-16k';
+      final variantCtx = await effectiveNumCtx(run, variant);
+      if (variantCtx == null || variantCtx < kInquiryMinNumCtx) {
+        final ok = await _bake(model, variant);
+        if (!ok) {
+          actions.add('failed to create $variant (ollama create)');
+          continue;
+        }
+        actions.add('created Ollama model $variant (num_ctx $kInquiryMinNumCtx)');
+      }
+      replacements[model] = variant;
+    }
+
+    if (replacements.isNotEmpty) {
+      fs.writeFile('$_cfgPath.bak', raw);
+      fs.writeFile(_cfgPath, _rewriteConfig(raw, replacements));
+      actions.add(
+        'updated opencode.jsonc — Ollama models now: '
+        '${replacements.values.join(', ')} (backup: opencode.jsonc.bak)',
+      );
+    }
+    return actions;
+  }
+
+  Future<bool> _bake(String base, String variant) async {
+    final modelfile = p.join(homeDir, '.config', 'opencode', '.inquiry.Modelfile');
+    fs.writeFile(modelfile, 'FROM $base\nPARAMETER num_ctx $kInquiryMinNumCtx\n');
+    try {
+      final res = await run('ollama', ['create', variant, '-f', modelfile]);
+      return res.exitCode == 0;
+    } catch (_) {
+      return false;
+    } finally {
+      fs.deleteFile(modelfile);
+    }
+  }
+
+  /// Rewrites opencode.jsonc, replacing each inadequate model key with its
+  /// adequate variant (preserving the variant's metadata if already present).
+  String _rewriteConfig(String raw, Map<String, String> replacements) {
+    final json = jsonDecode(stripJsonComments(raw)) as Map<String, dynamic>;
+    final provider = json['provider'] as Map;
+    final ollama = provider['ollama'] as Map;
+    final models = Map<String, dynamic>.from(ollama['models'] as Map);
+    replacements.forEach((bad, variant) {
+      final meta = models.remove(bad);
+      models.putIfAbsent(
+        variant,
+        () => meta ?? <String, dynamic>{'name': variant},
+      );
+    });
+    ollama['models'] = models;
+    return '${const JsonEncoder.withIndent('  ').convert(json)}\n';
+  }
+}

--- a/code/cli/lib/modules/global/commands/doctor.dart
+++ b/code/cli/lib/modules/global/commands/doctor.dart
@@ -3,7 +3,6 @@
 /// Checks: inquiry version, git, gh, gh auth, .inquiry/ init, host deployment.
 library;
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:cli_router/cli_router.dart';
@@ -15,6 +14,7 @@ import '../../../src/version.dart' as version_lib;
 import '../../../src/version_check.dart';
 import '../../../hosts/all_adapters.dart';
 import '../../../hosts/host_adapter.dart';
+import '../../../hosts/ollama_context.dart';
 
 /// Function type for running external processes.
 ///
@@ -199,11 +199,6 @@ abstract class FileSystemOps {
   /// Reads a text file, or returns null if it does not exist.
   String? readFile(String path);
 }
-
-/// Minimum Ollama `num_ctx` for the Inquiry firmware + OpenCode tool schemas to
-/// fit (the assembled prompt measures ~7.3–7.9k tokens; a full cycle approaches
-/// 16k). 32768+ is recommended for long cycles.
-const int kInquiryMinNumCtx = 16384;
 
 /// Production implementation using dart:io.
 class RealFileSystemOps implements FileSystemOps {
@@ -401,12 +396,12 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
     final raw = _fileSystem.readFile(cfgPath);
     if (raw == null) return null;
 
-    final models = _ollamaModelsFromConfig(raw);
+    final models = ollamaModelsFromConfig(raw);
     if (models.isEmpty) return null;
 
     final tooSmall = <String>[];
     for (final model in models) {
-      final ctx = await _effectiveNumCtx(model);
+      final ctx = await effectiveNumCtx(_runProcess, model);
       if (ctx == null) continue; // can't determine (Ollama absent) — skip
       if (ctx < kInquiryMinNumCtx) tooSmall.add('$model (num_ctx=$ctx)');
     }
@@ -423,87 +418,6 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
           "(32768 recommended) — and point opencode.jsonc at it. "
           "Or run 'iq host get --host opencode' to configure it.",
     );
-  }
-
-  /// Extracts the Ollama provider model names from opencode.jsonc (JSONC).
-  List<String> _ollamaModelsFromConfig(String raw) {
-    try {
-      final json = jsonDecode(_stripJsonComments(raw)) as Map<String, dynamic>;
-      final provider = json['provider'];
-      if (provider is! Map) return [];
-      final ollama = provider['ollama'];
-      if (ollama is! Map) return [];
-      final models = ollama['models'];
-      if (models is! Map) return [];
-      return models.keys.map((k) => k.toString()).toList();
-    } catch (_) {
-      return [];
-    }
-  }
-
-  /// Effective `num_ctx` for an Ollama model: the Modelfile `PARAMETER num_ctx`
-  /// if set, else Ollama's 4096 default. Null if Ollama can't be queried.
-  Future<int?> _effectiveNumCtx(String model) async {
-    try {
-      final res = await _runProcess('ollama', ['show', model, '--modelfile']);
-      if (res.exitCode != 0) return null;
-      final out = res.stdout?.toString() ?? '';
-      final m = RegExp(
-        r'num_ctx\s+(\d+)',
-        caseSensitive: false,
-      ).firstMatch(out);
-      if (m != null) return int.tryParse(m.group(1)!) ?? 4096;
-      return 4096; // Ollama default when unset
-    } catch (_) {
-      return null;
-    }
-  }
-
-  /// Strips `//` and `/* */` comments from JSONC, respecting string literals.
-  String _stripJsonComments(String s) {
-    final buf = StringBuffer();
-    var i = 0;
-    var inStr = false;
-    var esc = false;
-    while (i < s.length) {
-      final c = s[i];
-      if (inStr) {
-        buf.write(c);
-        if (esc) {
-          esc = false;
-        } else if (c == '\\') {
-          esc = true;
-        } else if (c == '"') {
-          inStr = false;
-        }
-        i++;
-        continue;
-      }
-      if (c == '"') {
-        inStr = true;
-        buf.write(c);
-        i++;
-        continue;
-      }
-      if (c == '/' && i + 1 < s.length && s[i + 1] == '/') {
-        i += 2;
-        while (i < s.length && s[i] != '\n') {
-          i++;
-        }
-        continue;
-      }
-      if (c == '/' && i + 1 < s.length && s[i + 1] == '*') {
-        i += 2;
-        while (i + 1 < s.length && !(s[i] == '*' && s[i + 1] == '/')) {
-          i++;
-        }
-        i += 2;
-        continue;
-      }
-      buf.write(c);
-      i++;
-    }
-    return buf.toString();
   }
 
   /// Discovers expected skills from the asset tree.

--- a/code/cli/lib/modules/host/commands/get.dart
+++ b/code/cli/lib/modules/host/commands/get.dart
@@ -9,6 +9,7 @@ import 'package:cli_router/cli_router.dart';
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 
 import '../../../hosts/deployer.dart';
+import '../../../hosts/opencode_ollama_configurator.dart';
 
 // ─── Input ──────────────────────────────────────────────────────────────────
 
@@ -45,7 +46,11 @@ class HostGetCommand implements Command<HostGetInput, HostGetOutput> {
   final HostGetInput input;
   final HostDeployer deployer;
 
-  HostGetCommand(this.input, {required this.deployer});
+  /// OpenCode-only: ensures the configured Ollama models have an adequate
+  /// `num_ctx` (bakes variants + rewrites opencode.jsonc). Null disables it.
+  final OpenCodeOllamaConfigurator? configurator;
+
+  HostGetCommand(this.input, {required this.deployer, this.configurator});
 
   @override
   String? validate() {
@@ -60,8 +65,10 @@ class HostGetCommand implements Command<HostGetInput, HostGetOutput> {
   @override
   Future<HostGetOutput> execute() async {
     deployer.deployExclusive(input.host);
-    return HostGetOutput(
-      message: 'Inquiry skills deployed to host ${input.host}',
-    );
+    final lines = ['Inquiry skills deployed to host ${input.host}'];
+    if (input.host == 'opencode' && configurator != null) {
+      lines.addAll(await configurator!.configure());
+    }
+    return HostGetOutput(message: lines.join('\n'));
   }
 }

--- a/code/cli/lib/modules/host/host_builder.dart
+++ b/code/cli/lib/modules/host/host_builder.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 
 import '../../hosts/deployer.dart';
+import '../../hosts/opencode_ollama_configurator.dart';
 import 'commands/clean.dart';
 import 'commands/get.dart';
 
@@ -14,6 +17,11 @@ void buildHostModule(
     (req) => HostGetCommand(
       HostGetInput.fromCliRequest(req),
       deployer: deployer,
+      configurator: OpenCodeOllamaConfigurator(
+        run: Process.run,
+        fs: RealConfigFs(),
+        homeDir: deployer.homeDir,
+      ),
     ),
     description: 'Deploy Inquiry skills to the specified host (default: copilot)',
   );

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.10.5';
+const String inquiryVersion = '0.10.6';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.10.5
+version: 0.10.6
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/opencode_ollama_configurator_test.dart
+++ b/code/cli/test/opencode_ollama_configurator_test.dart
@@ -1,0 +1,133 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:inquiry_cli/hosts/ollama_context.dart';
+import 'package:inquiry_cli/hosts/opencode_ollama_configurator.dart';
+
+class FakeConfigFs implements ConfigFs {
+  final Map<String, String> files = {};
+  @override
+  String? readFile(String path) => files[path];
+  @override
+  void writeFile(String path, String content) => files[path] = content;
+  @override
+  void deleteFile(String path) => files.remove(path);
+}
+
+/// Stateful fake `ollama`: `show` reflects the [ctx] map (missing model → exit
+/// 1); `create <variant>` registers it at 16384. When [available] is false,
+/// every call fails (simulating Ollama not installed).
+OllamaProcessRunner fakeOllama(Map<String, int> ctx, {bool available = true}) {
+  return (String exe, List<String> args, {String? workingDirectory}) async {
+    if (!available) return ProcessResult(0, 1, '', 'ollama: not found');
+    if (exe == 'ollama' && args.isNotEmpty && args.first == 'show') {
+      final model = args[1];
+      if (!ctx.containsKey(model)) {
+        return ProcessResult(0, 1, '', 'model not found');
+      }
+      return ProcessResult(0, 0, 'FROM base\nPARAMETER num_ctx ${ctx[model]}\n', '');
+    }
+    if (exe == 'ollama' && args.isNotEmpty && args.first == 'create') {
+      ctx[args[1]] = 16384; // variant now exists
+      return ProcessResult(0, 0, 'success', '');
+    }
+    return ProcessResult(0, 0, '', '');
+  };
+}
+
+const home = '/home/test';
+// Must match the configurator's own p.join(homeDir, ...) (separators differ by OS).
+final cfgPath = p.join(home, '.config', 'opencode', 'opencode.jsonc');
+
+String cfg(List<String> models) {
+  final entries = models.map((m) => '"$m": {}').join(', ');
+  return '{ "provider": { "ollama": { "models": { $entries } } } }';
+}
+
+void main() {
+  group('OpenCodeOllamaConfigurator', () {
+    test('replaces a 4096 model with its existing 16k variant (no re-bake)', () async {
+      final fs = FakeConfigFs()
+        ..files[cfgPath] = cfg(['qwen3-coder:30b', 'qwen3-coder:30b-16k']);
+      final ctx = {'qwen3-coder:30b': 4096, 'qwen3-coder:30b-16k': 16384};
+      final cfgr = OpenCodeOllamaConfigurator(
+        run: fakeOllama(ctx),
+        fs: fs,
+        homeDir: home,
+      );
+
+      final actions = await cfgr.configure();
+
+      final models = ollamaModelsFromConfig(fs.files[cfgPath]!);
+      expect(models, equals(['qwen3-coder:30b-16k']),
+          reason: 'inadequate model dropped, adequate variant kept');
+      expect(fs.files['$cfgPath.bak'], isNotNull, reason: 'original backed up');
+      expect(actions.join('\n'), contains('updated opencode.jsonc'));
+      expect(actions.join('\n'), isNot(contains('created')),
+          reason: 'variant already adequate — must not re-bake');
+    });
+
+    test('bakes a 16k variant when none exists, then lists it', () async {
+      final fs = FakeConfigFs()..files[cfgPath] = cfg(['gemma4:12b']);
+      final ctx = {'gemma4:12b': 4096}; // no -16k variant yet
+      final cfgr = OpenCodeOllamaConfigurator(
+        run: fakeOllama(ctx),
+        fs: fs,
+        homeDir: home,
+      );
+
+      final actions = await cfgr.configure();
+
+      expect(ctx.containsKey('gemma4:12b-16k'), isTrue,
+          reason: 'ollama create was invoked for the variant');
+      expect(ctx['gemma4:12b-16k'], 16384);
+      expect(ollamaModelsFromConfig(fs.files[cfgPath]!),
+          equals(['gemma4:12b-16k']));
+      expect(actions.join('\n'), contains('created Ollama model gemma4:12b-16k'));
+    });
+
+    test('does nothing when all models already have num_ctx >= 16384', () async {
+      final original = cfg(['qwen3-coder:30b-16k']);
+      final fs = FakeConfigFs()..files[cfgPath] = original;
+      final cfgr = OpenCodeOllamaConfigurator(
+        run: fakeOllama({'qwen3-coder:30b-16k': 32768}),
+        fs: fs,
+        homeDir: home,
+      );
+
+      final actions = await cfgr.configure();
+
+      expect(actions, isEmpty);
+      expect(fs.files[cfgPath], original, reason: 'config untouched');
+      expect(fs.files.containsKey('$cfgPath.bak'), isFalse);
+    });
+
+    test('skips (no mutation) when Ollama cannot be queried', () async {
+      final original = cfg(['qwen3-coder:30b']);
+      final fs = FakeConfigFs()..files[cfgPath] = original;
+      final cfgr = OpenCodeOllamaConfigurator(
+        run: fakeOllama({'qwen3-coder:30b': 4096}, available: false),
+        fs: fs,
+        homeDir: home,
+      );
+
+      final actions = await cfgr.configure();
+
+      expect(actions.join('\n'), contains('could not query Ollama'));
+      expect(fs.files[cfgPath], original, reason: 'config untouched');
+      expect(fs.files.containsKey('$cfgPath.bak'), isFalse);
+    });
+
+    test('no-op when there is no opencode.jsonc', () async {
+      final fs = FakeConfigFs();
+      final cfgr = OpenCodeOllamaConfigurator(
+        run: fakeOllama({}),
+        fs: fs,
+        homeDir: home,
+      );
+      expect(await cfgr.configure(), isEmpty);
+    });
+  });
+}

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.10.5</span>
+      <span class="badge">v0.10.6</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
Completes #259 (part 1 was the `iq doctor` blocking check in #261).

## What

After `iq host get --host opencode` deploys, it now **leaves the configuration correct**: for each Ollama model in `opencode.jsonc` with effective `num_ctx < 16384`, it
1. **bakes a `<model>-16k` variant** (`ollama create` with `PARAMETER num_ctx 16384` — additive, never deletes the original), and
2. **rewrites `opencode.jsonc`** (backup → `opencode.jsonc.bak`) so only adequate models remain selectable.

Net effect: the OpenCode model picker can no longer land on a 4096-ctx model that silently truncates the firmware, and `iq doctor` goes green. No-op when Ollama isn't installed or there's no Ollama provider.

Why "configure the available models" rather than "pin the model in the agent": an explicit model selection overrides an agent-pinned `model:` (proven empirically — see #259), so controlling what's selectable is the only reliable lever.

## Design

- New `OpenCodeOllamaConfigurator` (injectable `ProcessRunner` + `ConfigFs`).
- Shared `hosts/ollama_context.dart` (JSONC model parsing, effective-num_ctx query, the 16384 threshold) — now used by **both** `iq doctor` (verify) and `iq host get` (configure), so the two paths can't drift.

## QA

- `dart analyze` clean; full `dart test` **462 passing** (5 new configurator tests: replace-with-existing-variant, bake-new-variant, all-adequate no-op, Ollama-absent skip, no-config no-op).
- **Verified live** (0.10.6 binary):
  ```
  iq host get --host opencode
  → created Ollama model gemma4:12b-16k (num_ctx 16384)
  → updated opencode.jsonc — Ollama models now: qwen3-coder:30b-16k, gemma4:12b-16k (backup: opencode.jsonc.bak)
  iq doctor → All checks passed.
  ```