### PR TITLE
fix: bilingual specification_ready gate — --lang es specs were wrongly rejected (v0.15.1)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.15.1]
+### Fixed
+- **The `specification_ready` gate was English-only and rejected every `--lang es` spec** (found by dogfooding a real requirement): the gate matched section headers (`1. User Stories`), scope subheadings (`Includes`/`Does NOT include`) and the `**Decision**`/`**Evidence**` markers by their English text, so a Spanish specification — which the same CLI generates with `iq specification new --lang es` — failed with `SPEC_NO_USER_STORY` even when fully and correctly filled. The gate is now **bilingual / language-agnostic**: sections are matched by their leading number (`1.`/`2.`/`3.`/`4.`, identical across templates), and the scope subheadings and Decision/Evidence markers accept both English and Spanish (`Incluye`/`NO incluye`, `Decisión`/`Evidencia`); role lines are read by the English keyword the es template embeds (`**As a (Como)**`). A filled Spanish spec now passes. Regression test added.
+
 ## [0.15.0]
 ### Added
 - **The QA specification phase — turn a raw requisition into a healthy specification + issues, deciding by evidence** (#282): a new, independent QA-facing phase that *precedes* the dev cycle (analyze→plan→execute) and produces the issues it hands off. It is the methodology's controlled-vocabulary chain **requisition → specification → requirements**, made executable:

--- a/code/cli/lib/modules/specification/specification_gate.dart
+++ b/code/cli/lib/modules/specification/specification_gate.dart
@@ -65,7 +65,7 @@ class SpecificationGate {
     Map<String, String> sections,
     List<SpecificationViolation> violations,
   ) {
-    final body = _sectionStartingWith(sections, '1. User Stories');
+    final body = _section(sections, 1);
     if (body == null) {
       violations.add(const SpecificationViolation(
         'SPEC_NO_USER_STORY', 'No "User Stories" section found.'));
@@ -97,7 +97,7 @@ class SpecificationGate {
     Map<String, String> sections,
     List<SpecificationViolation> violations,
   ) {
-    final body = _sectionStartingWith(sections, '2. Testing Strategy');
+    final body = _section(sections, 2);
     final hasFilledRow = body != null &&
         _tableDataRows(body).any((cells) =>
             cells.length >= 2 && _isFilled(cells[1]));
@@ -114,10 +114,11 @@ class SpecificationGate {
     Map<String, String> sections,
     List<SpecificationViolation> violations,
   ) {
-    final body = _sectionStartingWith(sections, '3. Explicit Scope');
-    final includes = body == null ? false : _hasFilledBullet(body, 'Includes');
+    final body = _section(sections, 3);
+    final includes =
+        body == null ? false : _hasFilledBullet(body, _includesHeadings);
     final excludes =
-        body == null ? false : _hasFilledBullet(body, 'Does NOT include');
+        body == null ? false : _hasFilledBullet(body, _excludesHeadings);
     if (!includes || !excludes) {
       violations.add(const SpecificationViolation(
         'SPEC_SCOPE_INCOMPLETE',
@@ -131,16 +132,15 @@ class SpecificationGate {
     Map<String, String> sections,
     List<SpecificationViolation> violations,
   ) {
-    final body = _sectionStartingWith(sections, '4. Decisions');
+    final body = _section(sections, 4);
     final hasEvidence = body != null &&
         body.split('\n').any((line) {
-          if (!line.contains('**Decision**') ||
-              !line.contains('**Evidence**')) {
-            return false;
-          }
-          final decision = _valueAfter(line, '**Decision**');
-          final evidence = _valueAfter(line, '**Evidence**');
-          return _isFilled(decision) && _isFilled(evidence);
+          final decision = _valueAfterAnyMarker(line, _decisionMarkers);
+          final evidence = _valueAfterAnyMarker(line, _evidenceMarkers);
+          return decision != null &&
+              evidence != null &&
+              _isFilled(decision) &&
+              _isFilled(evidence);
         });
     if (!hasEvidence) {
       violations.add(const SpecificationViolation(
@@ -159,7 +159,7 @@ class SpecificationGate {
     List<String> issues,
     List<SpecificationViolation> violations,
   ) {
-    final body = _sectionStartingWith(sections, '1. User Stories');
+    final body = _section(sections, 1);
     if (body == null) return;
 
     final declared = <String>{};
@@ -207,9 +207,13 @@ class SpecificationGate {
     return sections;
   }
 
-  String? _sectionStartingWith(Map<String, String> sections, String prefix) {
+  /// Looks up a section by its leading number (`## 1. …`). The templates number
+  /// the sections identically in every language (`1.` User Stories /
+  /// Historias de Usuario, `2.` Testing Strategy / Estrategia de Testing, …), so
+  /// this is language-agnostic — the gate works on `--lang es` specs too.
+  String? _section(Map<String, String> sections, int number) {
     for (final entry in sections.entries) {
-      if (entry.key.startsWith(prefix)) return entry.value;
+      if (entry.key.startsWith('$number.')) return entry.value;
     }
     return null;
   }
@@ -249,11 +253,15 @@ class SpecificationGate {
         ? title.substring(title.indexOf(':') + 1).trim()
         : title;
     if (!_isFilled(titleValue)) return false;
-    for (final marker in const ['**As a**', '**I want**', '**So that**']) {
+    // Role keywords are English in both templates (the es template embeds them:
+    // `**As a (Como)**`), so matching the English keyword finds the line in
+    // either language; the value is whatever follows the bold label.
+    for (final keyword in const ['As a', 'I want', 'So that']) {
       final line = block
           .split('\n')
-          .firstWhere((l) => l.contains(marker), orElse: () => '');
-      if (line.isEmpty || !_isFilled(_valueAfter(line, marker))) return false;
+          .firstWhere((l) => l.contains('**') && l.contains(keyword),
+              orElse: () => '');
+      if (line.isEmpty || !_isFilled(_valueAfterBold(line))) return false;
     }
     return true;
   }
@@ -287,20 +295,23 @@ class SpecificationGate {
       if (RegExp(r'^\|[\s\-:|]+\|?$').hasMatch(t)) continue; // separator
       final cells = _cells(line);
       if (cells.isEmpty) continue;
-      // Skip the header row (first cell is a known column label).
+      // Skip the header row (first cell is a known column label, en or es).
       final first = cells.first.toLowerCase();
-      if (first == 'type' || first == '#' || first == 'field') continue;
+      if (const {'type', 'tipo', '#', 'field', 'campo'}.contains(first)) {
+        continue;
+      }
       rows.add(cells);
     }
     return rows;
   }
 
-  bool _hasFilledBullet(String scopeBody, String subheading) {
+  bool _hasFilledBullet(String scopeBody, List<String> subheadings) {
     final lines = scopeBody.split('\n');
     var inSub = false;
     for (final line in lines) {
       if (line.startsWith('### ')) {
-        inSub = line.substring(4).trim().startsWith(subheading);
+        final heading = line.substring(4).trim();
+        inSub = subheadings.any((s) => heading.startsWith(s));
         continue;
       }
       if (inSub && line.trimLeft().startsWith('- ')) {
@@ -318,16 +329,42 @@ class SpecificationGate {
       .map((c) => c.trim())
       .toList();
 
-  String _valueAfter(String line, String marker) {
-    final i = line.indexOf(marker);
-    if (i < 0) return '';
-    var rest = line.substring(i + marker.length);
+  /// The text after the first `**…**` bold span on [line] (a role label such as
+  /// `**As a**` / `**As a (Como)**`), up to the next bold span. Language-neutral.
+  String _valueAfterBold(String line) {
+    final open = line.indexOf('**');
+    if (open < 0) return '';
+    final close = line.indexOf('**', open + 2);
+    if (close < 0) return '';
+    var rest = line.substring(close + 2);
     if (rest.startsWith(':')) rest = rest.substring(1);
-    // Stop at the next bold marker on the same line (e.g. **Evidence**).
     final next = rest.indexOf('**');
     if (next >= 0) rest = rest.substring(0, next);
     return rest;
   }
+
+  /// The value after the first matching bold [markers] label (e.g. `**Decision**`
+  /// or `**Decisión**`), stopping at the next bold span. Returns null when no
+  /// marker is present on the line.
+  String? _valueAfterAnyMarker(String line, List<String> markers) {
+    for (final marker in markers) {
+      final token = '**$marker**';
+      final i = line.indexOf(token);
+      if (i < 0) continue;
+      var rest = line.substring(i + token.length);
+      if (rest.startsWith(':')) rest = rest.substring(1);
+      final next = rest.indexOf('**');
+      if (next >= 0) rest = rest.substring(0, next);
+      return rest;
+    }
+    return null;
+  }
+
+  // Bilingual headings/markers (en + es) the templates ship.
+  static const _includesHeadings = ['Includes', 'Incluye'];
+  static const _excludesHeadings = ['Does NOT include', 'NO incluye'];
+  static const _decisionMarkers = ['Decision', 'Decisión'];
+  static const _evidenceMarkers = ['Evidence', 'Evidencia'];
 
   /// A value is "filled" when, after removing HTML comments and trailing
   /// punctuation/whitespace, something real remains.

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.15.0';
+const String inquiryVersion = '0.15.1';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.15.0
+version: 0.15.1
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/specification_gate_test.dart
+++ b/code/cli/test/specification_gate_test.dart
@@ -54,6 +54,55 @@ const _filledSpec = '''
 ## Annexes
 ''';
 
+/// A fully-filled Spanish (`--lang es`) specification — the gate must accept it
+/// (section headers, scope subheadings and Decision/Evidence markers are all in
+/// Spanish). Regression for the dogfood finding that the gate was English-only.
+const _filledSpecEs = '''
+# Especificación de Requerimiento
+
+## Metadatos
+
+| Campo | Valor |
+| ----- | ----- |
+| ID    | REQ-2026-06-30-001 |
+
+## 1. Historias de Usuario
+
+### HU-1: Registrar una factura
+
+**As a (Como)** analista de facturación,
+**I want (Quiero)** registrar una factura desde un formulario,
+**So that (Para)** no se pierdan registros.
+
+#### Acceptance Criteria
+
+| #    | Given (Dado que)   | When (Cuando)        | Then (Entonces)        |
+| ---- | ------------------ | -------------------- | ---------------------- |
+| AC-1 | el formulario abre | envío datos válidos  | la factura se almacena |
+
+## 2. Estrategia de Testing
+
+| Tipo | Qué debe validar          | AC asociados |
+| ---- | ------------------------- | ------------ |
+| Unit | la regla de no-duplicados | AC-1         |
+
+## 3. Alcance Explícito
+
+### Incluye
+
+- Formulario de registro de facturas.
+
+### NO incluye
+
+- El flujo de aprobación de facturas.
+
+## 4. Decisiones (evidencia)
+
+- **Decisión**: reusar la tabla `billing`. **Evidencia**: `psql -c "\\d billing"` muestra las columnas (corrido 2026-06-30).
+
+## Anexos
+''';
+
 void main() {
   final gate = SpecificationGate();
 
@@ -75,6 +124,12 @@ void main() {
 
     test('a fully-filled spec with one tracing issue passes', () {
       final r = gate.evaluate(_filledSpec, issues: tracingIssues);
+      expect(r.passed, isTrue, reason: r.violations.join('\n'));
+      expect(r.violations, isEmpty);
+    });
+
+    test('a fully-filled Spanish (--lang es) spec passes (bilingual gate)', () {
+      final r = gate.evaluate(_filledSpecEs, issues: const ['Cubre AC-1.']);
       expect(r.passed, isTrue, reason: r.violations.join('\n'));
       expect(r.violations, isEmpty);
     });

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.15.0</span>
+      <span class="badge">v0.15.1</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Bilingual `specification_ready` gate (v0.15.1)

**Found by dogfooding a real requirement.** Driving the brand-new specification phase on an actual `--lang es` requirement (ticket purchase from the credit history, in `impulsa/`), `iq specification check` rejected a fully and correctly filled Spanish spec with `SPEC_NO_USER_STORY`.

### Root cause
The gate matched **section headers** (`1. User Stories`), **scope subheadings** (`Includes`/`Does NOT include`) and the **`**Decision**`/`**Evidence**`** markers by their *English text*. The same CLI generates Spanish specs with `iq specification new --lang es` (`## 1. Historias de Usuario`, `Incluye`/`NO incluye`, `**Decisión**`/`**Evidencia**`), so the gate found nothing and failed every rule — the tool couldn't validate the artifacts it scaffolds.

### Fix — language-agnostic gate
- **Sections matched by leading number** (`1.`/`2.`/`3.`/`4.`) — identical across templates in every language.
- **Scope subheadings + Decision/Evidence markers** accept en + es (`Incluye`/`NO incluye`, `Decisión`/`Evidencia`).
- **Role lines** read by the English keyword the es template embeds (`**As a (Como)**`), via `_valueAfterBold`.

### Evidence
Verified on the real `impulsa` spec — `iq specification check ticket-purchase-from-credit-history` now exits 0 ("is ready"). Regression test added (a fully-filled Spanish spec passes). Full suite **517 green**.