### PR TITLE
fix(analyze): require an evidence handle per bullet + name offending bullets on gate failure (#268)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.10.9]
+### Changed
+- **ANALYZE evidence handle: clearer operator contract + targeted gate error** (#268): SOCRATES's diagnosis contract now requires every Evidence bullet to carry a re-checkable handle (a `file:line` like `average.py:3`, a URL, or inline-code in backticks) — a bullet without one is invalid, add the handle rather than dropping the claim. When `complete_analysis` blocks on `DIAGNOSIS_EVIDENCE_UNVERIFIABLE`, the error now **names the offending bullet(s)** so the operator can repair precisely (feeding the #263 repair loop) instead of re-writing the whole diagnosis. Accepted handle forms (URL / file:line / inline-code) are unchanged.
+
 ## [0.10.8]
 ### Changed
 - **Operator dispatched as a write-capable function that must produce its artifact** (#266): the firmware Inner Loop now dispatches each phase operator to a **write-capable** sub-agent (not a read-only explorer), declares its deliverable to be **writing the phase artifact** (e.g. `diagnosis.md` at the `authoritative_handoff` path) — returning prose without writing it is a failure — and **verifies the artifact was written/updated before advancing** (`iq ape transition`), re-dispatching if it is still the template. Fixes the observed failure where the operator advanced ANALYZE sub-phases without ever writing `diagnosis.md` (left as scaffold), so the gate could never pass. Realizes the artifact-as-function model: sub-agent inputs/outputs are `.md` files on disk, not the orchestrator's context.

--- a/code/cli/assets/apes/socrates.yaml
+++ b/code/cli/assets/apes/socrates.yaml
@@ -57,6 +57,8 @@ base_prompt: |
   - **Scope** (what enters, what does not)
   - **References** (links to other analysis documents)
 
+  Every **Evidence** bullet MUST carry a re-checkable handle so each claim can be reopened and verified: a `file:line` reference (e.g. `average.py:3`), a URL, or an inline-code span in backticks (a path, command, or test id). A bullet with no handle is invalid and will block the ANALYZE→PLAN gate — add the handle rather than removing the claim.
+
   Treat the diagnosis like a paper: rigorous, well-documented, and grounded in references.
   Keep each contribution focused on clarifying the problem rather than prescribing implementation.
 

--- a/code/cli/lib/modules/fsm/commands/transition.dart
+++ b/code/cli/lib/modules/fsm/commands/transition.dart
@@ -783,7 +783,8 @@ class StateTransitionCommand
     }
 
     if (prechecks.contains('diagnosis_evidence_verifiable')) {
-      if (!_diagnosisEvidenceIsVerifiable(branch, workingDirectory)) {
+      final unverifiable = _unverifiableEvidenceBullets(branch, workingDirectory);
+      if (unverifiable == null || unverifiable.isNotEmpty) {
         _recordPrecheckSensor(
           executor,
           currentState: currentState,
@@ -793,7 +794,10 @@ class StateTransitionCommand
           issue: issue,
           promptFragmentId: promptFragmentId,
         );
-        return 'ERROR_PRECONDITION_DIAGNOSIS_EVIDENCE_UNVERIFIABLE: every diagnosis.md Evidence bullet must carry a re-checkable handle (a file:line reference, a URL, or an inline-code command/test id) so each claim can be reopened and verified';
+        final offenders = (unverifiable == null || unverifiable.isEmpty)
+            ? ''
+            : ' Bullets missing a handle: ${unverifiable.take(3).map((b) => '"${b.length > 70 ? '${b.substring(0, 70)}…' : b}"').join('; ')}';
+        return 'ERROR_PRECONDITION_DIAGNOSIS_EVIDENCE_UNVERIFIABLE: every diagnosis.md Evidence bullet must carry a re-checkable handle (a file:line reference, a URL, or an inline-code command/test id) so each claim can be reopened and verified.$offenders';
       }
       _recordPrecheckSensor(
         executor,
@@ -1033,15 +1037,21 @@ class StateTransitionCommand
     );
   }
 
-  bool _diagnosisEvidenceIsVerifiable(String branch, String workingDirectory) {
+  /// Evidence bullets that lack a re-checkable handle. Empty = all verifiable;
+  /// null = the Evidence section is unreadable/empty (a structural problem
+  /// surfaced by other prechecks).
+  List<String>? _unverifiableEvidenceBullets(
+    String branch,
+    String workingDirectory,
+  ) {
     final content = _readDiagnosisContent(branch, workingDirectory);
-    if (content == null) return false;
+    if (content == null) return null;
 
     final evidenceBody = _diagnosisSectionBody(
       content,
       _diagnosisSectionPatterns['Evidence']!,
     );
-    if (evidenceBody == null) return false;
+    if (evidenceBody == null) return null;
 
     final bullets = evidenceBody
         .split('\n')
@@ -1052,9 +1062,11 @@ class StateTransitionCommand
               line.toLowerCase() != _diagnosisEvidenceBootstrapPlaceholder,
         )
         .toList(growable: false);
-    if (bullets.isEmpty) return false;
+    if (bullets.isEmpty) return null;
 
-    return bullets.every(_evidenceLineHasVerifiableHandle);
+    return bullets
+        .where((b) => !_evidenceLineHasVerifiableHandle(b))
+        .toList(growable: false);
   }
 
   /// A re-checkable evidence handle: a URL, a `file:line` reference, or an

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.10.8';
+const String inquiryVersion = '0.10.9';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.10.8
+version: 0.10.9
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/fsm_transition_test.dart
+++ b/code/cli/test/fsm_transition_test.dart
@@ -274,6 +274,10 @@ void main() {
           output.message,
           contains('ERROR_PRECONDITION_DIAGNOSIS_EVIDENCE_UNVERIFIABLE'),
         );
+        // #268: the error names the offending bullet so the operator can repair
+        // precisely (not re-write the whole diagnosis).
+        expect(output.message, contains('Bullets missing a handle'));
+        expect(output.message, contains('did not reach the END state'));
 
         final traceContent = File(
           p.join(tempDir.path, 'cleanrooms', branch, 'run_trace.yaml'),

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.10.8</span>
+      <span class="badge">v0.10.9</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
Closes #268. The last gap between "operator writes a good diagnosis" (#266) and "first ANALYZE→PLAN gate passes on a local model".

## Evidence

After #266 the local model wrote a real `diagnosis.md`, but `complete_analysis` still blocked on `DIAGNOSIS_EVIDENCE_UNVERIFIABLE`. Investigating the gate (`_evidenceLineHasVerifiableHandle`): it already accepts a URL, a `file:line`, **or any inline-code (backtick) span**. The produced bullets:
- `…(file: \`average.py\`, line 3)` → passes (backtick `average.py`)
- `…the function \`len(nums)\`…` → passes (backtick)
- `This was confirmed by examining the implementation…` → **no handle** → the whole `.every()` fails.

So the gate isn't too strict — **one bullet simply had no handle**.

## Fix

- **Operator** (`socrates.yaml`): every Evidence bullet MUST carry a re-checkable handle (`file:line` like `average.py:3`, a URL, or inline-code in backticks); a bullet without one is invalid — add the handle, don't drop the claim.
- **Gate error** (`transition.dart`): `DIAGNOSIS_EVIDENCE_UNVERIFIABLE` now **names the offending bullet(s)** so the operator repairs precisely (feeds the #263 repair loop) instead of re-writing the whole diagnosis. Refactored the detector to return the unverifiable bullets; accepted handle forms unchanged.

## QA

- `dart analyze` clean; full `dart test` **465 passing** (existing fail/pass evidence tests hold; the fail test now also asserts the offending bullet is named).
- A milestone conducted experiment (does `complete_analysis` finally pass on qwen3-coder:30b-16k?) is running; result will be reported. Note the gate fix stands independently of model engagement (#264).