### PR TITLE
fix(firmware): repair on gate failure instead of blind retry (#263)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.10.7]
+### Changed
+- **Gate/precondition failures no longer trigger blind retries** (#263): when `iq fsm transition`/`iq ape transition` returns `validationFailed`, the firmware now re-dispatches the operator with the error to repair the artifact and retries, instead of re-firing the same failing event. Previously a weak local model looped `complete_analysis` 5× in one turn and saturated its context (~16k tokens). The transition's failure output also carries an explicit "do not re-run unchanged — fix what the error reports, then retry" hint. Reinforces the artifact-as-function model (inputs/outputs are `.md` files on disk). Verified across conducted trials: `complete_analysis` now fires once per attempt with no consecutive identical retries.
+
 ## [0.10.6]
 ### Added
 - **`iq host get --host opencode` auto-configures Ollama context** (#259, part 2): after deploying, for each Ollama model in `opencode.jsonc` whose effective `num_ctx < 16384`, it bakes a `<model>-16k` variant (`ollama create`, additive — never deletes the original) and rewrites `opencode.jsonc` (backup: `opencode.jsonc.bak`) so only adequate models remain selectable — leaving `iq doctor` green. No-op when Ollama isn't installed or no Ollama provider is configured. Completes #259.

--- a/code/cli/assets/agents/inquiry.body.md
+++ b/code/cli/assets/agents/inquiry.body.md
@@ -82,7 +82,7 @@ Dispatch is **unconditional and immediate**. When you enter the Inner Loop, exec
 - **NEVER** narrate the process. Do not say "the next step is..." or "I will now...". Execute.
 - During ANALYZE, keep the investigation visible in chat; do not collapse user interaction into the completion gate.
 - **NEVER** combine `iq ape transition --event complete` and `iq fsm transition` in the same turn when authority is `"user"`.
-- If a command fails, report the error and offer retry.
+- On an `iq fsm transition`/`iq ape transition` precondition/validation failure (a gate block), do NOT re-fire the same event (blind retry keeps failing); re-dispatch the active operator with the precondition error so it repairs the artifact (add the missing `diagnosis.md` sections / verifiable handles), then retry — inputs/outputs are the `.md` artifacts on disk, not your context. Any other command failure: report and offer retry.
 - If you are unsure of your state, run `iq fsm state --json`; complete one sub-phase at a time before transitioning.
 - Do not enumerate states, transitions, or sub-agent names from memory. Read them from the CLI output.
 - If the user requests an exact literal response (for example "respond exactly TOKEN"), output only that literal in the final response and nothing else.

--- a/code/cli/lib/modules/fsm/commands/transition.dart
+++ b/code/cli/lib/modules/fsm/commands/transition.dart
@@ -201,9 +201,18 @@ class StateTransitionOutput extends Output {
 
   @override
   String? toText() {
+    // A gate/precondition block: tell the scheduler to repair the artifact and
+    // retry, NOT to re-fire the same event (which would just fail again).
+    final gateHint = (!allowed && code == ExitCode.validationFailed)
+        ? '\n\n→ Precondition not met. Do NOT re-run "$event" unchanged — that is a '
+              'blind retry and will keep failing. Fix what the error reports above; '
+              'for an artifact gate, re-dispatch the operator to repair the `.md` '
+              '(read it, fix it, write it back), then retry the transition.'
+        : '';
+
     final instructions = requiredInstructions;
     if (instructions == null || instructions.isEmpty) {
-      return message;
+      return '$message$gateHint';
     }
 
     final summary = instructionSummary?.trim();

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.10.6';
+const String inquiryVersion = '0.10.7';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.10.6
+version: 0.10.7
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/firmware_agent_test.dart
+++ b/code/cli/test/firmware_agent_test.dart
@@ -160,5 +160,12 @@ void main() {
       );
       expect(content, contains('output only that literal'));
     });
+
+    test('on a gate/validation failure, repairs the artifact instead of blind retry (#263)', () {
+      expect(content, contains('do NOT re-fire the same event'));
+      expect(content, contains('repairs the artifact'));
+      // the artifact-as-function ideal must be stated
+      expect(content, contains('.md` artifacts on disk'));
+    });
   });
 }

