### PR TITLE
feat(spec): commitment-date §1 (gate-enforced) + context section + nomenclature titles; release v0.16.0

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.16.0]
+### Changed
+- **The specification template now leads with schedule, gives domain context a real home, and drops the false-friend title** (found by dogfooding — scope + schedule are both fundamental to a spec, and the `>` preamble/context blocks read as noise). Four coordinated changes to `specification.template.{en,es}.md` and the `specification_ready` gate:
+  - **Commitment date is a first-class, gate-enforced section.** New **`## 1. Commitment date` / `## 1. Fecha de compromiso`** — a milestone+date table (ready to grow into a mini-schedule) that the gate **requires**: the new `SPEC_NO_COMMITMENT_DATE` rejects a spec whose §1 lacks a real ISO `YYYY-MM-DD` date. The document's *issued* date moves to Metadata (`Issued` / `Fecha de emisión`) — it is secondary; the committed delivery date is not.
+  - **Numbered sections shift by one** to make room: `2.` User Stories, `3.` Testing Strategy, `4.` Explicit Scope, `5.` Decisions. The gate's number-based (language-agnostic) section lookup moves with them, so `--lang es` specs keep working.
+  - **Context is content, not an aside.** A new unnumbered **`## Context and ground rules` / `## Contexto y reglas base`** section gives the domain glossary, assumptions and cross-cutting rules a first-class home instead of a wall of `>` block-quotes; the methodology-citation preamble becomes an HTML comment (guidance in the source, no noise in the rendered PDF).
+  - **Titles adopt the controlled vocabulary.** `# Specification` / `# Especificación` and `# Requisition` / `# Solicitud` — the false-friend "Requirement"/"Requerimiento" is dropped from the titles, consistent with the requisition → specification chain.
+
 ## [0.15.3]
 ### Fixed
 - **The acceptance-criteria table collapsed its AC-id column when exported to PDF/DOCX** (found by dogfooding — rendering the spec through a Pandoc-based exporter): the template's id column header was `#` with `AC-N` cells, and because Pandoc allocates pipe-table column widths proportional to the separator dash counts, a narrow id column next to wide prose columns was starved to near-zero width — the `AC-1…AC-N` ids vanished from the PDF (data loss) or wrapped character-by-character. The template now uses an **`AC` column with a short numeric cell** (`1`, `2`, …; the id is `AC-<n>`) and carries a note to keep the separator dashes balanced. The `specification_ready` gate parses **both** forms — inline `AC-3` and a bare `3` under an `AC` header — and normalizes to the canonical `AC-3`, so traceability (`SPEC_AC_NOT_TRACED`) is unaffected.

--- a/code/cli/assets/artifacts/requisition.template.es.md
+++ b/code/cli/assets/artifacts/requisition.template.es.md
@@ -1,4 +1,4 @@
-# Solicitud de Requerimiento
+# Solicitud
 
 > **Todos los campos de esta solicitud son obligatorios.**
 > Estructura basada en *Gap Analysis* — BABOK® v3 (IIBA), cap. 8.

--- a/code/cli/assets/artifacts/specification.template.en.md
+++ b/code/cli/assets/artifacts/specification.template.en.md
@@ -1,10 +1,12 @@
-# Requirement Specification
+# Specification
 
-> **All fields are mandatory.**
-> User stories per *User Stories Applied* (Mike Cohn, 2004).
-> Acceptance Criteria in *Given-When-Then* — BDD (Dan North, 2006).
-> Testing strategy aligned with *TDD* (Kent Beck, 2002).
-> Decisions are licensed by **evidence from experiments, not by inference**.
+<!--
+  All fields are mandatory.
+  User stories: User Stories Applied (Cohn, 2004).
+  Acceptance Criteria: Given-When-Then — BDD (North, 2006).
+  Testing strategy: TDD (Beck, 2002).
+  Decisions: licensed by evidence from experiments, not by inference.
+-->
 
 ## Metadata
 
