### PR TITLE
fix: AC table renders in PDF — AC column + numeric id (v0.15.3)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.15.3]
+### Fixed
+- **The acceptance-criteria table collapsed its AC-id column when exported to PDF/DOCX** (found by dogfooding — rendering the spec through a Pandoc-based exporter): the template's id column header was `#` with `AC-N` cells, and because Pandoc allocates pipe-table column widths proportional to the separator dash counts, a narrow id column next to wide prose columns was starved to near-zero width — the `AC-1…AC-N` ids vanished from the PDF (data loss) or wrapped character-by-character. The template now uses an **`AC` column with a short numeric cell** (`1`, `2`, …; the id is `AC-<n>`) and carries a note to keep the separator dashes balanced. The `specification_ready` gate parses **both** forms — inline `AC-3` and a bare `3` under an `AC` header — and normalizes to the canonical `AC-3`, so traceability (`SPEC_AC_NOT_TRACED`) is unaffected.
+
 ## [0.15.2]
 ### Fixed
 - **`iq specification new`/`check <slug>` now accept the `requisitions/<slug>` path, so shell tab-completion works** (found by dogfooding): the commands assumed the bare slug and prepended `requisitions/`, so tab-completing the argument (which yields `.\requisitions\<slug>\`) produced a broken `requisitions/.\requisitions\<slug>\` path, and a trailing separator leaked into the slug. The `<slug>` argument is now normalized — a bare slug, a `requisitions/<slug>` path (either separator, optional leading `./` and trailing separator), or even a path into the directory all resolve to the same slug.

--- a/code/cli/assets/artifacts/specification.template.en.md
+++ b/code/cli/assets/artifacts/specification.template.en.md
@@ -29,9 +29,13 @@
 
 #### Acceptance Criteria
 
-| #    | Given (context)         | When (action)          | Then (expected result)  |
-| ---- | ----------------------- | ---------------------- | ----------------------- |
-| AC-1 | <!-- precondition -->   | <!-- action -->        | <!-- expected result -->|
+<!-- The AC column holds ONLY the number (1, 2, …); the id is AC-<number>. Keep
+     the separator dashes moderate — do not widen them to the text width, or the
+     PDF export splits the column. -->
+
+| AC  | Given (context)         | When (action)        | Then (expected result) |
+| --- | ----------------------- | -------------------- | ---------------------- |
+| 1   | <!-- precondition -->   | <!-- action -->      | <!-- expected result --> |
 
 <!-- Duplicate the US-N block for more stories. -->
 

--- a/code/cli/assets/artifacts/specification.template.es.md
+++ b/code/cli/assets/artifacts/specification.template.es.md
@@ -29,9 +29,13 @@
 
 #### Acceptance Criteria
 
-| #    | Given (Dado que)            | When (Cuando)          | Then (Entonces)         |
-| ---- | --------------------------- | ---------------------- | ----------------------- |
-| AC-1 | <!-- Contexto/precondición -->  | <!-- Acción que ocurre --> | <!-- Resultado esperado --> |
+<!-- La columna AC lleva SOLO el número (1, 2, …); el id es AC-<número>. Mantén
+     los guiones del separador moderados — no los amplíes al ancho del texto, o
+     la exportación a PDF parte la columna. -->
+
+| AC  | Given (Dado que)        | When (Cuando)        | Then (Entonces)        |
+| --- | ----------------------- | -------------------- | ---------------------- |
+| 1   | <!-- Contexto/precondición --> | <!-- Acción que ocurre --> | <!-- Resultado esperado --> |
 
 <!-- Duplicar el bloque HU-N para más historias. -->
 

--- a/code/cli/lib/modules/specification/specification_gate.dart
+++ b/code/cli/lib/modules/specification/specification_gate.dart
@@ -164,9 +164,7 @@ class SpecificationGate {
 
     final declared = <String>{};
     for (final story in _splitStories(body)) {
-      for (final row in _acRows(story.body)) {
-        declared.add(row.first); // the AC-id cell, e.g. "AC-1"
-      }
+      declared.addAll(_acRows(story.body)); // canonical AC-N ids
     }
 
     for (final ac in declared) {
@@ -266,24 +264,35 @@ class SpecificationGate {
     return true;
   }
 
-  /// Filled acceptance-criteria rows in a block: `| AC-N | given | when | then |`
-  /// with all three cells filled.
-  List<List<String>> _acRows(String block) {
-    final rows = <List<String>>[];
+  /// The canonical AC ids of the **filled** acceptance-criteria rows in [block]
+  /// (`| id | given | when | then |` with the three cells filled). The id cell
+  /// is read in either form — inline `AC-3`, or a bare number `3` under an "AC"
+  /// column header — and normalized to `AC-3`, so the rendered table can use the
+  /// short numeric form (which survives a narrow PDF column) without breaking
+  /// traceability.
+  List<String> _acRows(String block) {
+    final ids = <String>[];
     for (final line in block.split('\n')) {
-      if (!RegExp(r'^\s*\|\s*AC-\d+', caseSensitive: false).hasMatch(line)) {
-        continue;
-      }
+      if (!line.trimLeft().startsWith('|')) continue;
       final cells = _cells(line);
-      // cells: [AC-N, given, when, then]
-      if (cells.length >= 4 &&
-          _isFilled(cells[1]) &&
-          _isFilled(cells[2]) &&
-          _isFilled(cells[3])) {
-        rows.add(cells);
+      if (cells.length < 4) continue;
+      final id = _acId(cells[0]);
+      if (id == null) continue; // header / separator / non-AC row
+      if (_isFilled(cells[1]) && _isFilled(cells[2]) && _isFilled(cells[3])) {
+        ids.add(id);
       }
     }
-    return rows;
+    return ids;
+  }
+
+  /// Normalizes an AC-id cell to its canonical `AC-N` form: `AC-3` → `AC-3`,
+  /// `3` → `AC-3`. Returns null for headers, separators, or other cells.
+  String? _acId(String cell) {
+    final inline = RegExp(r'^AC-(\d+)$', caseSensitive: false).firstMatch(cell);
+    if (inline != null) return 'AC-${inline.group(1)}';
+    final numeric = RegExp(r'^(\d+)$').firstMatch(cell);
+    if (numeric != null) return 'AC-${numeric.group(1)}';
+    return null;
   }
 
   /// Data rows of any markdown table in [block] (skips header + separator).

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.15.2';
+const String inquiryVersion = '0.15.3';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.15.2
+version: 0.15.3
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/specification_gate_test.dart
+++ b/code/cli/test/specification_gate_test.dart
@@ -134,6 +134,22 @@ void main() {
       expect(r.violations, isEmpty);
     });
 
+    test('numeric AC column (header "AC", cell "1") is read as AC-1', () {
+      // The rendered table uses a short numeric id cell so a narrow PDF column
+      // does not wrap "AC-1" character by character; the gate reconstructs AC-1.
+      final numericAc = _filledSpec.replaceAll('| AC-1 |', '| 1    |').replaceAll(
+            '| # ',
+            '| AC ',
+          );
+      final r = gate.evaluate(numericAc, issues: const ['traces AC-1 and AC-2']);
+      expect(r.violations.map((v) => v.code),
+          isNot(contains('SPEC_STORY_MISSING_AC')));
+      // AC-1 (now cell "1") must still be traceable as "AC-1".
+      final notTraced = gate.evaluate(numericAc, issues: const ['only AC-2 here']);
+      expect(notTraced.violations.map((v) => v.code),
+          contains('SPEC_AC_NOT_TRACED'));
+    });
+
     test('no derived issue → SPEC_NO_ISSUE', () {
       final r = gate.evaluate(_filledSpec, issues: const []);
       expect(r.passed, isFalse);

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.15.2</span>
+      <span class="badge">v0.15.3</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## AC table renders in PDF — `AC` column + numeric id (v0.15.3)

**Found by dogfooding.** Exporting a real specification to PDF/DOCX (Pandoc-based exporter) collapsed the acceptance-criteria **id column**: the `AC-1…AC-N` ids either **vanished** from the PDF (data loss — traceability ids gone from the human doc) or wrapped **character-by-character** (`A / C / - / 1 / 1`).

### Root cause
Pandoc allocates pipe-table column widths **proportional to the separator dash counts**. The template's id column (`| #    |`, `| ---- |`) beside wide prose columns got a ~2-3% share — too narrow even for `AC-11`.

### Fix
- **Templates (es/en):** the id column is now **`AC`** with a **short numeric cell** (`1`, `2`, …; the canonical id is `AC-<n>`), plus an authoring note to keep separator dashes balanced.
- **Gate:** `_acRows` parses **both** forms — inline `AC-3` and a bare `3` under an `AC` header — normalizing to canonical `AC-3`, so `SPEC_AC_NOT_TRACED` traceability is unchanged (issues still reference `AC-N`).

### Evidence
Rendered the real `impulsa` spec after the fix: the AC numbers **1..17 now appear** in the PDF (previously absent). The gate parses `AC-1..AC-17` from the numeric cells (no `SPEC_STORY_MISSING_AC`). TDD: +1 gate test. Full suite **527 green**.