--- a/code/cli/test/fsm_transition_integration_test.dart
+++ b/code/cli/test/fsm_transition_integration_test.dart
@@ -60,7 +60,10 @@ void main() {
 
         expect(blocked.allowed, isFalse);
         expect(blocked.nextState, isNull);
-        expect(blocked.toText(), equals(blocked.message));
+        // validationFailed output preserves the message and appends the
+        // no-blind-retry / repair hint (#263).
+        expect(blocked.toText(), startsWith(blocked.message));
+        expect(blocked.toText(), contains('Do NOT re-run'));
         expect(
           File(
             p.join(

--- a/code/cli/test/fsm_transition_test.dart
+++ b/code/cli/test/fsm_transition_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -1503,6 +1504,41 @@ void main() {
         emptyInstructionsOutput.toText(),
         equals('Transition PLAN --approve_plan--> EXECUTE'),
       );
+    });
+
+    test('gate/validation failure appends repair guidance, not blind retry (#263)', () {
+      final gateFail = StateTransitionOutput(
+        allowed: false,
+        currentState: 'ANALYZE',
+        event: 'complete_analysis',
+        nextState: null,
+        operationsExecuted: const ['validate_transition', 'validate_prechecks'],
+        promptFragmentId: null,
+        requiredRole: null,
+        requiredInstructions: null,
+        message: 'ERROR_PRECONDITION_DIAGNOSIS_EVIDENCE_UNVERIFIABLE: fix it',
+        code: ExitCode.validationFailed,
+      );
+      final text = gateFail.toText()!;
+      expect(text, contains('ERROR_PRECONDITION'),
+          reason: 'preserves the original gate error');
+      expect(text, contains('Do NOT re-run "complete_analysis"'));
+      expect(text, contains('re-dispatch the operator to repair'));
+
+      // a plain forbidden transition (not validationFailed) gets no repair hint
+      final forbidden = StateTransitionOutput(
+        allowed: false,
+        currentState: 'IDLE',
+        event: 'go_execute',
+        nextState: null,
+        operationsExecuted: const ['validate_transition'],
+        promptFragmentId: null,
+        requiredRole: null,
+        requiredInstructions: null,
+        message: 'forbidden',
+        code: 64,
+      );
+      expect(forbidden.toText(), isNot(contains('Do NOT re-run')));
     });
 
     test('surfaces structured metadata for instruction-bearing transitions', () {

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.10.6</span>
+      <span class="badge">v0.10.7</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
Closes #263.

## Problem (evidence)

On a weak local model, when the firmware reached the ANALYZE→PLAN gate, `iq fsm transition --event complete_analysis` returned `validationFailed` (EXIT 7) and the firmware **re-fired the same event 5× in one turn**, saturating context (~16k tokens). The only firmware guidance was "If a command fails, report the error and offer retry" → interpreted as blind retry.

## Fix

- **Firmware** (`inquiry.body.md`, one line, stays under the 90-line guard): on a precondition/validation failure, do NOT re-fire the same event — re-dispatch the active operator with the error so it repairs the artifact (`.md` on disk), then retry. Frames the sub-agent as a function over `.md` artifacts.
- **CLI** (`transition.dart` `toText`): `validationFailed` output now appends an explicit "do not re-run unchanged — fix what the error reports, then retry" hint, so the guidance is in the model's context at the failure point. General enough for both branch-policy and artifact gates.

## Validation (conducted trials, qwen3-coder:30b-16k)

- **Before:** `complete_analysis` re-fired 5× consecutively (blind retry) → context saturated.
- **After:** `complete_analysis` fires **once per attempt, no consecutive identical retries** (2 EXIT-7 across 4 trials, none repeated). The destructive loop is gone.
- `dart analyze` clean; full `dart test` **464 passing** (new: firmware rule present; toText hint for validationFailed and absent for a plain forbidden/code-64 transition; updated integration assertion).

## Honest scope

This removes the blind-retry pathology but does **not** by itself let a cycle complete on a weak model: the experiments revealed a deeper blocker — the ANALYZE operator advances sub-phases without writing a real `diagnosis.md` (it stays as the template), so the gate correctly blocks and there is nothing to repair. Tracked separately (artifact-as-function / operator output).