@@ -17,9 +19,26 @@
 | Priority      | <!-- High / Medium / Low -->       |
 | QA Analyst    | <!-- Name -->                      |
 | Dev Analyst   | <!-- Name -->                      |
-| Date          | {{DATE}}                           |
+| Issued        | {{DATE}}                           |
 
-## 1. User Stories
+## Context and ground rules
+
+<!-- First-class content (not an "aside"): a glossary of domain terms,
+     assumptions and cross-cutting rules that apply to every user story.
+     Optional but recommended — it avoids repeating context inside each AC. -->
+
+- <!-- Term, assumption, or cross-cutting rule -->
+
+## 1. Commitment date
+
+<!-- The committed delivery date, in ISO YYYY-MM-DD. Mandatory: the gate
+     enforces it. May grow into a mini-schedule (milestones + dates). -->
+
+| Milestone           | Date (YYYY-MM-DD)    |
+| ------------------- | -------------------- |
+| Committed delivery  | <!-- YYYY-MM-DD -->  |
+
+## 2. User Stories
 
 ### US-1: <!-- descriptive title -->
 
@@ -39,9 +58,10 @@
 
 <!-- Duplicate the US-N block for more stories. -->
 
-## 2. Testing Strategy
+## 3. Testing Strategy
 
-Define **which kinds of tests** are needed and **what they validate** — no function names or code.
+<!-- Define WHICH kinds of tests are needed and WHAT they validate — no function
+     names or code. -->
 
 | Type        | What it must validate                       | Related AC      |
 | ----------- | ------------------------------------------- | --------------- |
@@ -49,21 +69,21 @@ Define **which kinds of tests** are needed and **what they validate** — no fun
 | Integration | <!-- e.g. correct DB persistence -->        | <!-- AC-2 -->   |
 | E2E         | <!-- e.g. full UI flow — or N/A -->         | <!-- AC-1 -->   |
 
-## 3. Explicit Scope
+## 4. Explicit Scope
 
 ### Includes
 
-- <!-- what this requirement DOES cover -->
+- <!-- what this specification DOES cover -->
 
 ### Does NOT include
 
 - <!-- what is explicitly out of scope -->
 
-## 4. Decisions (evidence)
+## 5. Decisions (evidence)
 
-> Each key decision must cite the experiment that licensed it (a throwaway probe:
-> a DB query, a container run, an API call), with a re-checkable handle — not an
-> assumption.
+<!-- Each key decision must cite the experiment that licensed it (a throwaway
+     probe: a DB query, a container run, an API call), with a re-checkable
+     handle — not an assumption. -->
 
 - **Decision**: <!-- the decision made -->. **Evidence**: <!-- experiment + result, with a re-checkable handle: a query, a command, `inline-code`, or a file:line -->.
 

--- a/code/cli/assets/artifacts/specification.template.es.md
+++ b/code/cli/assets/artifacts/specification.template.es.md
@@ -1,25 +1,44 @@
-# Especificación de Requerimiento
+# Especificación
 
-> **Todos los campos de este documento son obligatorios.**
-> Historias de usuario según *User Stories Applied* (Mike Cohn, 2004).
-> Acceptance Criteria en formato *Given-When-Then* — BDD (Dan North, 2006).
-> Estrategia de testing alineada con *TDD* (Kent Beck, 2002).
-> Las decisiones se sustentan en **evidencia de experimentos, no en inferencia**.
+<!--
+  Todos los campos son obligatorios.
+  Historias de usuario: User Stories Applied (Cohn, 2004).
+  Acceptance Criteria: Given-When-Then — BDD (North, 2006).
+  Estrategia de testing: TDD (Beck, 2002).
+  Decisiones: licenciadas por evidencia de experimentos, no por inferencia.
+-->
 
 ## Metadatos
 
