### PR TITLE
feat(fsm): iq fsm state prescribes the single next action (#270 lever 1)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.10.10]
+### Added
+- **`iq fsm state` prescribes the single next action** (#270, lever 1 — "CLI is the brain"): the output now carries a `next` field: the exact next command to run, computed by the CLI from the state, active operator, and completion authority. The model (or a human using the CLI as a dev guide) no longer chooses FSM events or paths. When a real decision is due — a `completion_authority: user` gate, or more than one forward path — `next` hands it to the human ("STOP — present to the human; the human decides"), since decisions carry consequences and responsibility. The firmware's Outer Loop now reduces to "do exactly what `next` says". First step toward shifting decisions from the unreliable model to the deterministic FSM; the firmware also shed a now-redundant rule.
+
 ## [0.10.9]
 ### Changed
 - **ANALYZE evidence handle: clearer operator contract + targeted gate error** (#268): SOCRATES's diagnosis contract now requires every Evidence bullet to carry a re-checkable handle (a `file:line` like `average.py:3`, a URL, or inline-code in backticks) — a bullet without one is invalid, add the handle rather than dropping the claim. When `complete_analysis` blocks on `DIAGNOSIS_EVIDENCE_UNVERIFIABLE`, the error now **names the offending bullet(s)** so the operator can repair precisely (feeding the #263 repair loop) instead of re-writing the whole diagnosis. Accepted handle forms (URL / file:line / inline-code) are unchanged.

--- a/code/cli/assets/agents/inquiry.body.md
+++ b/code/cli/assets/agents/inquiry.body.md
@@ -24,6 +24,7 @@ After the Invariant succeeds, on the **first turn** of a new session:
 3. Enter Outer Loop.
 
 ## Outer Loop (Main FSM)
+**The `next` field of `iq fsm state --json` is your single source of truth: do EXACTLY what it says and nothing else. You never choose events or paths — the CLI computes them. When `next` says the choice is the human's, STOP and present the information; do not decide.** The steps below just elaborate `next`.
 1. Announce state: `[INQUIRY]`
 2. Read `instructions` — this describes what the current state does
 3. If `ape` is active AND `ape.state` is NOT `_DONE`: enter Inner Loop **immediately**
@@ -83,6 +84,5 @@ Dispatch is **unconditional and immediate**. When you enter the Inner Loop, exec
 - During ANALYZE, keep the investigation visible in chat; do not collapse user interaction into the completion gate.
 - **NEVER** combine `iq ape transition --event complete` and `iq fsm transition` in the same turn when authority is `"user"`.
 - On an `iq fsm transition`/`iq ape transition` precondition/validation failure (a gate block), do NOT re-fire the same event (blind retry keeps failing); re-dispatch the active operator with the precondition error so it repairs the artifact (add the missing `diagnosis.md` sections / verifiable handles), then retry — inputs/outputs are the `.md` artifacts on disk, not your context. Any other command failure: report and offer retry.
-- If you are unsure of your state, run `iq fsm state --json`; complete one sub-phase at a time before transitioning.
 - Do not enumerate states, transitions, or sub-agent names from memory. Read them from the CLI output.
 - If the user requests an exact literal response (for example "respond exactly TOKEN"), output only that literal in the final response and nothing else.

--- a/code/cli/lib/modules/fsm/commands/state.dart
+++ b/code/cli/lib/modules/fsm/commands/state.dart
@@ -38,6 +38,11 @@ class FsmStateOutput extends Output {
   final Map<String, dynamic>? ape;
   final String completionAuthority;
 
+  /// The single next action the CLI prescribes — the model executes it, it does
+  /// not decide. When a real choice is due, this hands the decision to the
+  /// human (#270).
+  final String next;
+
   FsmStateOutput({
     required this.state,
     required this.issue,
@@ -47,6 +52,7 @@ class FsmStateOutput extends Output {
     required this.operationalContract,
     this.ape,
     required this.completionAuthority,
+    required this.next,
   });
 
   @override
@@ -54,6 +60,7 @@ class FsmStateOutput extends Output {
     'state': state,
     'issue': issue,
     'completion_authority': completionAuthority,
+    'next': next,
     'transitions': transitions,
     'apes': apes,
     'instructions': instructions,
@@ -73,6 +80,8 @@ class FsmStateOutput extends Output {
     if (apes.isNotEmpty) {
       buf.writeln('APEs:  ${apes.map((a) => a['name']).join(', ')}');
     }
+
+    buf.writeln('Next:  $next');
 
     if (transitions.isNotEmpty) {
       buf.writeln('Valid transitions:');
@@ -126,7 +135,54 @@ class FsmStateCommand implements Command<FsmStateInput, FsmStateOutput> {
       operationalContract: operationalContract.toJson(),
       ape: apeInfo,
       completionAuthority: completionAuthority,
+      next: _computeNext(validTransitions, apeInfo, completionAuthority),
     );
+  }
+
+  /// Computes the single next action the model should take. The model never
+  /// chooses an event or a path — the CLI does; genuine choices are handed to
+  /// the human (#270).
+  String _computeNext(
+    List<Map<String, String>> transitions,
+    Map<String, dynamic>? apeInfo,
+    String completionAuthority,
+  ) {
+    // 1. An operator is still working: dispatch it; do not transition yet.
+    if (apeInfo != null && apeInfo['state'] != '_DONE') {
+      final name = apeInfo['name'];
+      final apeEvents = ((apeInfo['transitions'] as List?) ?? const [])
+          .map((t) => (t as Map)['event'] as String)
+          .where((e) => e != 'block')
+          .toList(growable: false);
+      final after = apeEvents.length == 1
+          ? ' Then run `iq ape transition --event ${apeEvents.first}`.'
+          : ' Then advance the operator with `iq ape transition` and re-run `iq fsm state --json` for the next step.';
+      return 'Run `iq ape prompt --name $name`, dispatch a write-capable '
+          'sub-agent with that prompt; it MUST write the phase deliverable '
+          'before you continue.$after Do not transition the main FSM yet.';
+    }
+
+    // 2. At a main-FSM transition point.
+    final forward = transitions
+        .map((t) => t['event']!)
+        .where((e) => e != 'block')
+        .toList(growable: false);
+    if (forward.isEmpty) {
+      return 'No forward transition is available from this state. '
+          'Run `iq doctor` if you are stuck.';
+    }
+    if (forward.length > 1) {
+      return 'DECISION FOR THE HUMAN: multiple paths are available '
+          '(${forward.join(', ')}). Present the situation and the options to '
+          'the human and let them choose — do not decide yourself.';
+    }
+    final event = forward.first;
+    if (completionAuthority == 'user') {
+      return 'STOP — the deliverable is ready. Present it to the human and ask '
+          'them to approve the transition `$event`. The human decides — do not '
+          'run the transition yourself.';
+    }
+    return 'Run `iq fsm transition --event $event`.';
   }
 
   List<Map<String, String>> _computeTransitions(

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.10.9';
+const String inquiryVersion = '0.10.10';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.10.9
+version: 0.10.10
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/fsm_state_test.dart
+++ b/code/cli/test/fsm_state_test.dart
@@ -102,6 +102,27 @@ void main() {
         },
       );
 
+      test('prescribes the single next action in `next` (#270)', () async {
+        setupWorkspace(state: 'ANALYZE', issue: '145');
+
+        final result = await FsmStateCommand(
+          FsmStateInput(workingDirectory: tempDir.path),
+        ).execute();
+        final next = result.toJson()['next'] as String;
+
+        expect(next, isNotEmpty);
+        // The CLI prescribes one concrete action: a command to run, or a
+        // hand-off to the human — the model never chooses for itself.
+        expect(
+          next.contains('Run `iq') ||
+              next.contains('STOP') ||
+              next.contains('DECISION FOR THE HUMAN'),
+          isTrue,
+          reason: 'next must prescribe a single action or defer to the human',
+        );
+        expect(result.toText(), contains('Next:'));
+      });
+
       test('returns operational contract sourced from state assets', () async {
         setupWorkspace(state: 'EXECUTE', issue: '145');
 

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.10.9</span>
+      <span class="badge">v0.10.10</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
First lever of #270 ("CLI is the brain, model is the hands").

## What

`iq fsm state` now emits a **`next`** field — the exact next command, computed by the CLI from the state, the active operator, and completion authority. The model (or a human using the CLI as a dev guide) no longer chooses FSM events or paths.

- operator running → dispatch the write-capable operator (it writes the deliverable), then advance;
- single forward event + `automatic` authority → `Run \`iq fsm transition --event X\``;
- `user` authority, or more than one forward path → **hand the decision to the human** ("STOP — present to the human; the human decides"), because decisions carry consequences and responsibility.

The firmware's Outer Loop reduces to "do exactly what `next` says" and shed a now-redundant rule (body stays under the 90-line guard).

## QA

- `dart analyze` clean; full `dart test` **466 passing** (new `next` test).
- **Honest validation note:** a conducted qwen3-coder:30b-16k batch could NOT measure lever 1's effect — **0/4 trials engaged** (the model never ran `iq fsm state`, so never saw `next`). This re-surfaces that **engagement (#264) is the upstream blocker**: relying on the model to *drive* the FSM loop is itself unreliable. Lever 1 is correct and necessary, but its benefit only applies once the loop is reliably entered — pointing toward a runner/conductor that drives the loop rather than hoping the model does.