### PR TITLE
fix(init): one host at a time on re-init — remove other host's agent + reconcile config host (#274)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.10.12]
+### Fixed
+- **`iq init` host switch left the old agent and a stale config host** (#274): switching hosts on an existing repo (`iq init`, then `iq init --host copilot`) left the previous host's per-project agent in place — both `.opencode/agent/` and `.github/agents/` present, the cross-host duplication #272 set out to avoid — and `.inquiry/config.yaml` kept the old `host:`. `iq init` now removes the other supported host's agent (exactly one host at a time) and reconciles the `host:` line in config while **preserving** other keys (e.g. `evolution.enabled`). Fresh init is unchanged.
+
 ## [0.10.11]
 ### Fixed
 - **OpenCode agent was deployed globally; now repo-scoped via `iq init`** (#272): `iq host get --host opencode` used to install the inquiry agent to `~/.config/opencode/agent/inquiry.md` (global), so it appeared in **every** OpenCode session in any directory — even repos that never ran `iq init` — and could duplicate across hosts that share discovery dirs (e.g. Copilot also reads `.claude/`). `iq init` now deploys the agent **into the repo**, like `git init`: `iq init [--host copilot|opencode]` (default **opencode**) writes `.opencode/agent/inquiry.md` or `.github/agents/inquiry.agent.md`, records the chosen host in `.inquiry/config.yaml`, and deploys **one host at a time** (no cross-host duplication). `OpenCodeAdapter.deploysAgent` is now `false`; `iq host get` deploys **skills only** and `clean()` removes any stale global agent from older versions. `iq doctor` verifies the per-project agent location via a new host-aware `HostAdapter.projectAgentRelPath`. **Behavior change:** `iq init`'s default host is now `opencode` (was `copilot`). Skills remain global pending a follow-up.

--- a/code/cli/lib/modules/global/commands/init.dart
+++ b/code/cli/lib/modules/global/commands/init.dart
@@ -119,8 +119,10 @@ class InitCommand implements Command<InitInput, InitOutput> {
     // Step 3: Create .inquiry/config.yaml with defaults (project-scoped)
     _ensureConfigYaml(root, steps);
 
-    // Step 4: Deploy inquiry.agent.md to .github/agents/ (repo-scoped)
+    // Step 4: Deploy the repo-scoped agent for this host; first remove any
+    // other host's agent so exactly one host is deployed at a time (#274).
     if (assets != null) {
+      _cleanOtherHostAgents(root, steps);
       _deployAgent(root, assets!, steps);
     }
 
@@ -153,6 +155,22 @@ class InitCommand implements Command<InitInput, InitOutput> {
     );
   }
 
+  /// Removes the per-project agent of every supported host other than the one
+  /// being initialized — enforces "one host at a time" even when switching
+  /// hosts on an existing repo (#274). No-op on a fresh init.
+  void _cleanOtherHostAgents(String root, List<String> steps) {
+    for (final host in const ['copilot', 'opencode']) {
+      if (host == input.host) continue;
+      final rel = _adapterForHost(host)?.projectAgentRelPath;
+      if (rel == null) continue;
+      final file = File(p.join(root, rel));
+      if (file.existsSync()) {
+        file.deleteSync();
+        steps.add('Removed $host agent (${rel.replaceAll(r'\', '/')})');
+      }
+    }
+  }
+
   /// Ensures `.inquiry/` and cycle-local state are in `.gitignore`.
   void _ensureGitignore(String root, List<String> steps) {
     const entries = <String>['.inquiry/', 'cleanrooms/**/.iq.state.yaml'];
@@ -178,7 +196,11 @@ class InitCommand implements Command<InitInput, InitOutput> {
     steps.add('Added Inquiry entries to .gitignore');
   }
 
-  /// Ensures `.inquiry/config.yaml` exists with default configuration.
+  /// Ensures `.inquiry/config.yaml` exists and records the chosen host.
+  ///
+  /// On a fresh repo it writes the defaults; on an existing repo it reconciles
+  /// the `host:` line to the chosen host while preserving every other key
+  /// (e.g. `evolution.enabled`), so switching hosts updates the record.
   void _ensureConfigYaml(String root, List<String> steps) {
     final configDir = Directory('$root/.inquiry');
     final configFile = File('$root/.inquiry/config.yaml');
@@ -191,6 +213,21 @@ class InitCommand implements Command<InitInput, InitOutput> {
         '  enabled: false\n',
       );
       steps.add('Created .inquiry/config.yaml');
+      return;
+    }
+
+    final content = configFile.readAsStringSync();
+    final hostLine = RegExp(r'^host:.*$', multiLine: true);
+    final desired = 'host: ${input.host}';
+    if (hostLine.hasMatch(content)) {
+      if (hostLine.firstMatch(content)!.group(0) != desired) {
+        configFile.writeAsStringSync(content.replaceFirst(hostLine, desired));
+        steps.add('Updated host to ${input.host} in .inquiry/config.yaml');
+      }
+    } else {
+      // Legacy config without a host line: prepend it, keep the rest.
+      configFile.writeAsStringSync('$desired\n$content');
+      steps.add('Recorded host: ${input.host} in .inquiry/config.yaml');
     }
   }
 

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.10.11';
+const String inquiryVersion = '0.10.12';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.10.11
+version: 0.10.12
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/init_command_test.dart
+++ b/code/cli/test/init_command_test.dart
@@ -345,6 +345,64 @@ void main() {
         expect(err, isNotNull);
         expect(err, contains('bogus'));
       });
+
+      test(
+          'switching host removes the previous host agent + updates config (#274)',
+          () async {
+        final assets = Assets(root: assetsRoot.path);
+        await InitCommand(
+          InitInput(workingDirectory: tempDir.path),
+          assets: assets,
+        ).execute(); // opencode (default)
+        expect(File(openCodeAgent(tempDir.path)).existsSync(), isTrue);
+
+        await InitCommand(
+          InitInput(workingDirectory: tempDir.path, host: 'copilot'),
+          assets: assets,
+        ).execute(); // switch
+
+        // Exactly one host at a time: copilot present, opencode removed.
+        expect(File(copilotAgent(tempDir.path)).existsSync(), isTrue);
+        expect(File(openCodeAgent(tempDir.path)).existsSync(), isFalse);
+
+        final config =
+            File('${tempDir.path}/.inquiry/config.yaml').readAsStringSync();
+        expect(config, contains('host: copilot'));
+        expect(config, isNot(contains('host: opencode')));
+      });
+
+      test('reconciling host preserves other config keys (#274)', () async {
+        Directory('${tempDir.path}/.inquiry').createSync(recursive: true);
+        File('${tempDir.path}/.inquiry/config.yaml')
+            .writeAsStringSync('host: opencode\nevolution:\n  enabled: true\n');
+
+        await InitCommand(
+          InitInput(workingDirectory: tempDir.path, host: 'copilot'),
+          assets: Assets(root: assetsRoot.path),
+        ).execute();
+
+        final config =
+            File('${tempDir.path}/.inquiry/config.yaml').readAsStringSync();
+        expect(config, contains('host: copilot'));
+        expect(config, contains('enabled: true')); // preserved
+      });
+
+      test('legacy config without a host line gets one recorded (#274)',
+          () async {
+        Directory('${tempDir.path}/.inquiry').createSync(recursive: true);
+        File('${tempDir.path}/.inquiry/config.yaml')
+            .writeAsStringSync('evolution:\n  enabled: false\n');
+
+        await InitCommand(
+          InitInput(workingDirectory: tempDir.path),
+          assets: Assets(root: assetsRoot.path),
+        ).execute();
+
+        final config =
+            File('${tempDir.path}/.inquiry/config.yaml').readAsStringSync();
+        expect(config, contains('host: opencode'));
+        expect(config, contains('enabled: false'));
+      });
     });
   });
 }

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.10.11</span>
+      <span class="badge">v0.10.12</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
Closes #274. Found during the 0.10.11 QA of #272.

## Problem

Fresh `iq init` is correct for both hosts, but **switching hosts on an existing repo** was not:
```
iq init                 # opencode → .opencode/agent/inquiry.md, config host: opencode
iq init --host copilot  # copilot agent added…
```
…left `.opencode/agent/inquiry.md` in place (both hosts' agents present — the cross-host duplication #272 set out to avoid) and `.inquiry/config.yaml` still said `host: opencode`.

## Fix

`iq init` now:
- **removes the other supported host's** per-project agent (exactly one host at a time; no-op on fresh init);
- **reconciles the `host:` line** in `.inquiry/config.yaml` to the chosen host, **preserving** every other key (e.g. `evolution.enabled`).

## QA

- `dart analyze` clean; full `dart test` **473 passing** (3 new #274 tests: switch removes old agent + updates config, reconcile preserves other keys, legacy config gains a host line).
- **Verified end-to-end with the real binary:** switch `opencode → copilot` reports `Removed opencode agent` + `Updated host to copilot`, leaves only `.github/agents/inquiry.agent.md`; switching back preserves `evolution.enabled: true`.