-| Campo          | Valor                                |
-| -------------- | ------------------------------------ |
-| ID             | REQ-{{DATE}}-XXX                     |
-| Sistema        | <!-- Valor del catálogo oficial -->  |
-| Proyecto       | <!-- Nombre del proyecto -->         |
-| Solicitante    | <!-- Área de Procesos -->            |
-| Prioridad      | <!-- Alta / Media / Baja -->         |
-| Analista QA    | <!-- Nombre Apellido -->             |
-| Analista Dev   | <!-- Nombre Apellido -->             |
-| Fecha          | {{DATE}}                             |
+| Campo            | Valor                                |
+| ---------------- | ------------------------------------ |
+| ID               | REQ-{{DATE}}-XXX                     |
+| Sistema          | <!-- Valor del catálogo oficial -->  |
+| Proyecto         | <!-- Nombre del proyecto -->         |
+| Solicitante      | <!-- Área de Procesos -->            |
+| Prioridad        | <!-- Alta / Media / Baja -->         |
+| Analista QA      | <!-- Nombre Apellido -->             |
+| Analista Dev     | <!-- Nombre Apellido -->             |
+| Fecha de emisión | {{DATE}}                             |
 
-## 1. Historias de Usuario
+## Contexto y reglas base
+
+<!-- Contenido de primera clase (no "cita"): glosario de términos del dominio,
+     supuestos y reglas transversales que aplican a todas las HU. Opcional pero
+     recomendado — evita repetir el contexto dentro de cada AC. -->
+
+- <!-- Término, supuesto o regla transversal -->
+
+## 1. Fecha de compromiso
+
+<!-- Fecha comprometida de entrega, en ISO AAAA-MM-DD. Obligatoria: el gate la
+     exige. Puede crecer a un mini-cronograma (hitos + fechas). -->
+
+| Hito                 | Fecha (AAAA-MM-DD)   |
+| -------------------- | -------------------- |
+| Entrega comprometida | <!-- AAAA-MM-DD -->  |
+
+## 2. Historias de Usuario
 
 ### HU-1: <!-- Título descriptivo -->
 
@@ -39,9 +58,10 @@
 
 <!-- Duplicar el bloque HU-N para más historias. -->
 
-## 2. Estrategia de Testing
+## 3. Estrategia de Testing
 
-Definir **qué tipos de tests** se necesitan y **qué validan**, sin entrar en nombres de funciones ni código.
+<!-- Definir QUÉ tipos de tests se necesitan y QUÉ validan, sin nombres de
+     funciones ni código. -->
 
 | Tipo        | Qué debe validar                                            | AC asociados   |
 | ----------- | ----------------------------------------------------------- | -------------- |
@@ -49,21 +69,21 @@ Definir **qué tipos de tests** se necesitan y **qué validan**, sin entrar en n
 | Integration | <!-- Ej. Persistencia correcta en base de datos -->         | <!-- AC-2 -->  |
 | E2E         | <!-- Ej. Flujo completo desde la UI — o N/A -->             | <!-- AC-1 -->  |
 
-## 3. Alcance Explícito
+## 4. Alcance Explícito
 
 ### Incluye
 
-- <!-- Qué SÍ abarca este requerimiento -->
+- <!-- Qué SÍ abarca esta especificación -->
 
 ### NO incluye
 
 - <!-- Qué queda fuera explícitamente -->
 
-## 4. Decisiones (evidencia)
+## 5. Decisiones (evidencia)
 
-> Cada decisión clave debe citar el experimento que la sustenta (una sonda
-> desechable: una consulta a BD, correr un contenedor, llamar un API), con un
-> handle re-verificable — no una suposición.
+<!-- Cada decisión clave debe citar el experimento que la sustenta (una sonda
+     desechable: una consulta a BD, correr un contenedor, llamar un API), con un
+     handle re-verificable — no una suposición. -->
 
 - **Decisión**: <!-- la decisión tomada -->. **Evidencia**: <!-- experimento + resultado, con handle re-verificable: una consulta, un comando, `inline-code`, o un archivo:línea -->.
 

