### PR TITLE
feat(spec): explicit iq:lang artifact-language directive; release v0.16.1

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.16.1]
+### Added
+- **Explicit artifact-language directive** (`<!-- iq:lang=xx -->`) at the top of the requisition and specification templates (found by dogfooding — issues were being derived in English from a Spanish spec because the language was only implicit in the `--lang` flag at scaffold time). The `es` templates carry `iq:lang=es`, the `en` templates `iq:lang=en`; it is a machine- and human-readable HTML comment (invisible in the PDF/DOCX) that declares the language of the artifact **and all its derived artifacts** (issues, requirements, plans). The `/iq-specification` skill now instructs the brain to read it and write the derived issues in that language, keeping the whole requisition → specification → issues chain consistent.
+
 ## [0.16.0]
 ### Changed
 - **The specification template now leads with schedule, gives domain context a real home, and drops the false-friend title** (found by dogfooding — scope + schedule are both fundamental to a spec, and the `>` preamble/context blocks read as noise). Four coordinated changes to `specification.template.{en,es}.md` and the `specification_ready` gate:

--- a/code/cli/assets/artifacts/requisition.template.en.md
+++ b/code/cli/assets/artifacts/requisition.template.en.md
@@ -1,5 +1,7 @@
 # Requisition
 
+<!-- iq:lang=en · Language of this requisition and ALL its derived artifacts (specification, issues, plans). Keep consistent. Not rendered in the PDF/DOCX. -->
+
 > A **requisition** is a formal request that a change be made — the business need that originates the work. (Spanish: *solicitud*.)
 
 > **All fields are mandatory.**

--- a/code/cli/assets/artifacts/requisition.template.es.md
+++ b/code/cli/assets/artifacts/requisition.template.es.md
@@ -1,5 +1,7 @@
 # Solicitud
 
+<!-- iq:lang=es · Idioma de esta solicitud y de TODOS sus artefactos derivados (especificación, issues, planes). Mantener consistente. No se renderiza en el PDF/DOCX. -->
+
 > **Todos los campos de esta solicitud son obligatorios.**
 > Estructura basada en *Gap Analysis* — BABOK® v3 (IIBA), cap. 8.
 > Terminología de dominio alineada con *Ubiquitous Language* — Domain-Driven Design (Eric Evans, 2003).

--- a/code/cli/assets/artifacts/specification.template.en.md
+++ b/code/cli/assets/artifacts/specification.template.en.md
@@ -1,5 +1,7 @@
 # Specification
 
+<!-- iq:lang=en · Language of this specification and ALL its derived artifacts (issues, requirements, plans). Keep consistent. Not rendered in the PDF/DOCX. -->
+
 <!--
   All fields are mandatory.
   User stories: User Stories Applied (Cohn, 2004).

--- a/code/cli/assets/artifacts/specification.template.es.md
+++ b/code/cli/assets/artifacts/specification.template.es.md
@@ -1,5 +1,7 @@
 # Especificación
 
+<!-- iq:lang=es · Idioma de esta especificación y de TODOS sus artefactos derivados (issues, requirements, planes). Mantener consistente. No se renderiza en el PDF/DOCX. -->
+
 <!--
   Todos los campos son obligatorios.
   Historias de usuario: User Stories Applied (Cohn, 2004).

--- a/code/cli/lib/hosts/skill_builder.dart
+++ b/code/cli/lib/hosts/skill_builder.dart
@@ -166,7 +166,7 @@ Turn a raw requisition (email, document, chat) into a coherent, actionable speci
 3. Gather the raw requisition from ALL its sources into `requisition.md` (AS-IS / TO-BE). Capture exactly what was asked — do not invent scope.
 4. For every decision you are unsure of, run a **throwaway experiment** to decide by EVIDENCE, not inference: read the DB, run code in a container, probe the API. These validate spec decisions; they are NOT product code. Record each under **Decisions (evidence)** with a re-checkable handle.
 5. Fill `specification.md` (see sections below). Set a committed delivery date (§1, ISO `YYYY-MM-DD` — the gate requires it); each user story needs ≥1 Given-When-Then acceptance criterion; state the testing strategy and the explicit scope (includes / does NOT include).
-6. Derive the issues: one tracked `issue-<slug>.md` per unit of work, each tracing to its acceptance criteria.
+6. Derive the issues: one tracked `issue-<slug>.md` per unit of work, each tracing to its acceptance criteria. **Write them in the artifact's declared language** — read the `<!-- iq:lang=xx -->` directive at the top of `specification.md` (e.g. `iq:lang=es` → issues in Spanish) and keep it consistent across all derived artifacts.
 7. `iq specification check <slug>` — the CLI runs the `specification_ready` gate. Fix exactly what it reports (do NOT skip a violation) until it exits 0.
 8. Dedup-check before creating: `gh issue list --search "<keywords>"`. If a too-similar issue exists, prepare a `gh issue edit` instead of a new one.
 9. Print the `gh issue create` / `gh issue edit` commands (do NOT run them blind) and present the specification + issues to the human. Stop — the human reviews and approves; the doc lands on `main` via a PR (the QA review gate).

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.16.0';
+const String inquiryVersion = '0.16.1';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.16.0
+version: 0.16.1
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/template_resolver_test.dart
+++ b/code/cli/test/template_resolver_test.dart
@@ -12,12 +12,15 @@ void main() {
     test('localized artifact: es returns the Spanish template, no notice', () {
       final r = resolver.resolve('specification', lang: 'es');
       expect(r.content, contains('# Especificación'));
+      // Declares its language for derived artifacts (issues, etc.).
+      expect(r.content, contains('iq:lang=es'));
       expect(r.notice, isNull);
     });
 
     test('localized artifact: en (default) returns English, no notice', () {
       final r = resolver.resolve('specification');
       expect(r.content, contains('# Specification'));
+      expect(r.content, contains('iq:lang=en'));
       expect(r.notice, isNull);
     });
 

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.16.0</span>
+      <span class="badge">v0.16.1</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Why
Dogfooding surfaced that issues were being derived **in English from a Spanish (`--lang es`) spec** — the artifact language was only implicit in the scaffold-time flag, so a human or AI agent arriving later had no explicit signal.

## What
- **`<!-- iq:lang=xx -->` directive** at the top of the requisition + specification templates (`es`→`iq:lang=es`, `en`→`iq:lang=en`). Machine- and human-readable HTML comment, **invisible in the PDF/DOCX**, declaring the language of the artifact **and all its derived artifacts** (issues, requirements, plans).
- The **`/iq-specification` skill** now instructs the brain to read the directive and write the derived issues in that language, keeping requisition → specification → issues consistent.

## Verification
- All **529** CLI tests pass; added assertions that the `es`/`en` templates carry `iq:lang=es`/`iq:lang=en`.