### PR TITLE
fix: accept requisitions/<slug> path so tab-completion works (v0.15.2)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.15.2]
+### Fixed
+- **`iq specification new`/`check <slug>` now accept the `requisitions/<slug>` path, so shell tab-completion works** (found by dogfooding): the commands assumed the bare slug and prepended `requisitions/`, so tab-completing the argument (which yields `.\requisitions\<slug>\`) produced a broken `requisitions/.\requisitions\<slug>\` path, and a trailing separator leaked into the slug. The `<slug>` argument is now normalized — a bare slug, a `requisitions/<slug>` path (either separator, optional leading `./` and trailing separator), or even a path into the directory all resolve to the same slug.
+
 ## [0.15.1]
 ### Fixed
 - **The `specification_ready` gate was English-only and rejected every `--lang es` spec** (found by dogfooding a real requirement): the gate matched section headers (`1. User Stories`), scope subheadings (`Includes`/`Does NOT include`) and the `**Decision**`/`**Evidence**` markers by their English text, so a Spanish specification — which the same CLI generates with `iq specification new --lang es` — failed with `SPEC_NO_USER_STORY` even when fully and correctly filled. The gate is now **bilingual / language-agnostic**: sections are matched by their leading number (`1.`/`2.`/`3.`/`4.`, identical across templates), and the scope subheadings and Decision/Evidence markers accept both English and Spanish (`Incluye`/`NO incluye`, `Decisión`/`Evidencia`); role lines are read by the English keyword the es template embeds (`**As a (Como)**`). A filled Spanish spec now passes. Regression test added.

--- a/code/cli/lib/modules/specification/commands/check.dart
+++ b/code/cli/lib/modules/specification/commands/check.dart
@@ -13,6 +13,7 @@ import 'package:cli_router/cli_router.dart';
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 import 'package:path/path.dart' as p;
 
+import '../slug.dart';
 import '../specification_gate.dart';
 
 // ─── Input ──────────────────────────────────────────────────────────────────
@@ -23,7 +24,7 @@ class SpecificationCheckInput extends Input {
   SpecificationCheckInput({required this.slug});
 
   factory SpecificationCheckInput.fromCliRequest(CliRequest req) =>
-      SpecificationCheckInput(slug: req.param('slug')?.trim() ?? '');
+      SpecificationCheckInput(slug: normalizeSlug(req.param('slug') ?? ''));
 
   @override
   Map<String, dynamic> toJson() => {'slug': slug};

--- a/code/cli/lib/modules/specification/commands/new.dart
+++ b/code/cli/lib/modules/specification/commands/new.dart
@@ -16,6 +16,7 @@ import 'package:modular_cli_sdk/modular_cli_sdk.dart';
 import 'package:path/path.dart' as p;
 
 import '../../../templates/template_resolver.dart';
+import '../slug.dart';
 
 // ─── Input ──────────────────────────────────────────────────────────────────
 
@@ -30,7 +31,7 @@ class SpecificationNewInput extends Input {
 
   factory SpecificationNewInput.fromCliRequest(CliRequest req) =>
       SpecificationNewInput(
-        slug: req.param('slug')?.trim() ?? '',
+        slug: normalizeSlug(req.param('slug') ?? ''),
         lang: req.flagString('lang') ?? 'en',
       );
 

--- a/code/cli/lib/modules/specification/slug.dart
+++ b/code/cli/lib/modules/specification/slug.dart
@@ -1,0 +1,29 @@
+/// Normalizes the `<slug>` argument of the `iq specification` commands.
+///
+/// The commands resolve a slug to `requisitions/<slug>/`. To let the shell's
+/// tab-completion fill the path, the argument may also be the path itself —
+/// `requisitions/<slug>`, with a leading `./` and/or a trailing separator, in
+/// either `/` or `\` form. This extracts the bare slug from any of those:
+///
+///   ticket-purchase                                  → ticket-purchase
+///   requisitions/ticket-purchase                     → ticket-purchase
+///   .\requisitions\ticket-purchase\                  → ticket-purchase
+///   requisitions/ticket-purchase/specification.md    → ticket-purchase
+library;
+
+String normalizeSlug(String raw) {
+  var s = raw.trim().replaceAll('\\', '/');
+  // Drop a leading "./" and any trailing slashes (tab-completion adds one).
+  s = s.replaceAll(RegExp(r'^\./'), '').replaceAll(RegExp(r'/+$'), '');
+
+  // If the path goes through a `requisitions/` segment, the slug is the first
+  // path segment after the last such marker.
+  const marker = 'requisitions/';
+  final idx = s.lastIndexOf(marker);
+  if (idx >= 0) {
+    s = s.substring(idx + marker.length);
+    final slash = s.indexOf('/');
+    if (slash >= 0) s = s.substring(0, slash);
+  }
+  return s;
+}

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.15.1';
+const String inquiryVersion = '0.15.2';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.15.1
+version: 0.15.2
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/specification_slug_test.dart
+++ b/code/cli/test/specification_slug_test.dart
@@ -1,0 +1,54 @@
+import 'package:test/test.dart';
+
+import 'package:inquiry_cli/modules/specification/slug.dart';
+
+void main() {
+  group('normalizeSlug', () {
+    test('a bare slug is unchanged', () {
+      expect(normalizeSlug('ticket-purchase'), 'ticket-purchase');
+    });
+
+    test('strips a trailing path separator (tab-completion adds one)', () {
+      expect(normalizeSlug('ticket-purchase/'), 'ticket-purchase');
+      expect(normalizeSlug(r'ticket-purchase\'), 'ticket-purchase');
+    });
+
+    test('accepts a requisitions/<slug> path (so tab-completion works)', () {
+      expect(normalizeSlug('requisitions/ticket-purchase'), 'ticket-purchase');
+      expect(normalizeSlug(r'requisitions\ticket-purchase'), 'ticket-purchase');
+    });
+
+    test('accepts the Windows tab-completion form .\\requisitions\\<slug>\\', () {
+      expect(
+        normalizeSlug(r'.\requisitions\ticket-purchase\'),
+        'ticket-purchase',
+      );
+    });
+
+    test('accepts a leading ./ on a bare slug', () {
+      expect(normalizeSlug('./ticket-purchase'), 'ticket-purchase');
+    });
+
+    test('extracts the slug when the path points inside the dir', () {
+      expect(
+        normalizeSlug('requisitions/ticket-purchase/specification.md'),
+        'ticket-purchase',
+      );
+    });
+
+    test('takes the last requisitions/ segment of an absolute-ish path', () {
+      expect(
+        normalizeSlug('C:/Users/x/impulsa/requisitions/ticket-purchase/'),
+        'ticket-purchase',
+      );
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(normalizeSlug('  ticket-purchase  '), 'ticket-purchase');
+    });
+
+    test('empty stays empty', () {
+      expect(normalizeSlug(''), '');
+    });
+  });
+}

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.15.1</span>
+      <span class="badge">v0.15.2</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Accept `requisitions/<slug>` path so tab-completion works (v0.15.2)

**Found by dogfooding.** Running `iq specification check` on a real requirement, tab-completing the `<slug>` argument from the workspace root produced:

```
❯ iq specification check .\requisitions\ticket-purchase-from-credit-history\
Error: No specification found at requisitions/.\requisitions\ticket-purchase-from-credit-history\/specification.md …
```

The command assumed a **bare slug** and prepended `requisitions/`, so the path the shell completes (`.\requisitions\<slug>\`) became a broken `requisitions/.\requisitions\<slug>\`, and a trailing separator leaked into the slug (`"…-history\" is ready`).

### Fix
New `normalizeSlug` extracts the bare slug from any form the shell produces:

| Input | → slug |
|-------|--------|
| `ticket-purchase` | `ticket-purchase` |
| `requisitions/ticket-purchase` | `ticket-purchase` |
| `.\requisitions\ticket-purchase\` | `ticket-purchase` |
| `requisitions/ticket-purchase/specification.md` | `ticket-purchase` |

Wired into both `iq specification new` and `check`.

### Evidence
TDD: 9 `normalizeSlug` tests. Full suite **526 green**. Verified on the real `impulsa` spec — all three invocation forms (`.\requisitions\…\`, `requisitions/…`, bare) now exit 0 with a clean slug in the message.