--- a/code/cli/lib/hosts/skill_builder.dart
+++ b/code/cli/lib/hosts/skill_builder.dart
@@ -165,7 +165,7 @@ Turn a raw requisition (email, document, chat) into a coherent, actionable speci
 2. `iq ape prompt --name dewey` — read the method (Deweyan inquiry) and apply it.
 3. Gather the raw requisition from ALL its sources into `requisition.md` (AS-IS / TO-BE). Capture exactly what was asked — do not invent scope.
 4. For every decision you are unsure of, run a **throwaway experiment** to decide by EVIDENCE, not inference: read the DB, run code in a container, probe the API. These validate spec decisions; they are NOT product code. Record each under **Decisions (evidence)** with a re-checkable handle.
-5. Fill `specification.md` (see sections below). Each user story needs ≥1 Given-When-Then acceptance criterion; state the testing strategy and the explicit scope (includes / does NOT include).
+5. Fill `specification.md` (see sections below). Set a committed delivery date (§1, ISO `YYYY-MM-DD` — the gate requires it); each user story needs ≥1 Given-When-Then acceptance criterion; state the testing strategy and the explicit scope (includes / does NOT include).
 6. Derive the issues: one tracked `issue-<slug>.md` per unit of work, each tracing to its acceptance criteria.
 7. `iq specification check <slug>` — the CLI runs the `specification_ready` gate. Fix exactly what it reports (do NOT skip a violation) until it exits 0.
 8. Dedup-check before creating: `gh issue list --search "<keywords>"`. If a too-similar issue exists, prepare a `gh issue edit` instead of a new one.

