### PR TITLE
fix(init): deploy the inquiry agent repo-scoped (per-project), not global — host-aware iq init (#272)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.10.11]
+### Fixed
+- **OpenCode agent was deployed globally; now repo-scoped via `iq init`** (#272): `iq host get --host opencode` used to install the inquiry agent to `~/.config/opencode/agent/inquiry.md` (global), so it appeared in **every** OpenCode session in any directory — even repos that never ran `iq init` — and could duplicate across hosts that share discovery dirs (e.g. Copilot also reads `.claude/`). `iq init` now deploys the agent **into the repo**, like `git init`: `iq init [--host copilot|opencode]` (default **opencode**) writes `.opencode/agent/inquiry.md` or `.github/agents/inquiry.agent.md`, records the chosen host in `.inquiry/config.yaml`, and deploys **one host at a time** (no cross-host duplication). `OpenCodeAdapter.deploysAgent` is now `false`; `iq host get` deploys **skills only** and `clean()` removes any stale global agent from older versions. `iq doctor` verifies the per-project agent location via a new host-aware `HostAdapter.projectAgentRelPath`. **Behavior change:** `iq init`'s default host is now `opencode` (was `copilot`). Skills remain global pending a follow-up.
+
+> Note (release ordering): branched off 0.10.9; merge after #271 (0.10.10).
+
 ## [0.10.9]
 ### Changed
-- **ANALYZE evidence handle: clearer operator contract + targeted gate error** (#268): SOCRATES's diagnosis contract now requires every Evidence bullet to carry a re-checkable handle (a `file:line` like `average.py:3`, a URL, or inline-code in backticks) — a bullet without one is invalid, add the handle rather than dropping the claim. When `complete_analysis` blocks on `DIAGNOSIS_EVIDENCE_UNVERIFIABLE`, the error now **names the offending bullet(s)** so the operator can repair precisely (feeding the #263 repair loop) instead of re-writing the whole diagnosis. Accepted handle forms (URL / file:line / inline-code) are unchanged.
+- **ANALYZE evidence handle: clearer operator contract + targeted gate error** (#268): SOCRATES's diagnosis contract now requires every Evidence bullet to carry a re-checkable handle (a `file:line` like `average.py:3`, a URL, or inline-code in backticks) — a bullet without one is invalid, add the handle rather than dropping the claim. When `complete_analysis` blocks on `DIAGNOSIS_EVIDENCE_UNVERIFIABLE`, the error now **names the offending bullet(s)** so the operator can repair precisely (feeding the #263 repair loop) instead of re-writing the whole diagnosis. Accepted handle forms (URL / file:line / inline-code) are unchanged. SOCRATES's diagnosis contract now requires every Evidence bullet to carry a re-checkable handle (a `file:line` like `average.py:3`, a URL, or inline-code in backticks) — a bullet without one is invalid, add the handle rather than dropping the claim. When `complete_analysis` blocks on `DIAGNOSIS_EVIDENCE_UNVERIFIABLE`, the error now **names the offending bullet(s)** so the operator can repair precisely (feeding the #263 repair loop) instead of re-writing the whole diagnosis. Accepted handle forms (URL / file:line / inline-code) are unchanged.
 
 ## [0.10.8]
 ### Changed

--- a/code/cli/lib/hosts/copilot_adapter.dart
+++ b/code/cli/lib/hosts/copilot_adapter.dart
@@ -17,6 +17,10 @@ class CopilotAdapter extends HostAdapter {
   String agentDirectory(String homeDir) =>
       p.join(homeDir, '.copilot', 'agents');
 
+  // Copilot discovers repo agents in `.github/agents/`.
+  @override
+  String get projectAgentRelPath => p.join('.github', 'agents', 'inquiry.agent.md');
+
   // Copilot runs inside VS Code: the install hint points at the command palette.
   @override
   Map<String, String> get agentSubstitutions => const {

--- a/code/cli/lib/hosts/host_adapter.dart
+++ b/code/cli/lib/hosts/host_adapter.dart
@@ -22,8 +22,15 @@ abstract class HostAdapter {
   /// Whether `host get` should also deploy the inquiry agent to this host.
   ///
   /// Most hosts receive skills only; the inquiry agent is repo-scoped via
-  /// `iq init`. Hosts that expose a global agent directory (OpenCode) opt in.
+  /// `iq init`. Hosts that expose a global agent directory may opt in.
   bool get deploysAgent => false;
+
+  /// Repo-relative path of this host's per-project agent file, e.g.
+  /// `.opencode/agent/inquiry.md` or `.github/agents/inquiry.agent.md`.
+  ///
+  /// `null` when this host has no per-project agent location. Used by `iq init`
+  /// (to deploy, repo-scoped like `git init`) and `iq doctor` (to verify).
+  String? get projectAgentRelPath => null;
 
   /// Asset path of this host's agent frontmatter YAML.
   ///

--- a/code/cli/lib/hosts/opencode_adapter.dart
+++ b/code/cli/lib/hosts/opencode_adapter.dart
@@ -14,16 +14,20 @@ class OpenCodeAdapter extends HostAdapter {
   String skillsDirectory(String homeDir) =>
       p.join(homeDir, '.config', 'opencode', 'skills');
 
-  // OpenCode discovers global agents in `~/.config/opencode/agent/` (singular).
-  // A plural `agents/` directory is ignored, so `opencode agent list` never sees
-  // the deployed agent and `opencode run --agent inquiry` silently falls back to
-  // the default agent (#247).
+  // OpenCode's global agent dir (singular `agent/`, #247). The agent is no
+  // longer deployed here — it is repo-scoped via `iq init` (#272) — but `clean()`
+  // still targets this path to remove any stale global agent from older versions.
   @override
   String agentDirectory(String homeDir) =>
       p.join(homeDir, '.config', 'opencode', 'agent');
 
+  // The agent is repo-scoped (per-project), like git init — never global (#272).
   @override
-  bool get deploysAgent => true;
+  bool get deploysAgent => false;
+
+  // OpenCode discovers repo agents in `.opencode/agent/`.
+  @override
+  String get projectAgentRelPath => p.join('.opencode', 'agent', 'inquiry.md');
 
   // OpenCode is a headless CLI: the install hint points at `iq init`.
   @override

--- a/code/cli/lib/modules/global/commands/doctor.dart
+++ b/code/cli/lib/modules/global/commands/doctor.dart
@@ -430,15 +430,12 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
     }
   }
 
-  /// Verifies that the repo-scoped agent exists at .github/agents/.
-  bool _verifyRepoAgent() {
-    final agentPath = p.join(
-      _workingDirectory,
-      '.github',
-      'agents',
-      'inquiry.agent.md',
-    );
-    return _fileSystem.fileExists(agentPath);
+  /// Verifies that the repo-scoped agent exists at this host's per-project
+  /// location (e.g. `.opencode/agent/inquiry.md` or `.github/agents/`).
+  bool _verifyRepoAgent(HostAdapter adapter) {
+    final rel = adapter.projectAgentRelPath;
+    if (rel == null) return false;
+    return _fileSystem.fileExists(p.join(_workingDirectory, rel));
   }
 
   /// Verifies a single host adapter's deployment.
@@ -451,7 +448,7 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
     final agentExists = adapter.deploysAgent
         ? _fileSystem
             .fileExists(p.join(adapter.agentDirectory(homeDir), 'inquiry.md'))
-        : _verifyRepoAgent();
+        : _verifyRepoAgent(adapter);
 
     // Check skills — adapter-scoped
     final missingSkills = <String>[];

--- a/code/cli/lib/modules/global/commands/init.dart
+++ b/code/cli/lib/modules/global/commands/init.dart
@@ -4,7 +4,9 @@
 /// 1. Create cleanrooms/ at project root if missing
 /// 2. Add .inquiry/ and cleanrooms/**/.iq.state.yaml to .gitignore
 /// 3. Create .inquiry/config.yaml with defaults (project-scoped)
-/// 4. Deploy inquiry.agent.md to .github/agents/ (repo-scoped)
+/// 4. Deploy the inquiry agent into the repo for the selected host (repo-scoped,
+///    like `git init`): `.opencode/agent/inquiry.md` (default) or
+///    `.github/agents/inquiry.agent.md` (`--host copilot`)
 ///
 /// Cycle runtime (`.iq.state.yaml`, `mutations.md`) is materialized per cycle
 /// under `cleanrooms/<branch>/` by the FSM, not scaffolded at init.
@@ -19,6 +21,8 @@ import 'package:path/path.dart' as p;
 import '../../../assets.dart';
 import '../../../hosts/agent_builder.dart';
 import '../../../hosts/copilot_adapter.dart';
+import '../../../hosts/host_adapter.dart';
+import '../../../hosts/opencode_adapter.dart';
 import '../../../src/git_utils.dart';
 
 // ─── Input ──────────────────────────────────────────────────────────────────
@@ -30,13 +34,33 @@ import '../../../src/git_utils.dart';
 class InitInput extends Input {
   final String workingDirectory;
 
-  InitInput({required this.workingDirectory});
+  /// The host to deploy the repo-scoped agent for. Defaults to `opencode`.
+  final String host;
 
-  factory InitInput.fromCliRequest(CliRequest req) =>
-      InitInput(workingDirectory: Directory.current.path);
+  InitInput({required this.workingDirectory, this.host = 'opencode'});
+
+  factory InitInput.fromCliRequest(CliRequest req) => InitInput(
+        workingDirectory: Directory.current.path,
+        host: req.flagString('host') ?? 'opencode',
+      );
 
   @override
-  Map<String, dynamic> toJson() => {'workingDirectory': workingDirectory};
+  Map<String, dynamic> toJson() => {
+        'workingDirectory': workingDirectory,
+        'host': host,
+      };
+}
+
+/// Resolves a host name to its adapter, or `null` if unknown / no repo agent.
+HostAdapter? _adapterForHost(String host) {
+  switch (host) {
+    case 'opencode':
+      return OpenCodeAdapter();
+    case 'copilot':
+      return CopilotAdapter();
+    default:
+      return null;
+  }
 }
 
 // ─── Output ─────────────────────────────────────────────────────────────────
@@ -68,7 +92,14 @@ class InitCommand implements Command<InitInput, InitOutput> {
   InitCommand(this.input, {this.assets});
 
   @override
-  String? validate() => null;
+  String? validate() {
+    final adapter = _adapterForHost(input.host);
+    if (adapter == null || adapter.projectAgentRelPath == null) {
+      return 'Unknown or unsupported host: "${input.host}". '
+          'Supported hosts: copilot, opencode.';
+    }
+    return null;
+  }
 
   @override
   Future<InitOutput> execute() async {
@@ -107,14 +138,19 @@ class InitCommand implements Command<InitInput, InitOutput> {
     return getProjectRoot(workingDirectory) ?? workingDirectory;
   }
 
+  /// Deploys the inquiry agent into the repo for the selected host — repo-scoped
+  /// like `git init`, never global (#272).
   void _deployAgent(String root, Assets assets, List<String> steps) {
-    final content = AgentBuilder(assets).build(CopilotAdapter());
-    final agentFile = File(
-      p.join(root, '.github', 'agents', 'inquiry.agent.md'),
-    );
+    final adapter = _adapterForHost(input.host)!;
+    final rel = adapter.projectAgentRelPath!;
+    final content = AgentBuilder(assets).build(adapter);
+    final agentFile = File(p.join(root, rel));
     agentFile.parent.createSync(recursive: true);
     agentFile.writeAsStringSync(content);
-    steps.add('Deployed inquiry.agent.md to .github/agents/');
+    steps.add(
+      'Deployed inquiry agent to ${rel.replaceAll(r'\', '/')} '
+      '(host: ${input.host})',
+    );
   }
 
   /// Ensures `.inquiry/` and cycle-local state are in `.gitignore`.
@@ -150,6 +186,7 @@ class InitCommand implements Command<InitInput, InitOutput> {
     if (!configFile.existsSync()) {
       if (!configDir.existsSync()) configDir.createSync(recursive: true);
       configFile.writeAsStringSync(
+        'host: ${input.host}\n'
         'evolution:\n'
         '  enabled: false\n',
       );

--- a/code/cli/lib/modules/global/global_builder.dart
+++ b/code/cli/lib/modules/global/global_builder.dart
@@ -30,7 +30,8 @@ void buildGlobalModule(
   m.command<InitInput, InitOutput>(
     'init',
     (req) => InitCommand(InitInput.fromCliRequest(req), assets: assets),
-    description: 'Initialize a new .inquiry/ workspace',
+    description:
+        'Initialize Inquiry in this repo (repo-scoped). --host <copilot|opencode> (default: opencode)',
   );
 
   m.command<VersionInput, VersionOutput>(

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.10.9';
+const String inquiryVersion = '0.10.11';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.10.9
+version: 0.10.11
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/doctor_test.dart
+++ b/code/cli/test/doctor_test.dart
@@ -576,9 +576,9 @@ void main() {
       test('Scenario E: OpenCode active, Copilot inactive → exit 0 (regression #257)', () async {
         final fs = MockFileSystemOps()..setHome(homeDir);
         fs.setDirectoryExists('.inquiry', true);
-        // OpenCode fully deployed: global agent + skills.
+        // OpenCode fully deployed: repo-scoped agent (#272) + skills.
         fs.setFileExists(
-          p.join(homeDir, '.config', 'opencode', 'agent', 'inquiry.md'),
+          p.join(workingDir, '.opencode', 'agent', 'inquiry.md'),
           true,
         );
         for (final skill in testSkills) {
@@ -650,7 +650,7 @@ void main() {
         final fs = MockFileSystemOps()..setHome(homeDir);
         fs.setDirectoryExists('.inquiry', true);
         fs.setFileExists(
-          p.join(homeDir, '.config', 'opencode', 'agent', 'inquiry.md'),
+          p.join(workingDir, '.opencode', 'agent', 'inquiry.md'),
           true,
         );
         for (final s in testSkills) {

--- a/code/cli/test/hosts_test.dart
+++ b/code/cli/test/hosts_test.dart
@@ -77,15 +77,25 @@ void main() {
     });
   });
 
-  group('deploysAgent capability', () {
-    test('opencode opts into agent deploy', () {
+  group('agent deploy is repo-scoped, never global (#272)', () {
+    test('opencode does not deploy a global agent', () {
       final opencode = deployAdapters.firstWhere((a) => a.name == 'opencode');
-      expect(opencode.deploysAgent, isTrue);
+      expect(opencode.deploysAgent, isFalse);
     });
 
-    test('copilot does not deploy the agent', () {
+    test('copilot does not deploy a global agent', () {
       final copilot = deployAdapters.firstWhere((a) => a.name == 'copilot');
       expect(copilot.deploysAgent, isFalse);
+    });
+
+    test('each host exposes its per-project agent path', () {
+      final opencode = deployAdapters.firstWhere((a) => a.name == 'opencode');
+      final copilot = deployAdapters.firstWhere((a) => a.name == 'copilot');
+      expect(opencode.projectAgentRelPath, p.join('.opencode', 'agent', 'inquiry.md'));
+      expect(
+        copilot.projectAgentRelPath,
+        p.join('.github', 'agents', 'inquiry.agent.md'),
+      );
     });
   });
 }

--- a/code/cli/test/init_command_test.dart
+++ b/code/cli/test/init_command_test.dart
@@ -229,27 +229,33 @@ void main() {
       });
     });
 
-    // ─── Step 7: .github/agents/inquiry.agent.md ──────────────────────
+    // ─── Step 7: repo-scoped, host-aware agent deploy (#272) ─────────────
 
     group('Step 7: repo-scoped agent deploy', () {
       late Directory assetsRoot;
 
+      // Per-project agent paths by host.
+      String openCodeAgent(String root) =>
+          p.join(root, '.opencode', 'agent', 'inquiry.md');
+      String copilotAgent(String root) =>
+          p.join(root, '.github', 'agents', 'inquiry.agent.md');
+
       setUp(() {
-        // Minimal assets tree with an agent file
+        // Minimal assets tree with the shared body + both host frontmatters.
         assetsRoot = Directory.systemTemp.createTempSync(
           'inquiry_assets_test_',
         );
         final agentDir = Directory(p.join(assetsRoot.path, 'assets', 'agents'));
         agentDir.createSync(recursive: true);
-        // Firmware is assembled from the shared body + per-host frontmatter.
         File(
           p.join(agentDir.path, 'inquiry.body.md'),
         ).writeAsStringSync('Test agent content.');
         final fmDir = Directory(p.join(agentDir.path, 'frontmatter'))
           ..createSync(recursive: true);
-        File(
-          p.join(fmDir.path, 'copilot.yaml'),
-        ).writeAsStringSync('name: inquiry');
+        File(p.join(fmDir.path, 'copilot.yaml'))
+            .writeAsStringSync('name: inquiry');
+        File(p.join(fmDir.path, 'opencode.yaml'))
+            .writeAsStringSync('name: inquiry');
       });
 
       tearDown(() {
@@ -257,75 +263,87 @@ void main() {
       });
 
       test(
-        'writes inquiry.agent.md to .github/agents/ when assets provided',
+        'default host (opencode): writes .opencode/agent/inquiry.md, not global',
         () async {
-          final assets = Assets(root: assetsRoot.path);
           final command = InitCommand(
             InitInput(workingDirectory: tempDir.path),
-            assets: assets,
+            assets: Assets(root: assetsRoot.path),
           );
           await command.execute();
 
-          final agentFile = File(
-            p.join(tempDir.path, '.github', 'agents', 'inquiry.agent.md'),
-          );
+          final agentFile = File(openCodeAgent(tempDir.path));
           expect(agentFile.existsSync(), isTrue);
           expect(agentFile.readAsStringSync(), contains('Test agent content.'));
+          // Repo-scoped: no copilot agent unless requested.
+          expect(File(copilotAgent(tempDir.path)).existsSync(), isFalse);
         },
       );
 
-      test('creates .github/agents/ directory if missing', () async {
-        final assets = Assets(root: assetsRoot.path);
+      test('--host copilot: writes .github/agents/inquiry.agent.md', () async {
         final command = InitCommand(
-          InitInput(workingDirectory: tempDir.path),
-          assets: assets,
+          InitInput(workingDirectory: tempDir.path, host: 'copilot'),
+          assets: Assets(root: assetsRoot.path),
         );
         await command.execute();
 
+        expect(File(copilotAgent(tempDir.path)).existsSync(), isTrue);
+        // One host at a time: no opencode agent.
+        expect(File(openCodeAgent(tempDir.path)).existsSync(), isFalse);
+      });
+
+      test('records the chosen host in .inquiry/config.yaml', () async {
+        await InitCommand(
+          InitInput(workingDirectory: tempDir.path, host: 'copilot'),
+          assets: Assets(root: assetsRoot.path),
+        ).execute();
+
+        final config =
+            File('${tempDir.path}/.inquiry/config.yaml').readAsStringSync();
+        expect(config, contains('host: copilot'));
+      });
+
+      test('creates the per-project agent directory if missing', () async {
+        await InitCommand(
+          InitInput(workingDirectory: tempDir.path),
+          assets: Assets(root: assetsRoot.path),
+        ).execute();
+
         expect(
-          Directory(p.join(tempDir.path, '.github', 'agents')).existsSync(),
+          Directory(p.join(tempDir.path, '.opencode', 'agent')).existsSync(),
           isTrue,
         );
       });
 
-      test(
-        'overwrites existing inquiry.agent.md on re-init (idempotent)',
-        () async {
-          // Write stale content first
-          final agentDir = Directory(p.join(tempDir.path, '.github', 'agents'))
-            ..createSync(recursive: true);
-          File(
-            p.join(agentDir.path, 'inquiry.agent.md'),
-          ).writeAsStringSync('stale content');
+      test('overwrites an existing agent on re-init (idempotent)', () async {
+        final agentDir = Directory(p.join(tempDir.path, '.opencode', 'agent'))
+          ..createSync(recursive: true);
+        File(p.join(agentDir.path, 'inquiry.md'))
+            .writeAsStringSync('stale content');
 
-          final assets = Assets(root: assetsRoot.path);
-          final command = InitCommand(
-            InitInput(workingDirectory: tempDir.path),
-            assets: assets,
-          );
-          await command.execute();
+        await InitCommand(
+          InitInput(workingDirectory: tempDir.path),
+          assets: Assets(root: assetsRoot.path),
+        ).execute();
 
-          final content = File(
-            p.join(tempDir.path, '.github', 'agents', 'inquiry.agent.md'),
-          ).readAsStringSync();
-          expect(content, contains('Test agent content.'));
-          expect(content, isNot(contains('stale content')));
-        },
-      );
+        final content = File(openCodeAgent(tempDir.path)).readAsStringSync();
+        expect(content, contains('Test agent content.'));
+        expect(content, isNot(contains('stale content')));
+      });
 
       test('skips agent deploy silently when assets is null', () async {
-        final command = InitCommand(
+        await InitCommand(
           InitInput(workingDirectory: tempDir.path),
-          // no assets param
-        );
-        await command.execute();
+        ).execute();
 
-        expect(
-          File(
-            p.join(tempDir.path, '.github', 'agents', 'inquiry.agent.md'),
-          ).existsSync(),
-          isFalse,
-        );
+        expect(File(openCodeAgent(tempDir.path)).existsSync(), isFalse);
+      });
+
+      test('rejects an unknown host via validate()', () {
+        final err = InitCommand(
+          InitInput(workingDirectory: tempDir.path, host: 'bogus'),
+        ).validate();
+        expect(err, isNotNull);
+        expect(err, contains('bogus'));
       });
     });
   });

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.10.9</span>
+      <span class="badge">v0.10.11</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
Closes #272. Found while testing on a real repo.

## Problem

`iq host get --host opencode` installed the inquiry agent **globally** at `~/.config/opencode/agent/inquiry.md`, so it showed up in **every** OpenCode session, in any directory — even repos that never ran `iq init`. Meanwhile `iq init` only deployed the **Copilot** agent (repo-scoped). Asymmetric and global-by-default; also risks cross-host duplication (Copilot also reads `.claude/`).

## Fix — `iq init` works like `git init` (repo-scoped, one host)

- `iq init [--host copilot|opencode]` — **default `opencode`** — deploys the agent **into the repo**: `.opencode/agent/inquiry.md` or `.github/agents/inquiry.agent.md`. Records the host in `.inquiry/config.yaml`. One host at a time → no duplication.
- New host-aware `HostAdapter.projectAgentRelPath`, used by both `iq init` (deploy) and `iq doctor` (verify).
- `OpenCodeAdapter.deploysAgent => false`; `iq host get` now deploys **skills only** and `clean()` removes any stale global agent.

**Behavior change:** `iq init` default host is now `opencode` (was `copilot`). Skills stay global for now (follow-up).

## QA

- `dart analyze` clean; full `dart test` **469 passing** (updated init/doctor/hosts tests; added `--host copilot`, config-records-host, unknown-host, per-project-path tests).
- **Verified end-to-end with the real binary:** `iq init`→`.opencode/agent/inquiry.md` (+ `host: opencode` in config, no `.github/agents/`); `iq init --host copilot`→`.github/agents/inquiry.agent.md`; `iq host get --host opencode`→stale global agent **cleaned**, skills retained.

> Release ordering: branched off 0.10.9 (0.10.11). Merge **after** #271 (0.10.10); a small CHANGELOG conflict may need resolving at merge.