--- a/code/cli/lib/modules/specification/specification_gate.dart
+++ b/code/cli/lib/modules/specification/specification_gate.dart
@@ -40,6 +40,7 @@ class SpecificationGate {
     final violations = <SpecificationViolation>[];
     final sections = _splitSections(specificationMd);
 
+    _checkCommitmentDate(sections, violations);
     _checkUserStories(sections, violations);
     _checkTestingStrategy(sections, violations);
     _checkScope(sections, violations);
@@ -61,11 +62,31 @@ class SpecificationGate {
 
   // ─── Rules ──────────────────────────────────────────────────────────────
 
-  void _checkUserStories(
+  /// §1 must carry a committed delivery date — an ISO `YYYY-MM-DD` — so scope
+  /// and schedule are both first-class. A mini-schedule (milestones + dates) is
+  /// welcome; it just has to contain at least one real date.
+  void _checkCommitmentDate(
     Map<String, String> sections,
     List<SpecificationViolation> violations,
   ) {
     final body = _section(sections, 1);
+    final stripped = body == null
+        ? ''
+        : body.replaceAll(RegExp(r'<!--.*?-->', dotAll: true), '');
+    if (!RegExp(r'\d{4}-\d{2}-\d{2}').hasMatch(stripped)) {
+      violations.add(const SpecificationViolation(
+        'SPEC_NO_COMMITMENT_DATE',
+        'No committed delivery date — section "1. Commitment date" needs a real '
+            'ISO date (YYYY-MM-DD).',
+      ));
+    }
+  }
+
+  void _checkUserStories(
+    Map<String, String> sections,
+    List<SpecificationViolation> violations,
+  ) {
+    final body = _section(sections, 2);
     if (body == null) {
       violations.add(const SpecificationViolation(
         'SPEC_NO_USER_STORY', 'No "User Stories" section found.'));
@@ -97,7 +118,7 @@ class SpecificationGate {
     Map<String, String> sections,
     List<SpecificationViolation> violations,
   ) {
-    final body = _section(sections, 2);
+    final body = _section(sections, 3);
     final hasFilledRow = body != null &&
         _tableDataRows(body).any((cells) =>
             cells.length >= 2 && _isFilled(cells[1]));
@@ -114,7 +135,7 @@ class SpecificationGate {
     Map<String, String> sections,
     List<SpecificationViolation> violations,
   ) {
-    final body = _section(sections, 3);
+    final body = _section(sections, 4);
     final includes =
         body == null ? false : _hasFilledBullet(body, _includesHeadings);
     final excludes =
@@ -132,7 +153,7 @@ class SpecificationGate {
     Map<String, String> sections,
     List<SpecificationViolation> violations,
   ) {
-    final body = _section(sections, 4);
+    final body = _section(sections, 5);
     final hasEvidence = body != null &&
         body.split('\n').any((line) {
           final decision = _valueAfterAnyMarker(line, _decisionMarkers);
@@ -159,7 +180,7 @@ class SpecificationGate {
     List<String> issues,
     List<SpecificationViolation> violations,
   ) {
-    final body = _section(sections, 1);
+    final body = _section(sections, 2);
     if (body == null) return;
 
     final declared = <String>{};
@@ -206,9 +227,10 @@ class SpecificationGate {
   }
 
   /// Looks up a section by its leading number (`## 1. …`). The templates number
-  /// the sections identically in every language (`1.` User Stories /
-  /// Historias de Usuario, `2.` Testing Strategy / Estrategia de Testing, …), so
-  /// this is language-agnostic — the gate works on `--lang es` specs too.
+  /// the sections identically in every language (`1.` Commitment date / Fecha de
+  /// compromiso, `2.` User Stories / Historias de Usuario, `3.` Testing Strategy
+  /// / Estrategia de Testing, `4.` Scope, `5.` Decisions), so this is
+  /// language-agnostic — the gate works on `--lang es` specs too.
   String? _section(Map<String, String> sections, int number) {
     for (final entry in sections.entries) {
       if (entry.key.startsWith('$number.')) return entry.value;

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.15.3';
+const String inquiryVersion = '0.16.0';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.15.3
+version: 0.16.0
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/skill_builder_test.dart
+++ b/code/cli/test/skill_builder_test.dart
@@ -54,10 +54,12 @@ void main() {
       test('lists the specification.md sections (from template, not embedded)',
           () {
         for (final section in const [
-          '- **1. User Stories**',
-          '- **2. Testing Strategy**',
-          '- **3. Explicit Scope**',
-          '- **4. Decisions (evidence)**',
+          '- **Context and ground rules**',
+          '- **1. Commitment date**',
+          '- **2. User Stories**',
+          '- **3. Testing Strategy**',
+          '- **4. Explicit Scope**',
+          '- **5. Decisions (evidence)**',
         ]) {
           expect(md, contains(section));
         }

--- a/code/cli/test/specification_check_command_test.dart
+++ b/code/cli/test/specification_check_command_test.dart
@@ -6,9 +6,15 @@ import 'package:test/test.dart';
 import 'package:inquiry_cli/modules/specification/commands/check.dart';
 
 const _filledSpec = '''
-# Requirement Specification
+# Specification
 
-## 1. User Stories
+## 1. Commitment date
+
+| Milestone          | Date       |
+| ------------------ | ---------- |
+| Committed delivery | 2026-08-15 |
+
+## 2. User Stories
 
 ### US-1: Register an invoice
 
@@ -22,13 +28,13 @@ const _filledSpec = '''
 | ---- | ---------------- | -------------- | --------------- |
 | AC-1 | the form is open | I submit data  | it is stored    |
 
-## 2. Testing Strategy
+## 3. Testing Strategy
 
 | Type | What it must validate | Related AC |
 | ---- | --------------------- | ---------- |
 | Unit | the no-duplicate rule | AC-1       |
 
-## 3. Explicit Scope
+## 4. Explicit Scope
 
 ### Includes
 
@@ -38,7 +44,7 @@ const _filledSpec = '''
 
 - The approval workflow.
 
-## 4. Decisions (evidence)
+## 5. Decisions (evidence)
 
 - **Decision**: reuse the billing table. **Evidence**: `psql -c "\\d billing"` (run 2026-06-30).
 ''';

--- a/code/cli/test/specification_gate_test.dart
+++ b/code/cli/test/specification_gate_test.dart
@@ -16,7 +16,13 @@ const _filledSpec = '''
 | ID    | REQ-2026-06-30-001 |
 | Date  | 2026-06-30 |
 
-## 1. User Stories
+## 1. Commitment date
+
+| Milestone          | Date       |
+| ------------------ | ---------- |
+| Committed delivery | 2026-08-15 |
+
+## 2. User Stories
 
 ### US-1: Register an invoice
 
@@ -31,13 +37,13 @@ const _filledSpec = '''
 | AC-1 | the form is open       | I submit valid data | the invoice is stored |
 | AC-2 | a duplicate number     | I submit it       | it is rejected         |
 
-## 2. Testing Strategy
+## 3. Testing Strategy
 
 | Type | What it must validate | Related AC |
 | ---- | --------------------- | ---------- |
 | Unit | the no-duplicate rule | AC-2       |
 
-## 3. Explicit Scope
+## 4. Explicit Scope
 
 ### Includes
 
@@ -47,7 +53,7 @@ const _filledSpec = '''
 
 - Invoice approval workflow.
 
-## 4. Decisions (evidence)
+## 5. Decisions (evidence)
 
 - **Decision**: store invoices in the existing `billing` table. **Evidence**: `psql -c "\\d billing"` shows the columns already exist (run 2026-06-30).
 
@@ -66,7 +72,13 @@ const _filledSpecEs = '''
 | ----- | ----- |
 | ID    | REQ-2026-06-30-001 |
 
-## 1. Historias de Usuario
+## 1. Fecha de compromiso
+
+| Hito                 | Fecha      |
+| -------------------- | ---------- |
+| Entrega comprometida | 2026-08-15 |
+
+## 2. Historias de Usuario
 
 ### HU-1: Registrar una factura
 
@@ -80,13 +92,13 @@ const _filledSpecEs = '''
 | ---- | ------------------ | -------------------- | ---------------------- |
 | AC-1 | el formulario abre | envío datos válidos  | la factura se almacena |
 
-## 2. Estrategia de Testing
+## 3. Estrategia de Testing
 
 | Tipo | Qué debe validar          | AC asociados |
 | ---- | ------------------------- | ------------ |
 | Unit | la regla de no-duplicados | AC-1         |
 
-## 3. Alcance Explícito
+## 4. Alcance Explícito
 
 ### Incluye
 
@@ -96,7 +108,7 @@ const _filledSpecEs = '''
 
 - El flujo de aprobación de facturas.
 
-## 4. Decisiones (evidencia)
+## 5. Decisiones (evidencia)
 
 - **Decisión**: reusar la tabla `billing`. **Evidencia**: `psql -c "\\d billing"` muestra las columnas (corrido 2026-06-30).
 
@@ -199,9 +211,24 @@ void main() {
     });
 
     test('no user story at all → SPEC_NO_USER_STORY', () {
-      const empty = '# Requirement Specification\n\n## 1. User Stories\n';
+      const empty = '# Specification\n\n## 2. User Stories\n';
       final r = gate.evaluate(empty, issues: const ['issue']);
       expect(r.violations.map((v) => v.code), contains('SPEC_NO_USER_STORY'));
+    });
+
+    test('no committed delivery date → SPEC_NO_COMMITMENT_DATE', () {
+      // Strip the ISO date from §1 (leave the section, remove the real date).
+      final noDate = _filledSpec.replaceAll('2026-08-15', '<!-- YYYY-MM-DD -->');
+      final r = gate.evaluate(noDate, issues: tracingIssues);
+      expect(r.passed, isFalse);
+      expect(r.violations.map((v) => v.code),
+          contains('SPEC_NO_COMMITMENT_DATE'));
+    });
+
+    test('a committed delivery date in §1 → no SPEC_NO_COMMITMENT_DATE', () {
+      final r = gate.evaluate(_filledSpec, issues: tracingIssues);
+      expect(r.violations.map((v) => v.code),
+          isNot(contains('SPEC_NO_COMMITMENT_DATE')));
     });
 
     test('missing testing strategy rows → SPEC_NO_TESTING_STRATEGY', () {

--- a/code/cli/test/specification_new_command_test.dart
+++ b/code/cli/test/specification_new_command_test.dart
@@ -42,7 +42,7 @@ void main() {
       expect(read('invoice-form', 'requisition'), contains('# Requisition'));
       expect(
         read('invoice-form', 'specification'),
-        contains('Requirement Specification'),
+        contains('# Specification'),
       );
     });
 
@@ -57,7 +57,7 @@ void main() {
       await cmd('factura', lang: 'es').execute();
       expect(
         read('factura', 'specification'),
-        contains('Especificación de Requerimiento'),
+        contains('# Especificación'),
       );
     });
 

--- a/code/cli/test/template_resolver_test.dart
+++ b/code/cli/test/template_resolver_test.dart
@@ -11,20 +11,20 @@ void main() {
   group('TemplateResolver', () {
     test('localized artifact: es returns the Spanish template, no notice', () {
       final r = resolver.resolve('specification', lang: 'es');
-      expect(r.content, contains('Especificación de Requerimiento'));
+      expect(r.content, contains('# Especificación'));
       expect(r.notice, isNull);
     });
 
     test('localized artifact: en (default) returns English, no notice', () {
       final r = resolver.resolve('specification');
-      expect(r.content, contains('Requirement Specification'));
+      expect(r.content, contains('# Specification'));
       expect(r.notice, isNull);
     });
 
     test('localized artifact: an unsupported lang falls back to English + notice',
         () {
       final r = resolver.resolve('specification', lang: 'pt');
-      expect(r.content, contains('Requirement Specification'));
+      expect(r.content, contains('# Specification'));
       expect(r.notice, contains('pt'));
       expect(r.notice, contains('English'));
     });

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.15.3</span>
+      <span class="badge">v0.16.0</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Why
Dogfooding the specification phase on a real requirement surfaced that a spec must lead with **scope + schedule**, that the `>` preamble/context blocks read as noise, and that the titles still carried the false-friend *Requerimiento/Requirement*.

## What changed (template `en`+`es` + `specification_ready` gate)
1. **Commitment date = first-class, gate-enforced §1.** New `## 1. Commitment date` / `## 1. Fecha de compromiso` — a milestone+date table (ready to grow into a mini-schedule). The gate now **requires** it: `SPEC_NO_COMMITMENT_DATE` rejects a spec whose §1 lacks a real ISO `YYYY-MM-DD`. The document's *issued* date drops to Metadata (`Issued`/`Fecha de emisión`), where it belongs — it is secondary.
2. **Sections shift by one:** `2.` User Stories, `3.` Testing Strategy, `4.` Explicit Scope, `5.` Decisions. The gate's number-based, language-agnostic section lookup moves with them, so `--lang es` keeps working.
3. **Context is content, not an aside.** New unnumbered `## Context and ground rules` / `## Contexto y reglas base` gives the domain glossary, assumptions and cross-cutting rules a first-class home instead of a wall of block-quotes; the methodology-citation preamble becomes an HTML comment (guidance in source, no noise in the PDF).
4. **Titles adopt the controlled vocabulary:** `# Specification` / `# Especificación`, `# Requisition` / `# Solicitud`.

## Verification
- All **529** CLI tests pass. Fixtures migrated to the new numbering; added `SPEC_NO_COMMITMENT_DATE` (negative + positive) tests.
- Re-ran the gate against the live dogfood spec (impulsa): AC-5…AC-21 still parse under §2, and the gate correctly emits `SPEC_NO_COMMITMENT_DATE` until a delivery date is committed.