### PR TITLE
feat(issue): iq issue new + publish (issue as code, --plan/--apply); release v0.17.0

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.17.0]
+### Added
+- **`iq issue` — "issue as code": derive an issue as a reviewable `.md`, then publish it to GitHub** (found by dogfooding — deriving issues was unstructured freehand, the language was easy to get wrong, and there was no path from the local `.md` to a real GitHub issue). Two commands plus bilingual templates:
+  - **`iq issue new <slug> <name> [--repo owner/repo] [--lang <en|es>]`** scaffolds `requisitions/<slug>/issue-<name>.md` from the single-source `issue.template.{en,es}.md`, **inheriting the specification's `iq:lang`** so a Spanish spec yields Spanish issues (no flag to remember). The `.md` carries YAML front-matter (`title`, `repo`, `labels`, `spec`, `covers`, `lang`) — the single source of truth — plus a structured body (Context, Scope, Technical decisions/evidence, AC covered). Idempotent. `covers:` feeds the `specification_ready` gate's AC→issue traceability.
+  - **`iq issue publish <slug> <name> [--plan|--apply]`** turns that `.md` into a GitHub issue via `gh`, Terraform-style: **`--plan`** (the default, safe) parses the front-matter and prints the exact `gh issue create` it would run without creating anything; **`--apply`** executes it and returns the new issue URL. The front-matter is the source of truth; only the body is published.
+  - The `/iq-specification` skill now drives the issue step through `iq issue new` / `iq issue publish` instead of freehand `gh issue create`.
+
 ## [0.16.1]
 ### Added
 - **Explicit artifact-language directive** (`<!-- iq:lang=xx -->`) at the top of the requisition and specification templates (found by dogfooding — issues were being derived in English from a Spanish spec because the language was only implicit in the `--lang` flag at scaffold time). The `es` templates carry `iq:lang=es`, the `en` templates `iq:lang=en`; it is a machine- and human-readable HTML comment (invisible in the PDF/DOCX) that declares the language of the artifact **and all its derived artifacts** (issues, requirements, plans). The `/iq-specification` skill now instructs the brain to read it and write the derived issues in that language, keeping the whole requisition → specification → issues chain consistent.

--- a/code/cli/assets/artifacts/issue.template.en.md
+++ b/code/cli/assets/artifacts/issue.template.en.md
@@ -1,0 +1,33 @@
+---
+kind: iq-issue
+lang: en
+title: "[repo] Short issue title"
+repo: "{{REPO}}"
+labels: []
+spec: "requisitions/{{SLUG}}/specification.md"
+covers: []
+---
+
+<!-- "Issue as code": this .md is the source of truth. Edit and review it here;
+     `iq issue publish <slug> <name> --plan` shows the `gh issue create` it would
+     assemble from the front-matter; `--apply` creates it. The body (everything
+     after the second `---`) is what gets published; the front-matter is NOT.
+     `covers:` must list the AC this issue covers — the gate enforces it. -->
+
+# [repo] Short issue title
+
+## Context
+
+<!-- What exists today and what is missing, with re-checkable handles (file:line). -->
+
+## Scope
+
+- <!-- What this issue builds -->
+
+## Technical decisions (evidence)
+
+- **Decision**: <!-- the decision -->. **Evidence**: <!-- re-checkable handle: a query, a command, `inline-code`, or file:line -->.
+
+## Acceptance criteria covered
+
+<!-- Echo here, for human reading, the AC from the front-matter (covers): AC-1, AC-2, … -->

--- a/code/cli/assets/artifacts/issue.template.es.md
+++ b/code/cli/assets/artifacts/issue.template.es.md
@@ -1,0 +1,33 @@
+---
+kind: iq-issue
+lang: es
+title: "[repo] Título corto de la issue"
+repo: "{{REPO}}"
+labels: []
+spec: "requisitions/{{SLUG}}/specification.md"
+covers: []
+---
+
+<!-- "Issue as code": este .md es la fuente de verdad. Edítalo y revísalo aquí;
+     `iq issue publish <slug> <nombre> --plan` muestra el `gh issue create` que
+     armaría con el front-matter; `--apply` lo crea. El cuerpo (todo lo que sigue
+     al segundo `---`) es lo que se publica; el front-matter NO se publica.
+     `covers:` debe listar los AC que cubre esta issue — el gate lo exige. -->
+
+# [repo] Título corto de la issue
+
+## Contexto
+
+<!-- Qué existe hoy y qué falta, con handles re-verificables (archivo:línea). -->
+
+## Alcance
+
+- <!-- Qué construye esta issue -->
+
+## Decisiones técnicas (evidencia)
+
+- **Decisión**: <!-- la decisión -->. **Evidencia**: <!-- handle re-verificable: una consulta, un comando, `inline-code`, o archivo:línea -->.
+
+## Criterios de aceptación cubiertos
+
+<!-- Repite aquí, para lectura humana, los AC del front-matter (covers): AC-1, AC-2, … -->

--- a/code/cli/lib/hosts/skill_builder.dart
+++ b/code/cli/lib/hosts/skill_builder.dart
@@ -166,10 +166,10 @@ Turn a raw requisition (email, document, chat) into a coherent, actionable speci
 3. Gather the raw requisition from ALL its sources into `requisition.md` (AS-IS / TO-BE). Capture exactly what was asked — do not invent scope.
 4. For every decision you are unsure of, run a **throwaway experiment** to decide by EVIDENCE, not inference: read the DB, run code in a container, probe the API. These validate spec decisions; they are NOT product code. Record each under **Decisions (evidence)** with a re-checkable handle.
 5. Fill `specification.md` (see sections below). Set a committed delivery date (§1, ISO `YYYY-MM-DD` — the gate requires it); each user story needs ≥1 Given-When-Then acceptance criterion; state the testing strategy and the explicit scope (includes / does NOT include).
-6. Derive the issues: one tracked `issue-<slug>.md` per unit of work, each tracing to its acceptance criteria. **Write them in the artifact's declared language** — read the `<!-- iq:lang=xx -->` directive at the top of `specification.md` (e.g. `iq:lang=es` → issues in Spanish) and keep it consistent across all derived artifacts.
+6. Derive the issues with **`iq issue new <slug> <name> [--repo owner/repo]`** — it scaffolds `requisitions/<slug>/issue-<name>.md` ("issue as code") **inheriting the spec's `iq:lang`** (so a Spanish spec yields Spanish issues). Fill each from evidence and list the acceptance criteria it covers in the front-matter `covers:`. One issue per unit of work (e.g. one per repo).
 7. `iq specification check <slug>` — the CLI runs the `specification_ready` gate. Fix exactly what it reports (do NOT skip a violation) until it exits 0.
-8. Dedup-check before creating: `gh issue list --search "<keywords>"`. If a too-similar issue exists, prepare a `gh issue edit` instead of a new one.
-9. Print the `gh issue create` / `gh issue edit` commands (do NOT run them blind) and present the specification + issues to the human. Stop — the human reviews and approves; the doc lands on `main` via a PR (the QA review gate).
+8. Dedup-check before creating: `gh issue list --search "<keywords>"`. If a too-similar issue exists, edit that one instead.
+9. Publish with **`iq issue publish <slug> <name> --plan`** (Terraform-style: previews the `gh issue create` from the front-matter) and, once the human approves, `--apply` to create it. Present the specification + issues to the human — the doc lands on `main` via a PR (the QA review gate).
 
 ## specification.md — fill these sections
 ${sections.map((s) => '- **$s**').join('\n')}

--- a/code/cli/lib/inquiry_cli.dart
+++ b/code/cli/lib/inquiry_cli.dart
@@ -13,6 +13,7 @@ import 'modules/global/global_builder.dart';
 import 'modules/fsm/fsm_builder.dart';
 import 'modules/ape/ape_builder.dart';
 import 'modules/host/host_builder.dart';
+import 'modules/issue/issue_builder.dart';
 import 'modules/specification/specification_builder.dart';
 import 'hosts/all_adapters.dart';
 import 'hosts/deployer.dart';
@@ -63,6 +64,7 @@ Future<int> runInquiry(List<String> args) async {
     'specification',
     (m) => buildSpecificationModule(m, assets: assets),
   );
+  cli.module('issue', (m) => buildIssueModule(m, assets: assets));
 
   return cli.run(normalizeInquiryArgs(args));
 }

--- a/code/cli/lib/modules/issue/commands/new.dart
+++ b/code/cli/lib/modules/issue/commands/new.dart
@@ -1,0 +1,138 @@
+/// `iq issue new <slug> <name> [--repo owner/repo] [--lang <lang>]` — scaffolds
+/// an "issue as code" file `requisitions/<slug>/issue-<name>.md`.
+///
+/// The CLI is the **hands** (Constitution I): it writes the issue skeleton from
+/// the single-source bilingual template, **inheriting the language** from the
+/// specification's `iq:lang` directive (so a Spanish spec yields Spanish issues)
+/// unless `--lang` overrides it. The brain then fills the body from evidence.
+/// Idempotent: an issue file that already exists is left untouched.
+library;
+
+import 'dart:io';
+
+import 'package:cli_router/cli_router.dart';
+import 'package:modular_cli_sdk/modular_cli_sdk.dart';
+import 'package:path/path.dart' as p;
+
+import '../../../templates/template_resolver.dart';
+import '../../specification/slug.dart';
+
+// ─── Input ────────────────────────────────────────────────────────────────
+
+class IssueNewInput extends Input {
+  /// The requisition workspace: `requisitions/<slug>/`.
+  final String slug;
+
+  /// The issue name → `issue-<name>.md`.
+  final String name;
+
+  /// Optional GitHub target repo (`owner/repo`) — pre-fills the front-matter.
+  final String? repo;
+
+  /// Optional language override; when null it is inherited from the spec.
+  final String? lang;
+
+  IssueNewInput({required this.slug, required this.name, this.repo, this.lang});
+
+  factory IssueNewInput.fromCliRequest(CliRequest req) => IssueNewInput(
+        slug: normalizeSlug(req.param('slug') ?? ''),
+        name: (req.param('name') ?? '').trim(),
+        repo: req.flagString('repo'),
+        lang: req.flagString('lang'),
+      );
+
+  @override
+  Map<String, dynamic> toJson() =>
+      {'slug': slug, 'name': name, 'repo': repo, 'lang': lang};
+}
+
+// ─── Output ─────────────────────────────────────────────────────────────────
+
+class IssueNewOutput extends Output {
+  final String message;
+
+  IssueNewOutput({required this.message});
+
+  @override
+  Map<String, dynamic> toJson() => {'message': message};
+
+  @override
+  int get exitCode => ExitCode.ok;
+
+  @override
+  String? toText() => message;
+}
+
+// ─── Command ────────────────────────────────────────────────────────────────
+
+class IssueNewCommand implements Command<IssueNewInput, IssueNewOutput> {
+  @override
+  final IssueNewInput input;
+
+  final TemplateResolver resolver;
+  final String workingDirectory;
+
+  static final _namePattern = RegExp(r'^[a-z0-9]+(?:-[a-z0-9]+)*$');
+
+  IssueNewCommand(
+    this.input, {
+    required this.resolver,
+    required this.workingDirectory,
+  });
+
+  String get _dir => p.join(workingDirectory, 'requisitions', input.slug);
+
+  @override
+  String? validate() {
+    if (input.slug.isEmpty || input.name.isEmpty) {
+      return 'Usage: iq issue new <slug> <name> [--repo owner/repo]';
+    }
+    if (!_namePattern.hasMatch(input.name)) {
+      return 'Invalid name "${input.name}": use lowercase letters, digits and '
+          'single hyphens (e.g. db, api, app, erp).';
+    }
+    if (!Directory(_dir).existsSync()) {
+      return 'No requisition workspace at requisitions/${input.slug}/ — run '
+          '`iq specification new ${input.slug}` first.';
+    }
+    return null;
+  }
+
+  @override
+  Future<IssueNewOutput> execute() async {
+    final relPath = p.posix.join('requisitions', input.slug, 'issue-${input.name}.md');
+    final file = File(p.join(_dir, 'issue-${input.name}.md'));
+
+    if (file.existsSync()) {
+      return IssueNewOutput(message: '  kept     $relPath (already exists)');
+    }
+
+    final lang = input.lang ?? _specLang() ?? 'en';
+    final resolution = resolver.resolve('issue', lang: lang);
+
+    final content = resolution.content
+        .replaceAll('{{SLUG}}', input.slug)
+        .replaceAll('{{REPO}}', input.repo ?? '');
+    file.writeAsStringSync(content);
+
+    final lines = <String>[
+      'Issue scaffolded ($lang):',
+      '  created  $relPath',
+      if (resolution.notice != null) '  note     ${resolution.notice}',
+      '',
+      'Next: fill its Contexto/Alcance/Decisiones from evidence, set `repo:` and '
+          '`covers:` in the front-matter, then `iq issue publish ${input.slug} '
+          '${input.name} --plan`.',
+    ];
+    return IssueNewOutput(message: lines.join('\n'));
+  }
+
+  /// The language declared by the spec's `<!-- iq:lang=xx -->` directive, if any.
+  String? _specLang() {
+    final spec = File(p.join(_dir, 'specification.md'));
+    if (!spec.existsSync()) return null;
+    final m = RegExp(r'iq:lang\s*=\s*([A-Za-z-]+)')
+        .firstMatch(spec.readAsStringSync());
+    return m?.group(1)?.toLowerCase();
+  }
+}

--- a/code/cli/lib/modules/issue/commands/publish.dart
+++ b/code/cli/lib/modules/issue/commands/publish.dart
@@ -1,0 +1,174 @@
+/// `iq issue publish <slug> <name> [--plan|--apply]` — turns an "issue as code"
+/// file into a real GitHub issue via `gh`.
+///
+/// Terraform-style: **`--plan`** (the default, safe) parses the front-matter and
+/// prints the exact `gh issue create` it would run — nothing is created.
+/// **`--apply`** executes it and prints the new issue URL. The `.md`'s
+/// front-matter (`repo`, `title`, `labels`) is the single source of truth; only
+/// the body (after the front-matter) is published.
+library;
+
+import 'dart:io';
+
+import 'package:cli_router/cli_router.dart';
+import 'package:modular_cli_sdk/modular_cli_sdk.dart';
+import 'package:path/path.dart' as p;
+
+import '../../specification/slug.dart';
+import '../front_matter.dart';
+
+typedef ProcessRunner = Future<ProcessResult> Function(
+  String executable,
+  List<String> arguments,
+);
+
+// ─── Input ────────────────────────────────────────────────────────────────
+
+class IssuePublishInput extends Input {
+  final String slug;
+  final String name;
+
+  /// When true, execute `gh issue create`; otherwise only plan (the default).
+  final bool apply;
+
+  IssuePublishInput({required this.slug, required this.name, this.apply = false});
+
+  factory IssuePublishInput.fromCliRequest(CliRequest req) => IssuePublishInput(
+        slug: normalizeSlug(req.param('slug') ?? ''),
+        name: (req.param('name') ?? '').trim(),
+        apply: req.flagBool('apply'),
+      );
+
+  @override
+  Map<String, dynamic> toJson() =>
+      {'slug': slug, 'name': name, 'apply': apply};
+}
+
+// ─── Output ─────────────────────────────────────────────────────────────────
+
+class IssuePublishOutput extends Output {
+  final String message;
+  final bool ok;
+
+  IssuePublishOutput({required this.message, required this.ok});
+
+  @override
+  Map<String, dynamic> toJson() => {'ok': ok, 'message': message};
+
+  @override
+  int get exitCode => ok ? ExitCode.ok : ExitCode.validationFailed;
+
+  @override
+  String? toText() => message;
+}
+
+// ─── Command ────────────────────────────────────────────────────────────────
+
+class IssuePublishCommand
+    implements Command<IssuePublishInput, IssuePublishOutput> {
+  @override
+  final IssuePublishInput input;
+
+  final String workingDirectory;
+  final ProcessRunner runProcess;
+
+  IssuePublishCommand(
+    this.input, {
+    required this.workingDirectory,
+    ProcessRunner? runProcess,
+  }) : runProcess = runProcess ?? Process.run;
+
+  File get _file => File(p.join(
+        workingDirectory,
+        'requisitions',
+        input.slug,
+        'issue-${input.name}.md',
+      ));
+
+  @override
+  String? validate() {
+    if (input.slug.isEmpty || input.name.isEmpty) {
+      return 'Usage: iq issue publish <slug> <name> [--plan|--apply]';
+    }
+    if (!_file.existsSync()) {
+      return 'No issue found at requisitions/${input.slug}/issue-${input.name}.md'
+          ' — run `iq issue new ${input.slug} ${input.name}` first.';
+    }
+    return null;
+  }
+
+  @override
+  Future<IssuePublishOutput> execute() async {
+    final doc = parseIssueDoc(_file.readAsStringSync());
+    if (doc == null) {
+      return _fail('The issue file has no valid `---` front-matter block.');
+    }
+
+    final repo = doc.repo;
+    final title = doc.title;
+    final problems = <String>[
+      if (repo == null) 'set `repo: owner/repo` in the front-matter',
+      if (title == null) 'set `title:` in the front-matter',
+      if (doc.covers.isEmpty)
+        'list the acceptance criteria in `covers:` (the gate requires it)',
+    ];
+    if (repo == null || title == null) {
+      return _fail('Cannot publish — ${problems.join('; ')}.');
+    }
+
+    final args = <String>[
+      'issue', 'create',
+      '--repo', repo,
+      '--title', title,
+      for (final l in doc.labels) ...['--label', l],
+    ];
+
+    if (!input.apply) {
+      final lines = <String>[
+        'Plan — issue "${input.name}" → $repo',
+        '  title:  $title',
+        '  labels: ${doc.labels.isEmpty ? '(none)' : doc.labels.join(', ')}',
+        '  covers: ${doc.covers.isEmpty ? '(none)' : doc.covers.join(', ')}',
+        '  body:   ${doc.body.split('\n').length} lines',
+        if (doc.covers.isEmpty) '  warn    ${problems.last}',
+        '',
+        'Would run (add --body-file with the body below):',
+        '  gh ${_display(args)} --body-file <body>',
+        '',
+        'Re-run with --apply to create it.',
+      ];
+      return IssuePublishOutput(ok: true, message: lines.join('\n'));
+    }
+
+    // --apply: write the body to a temp file and run gh.
+    final bodyFile = File(p.join(
+      Directory.systemTemp.createTempSync('iq_issue_').path,
+      'body.md',
+    ))
+      ..writeAsStringSync(doc.body);
+    try {
+      final result =
+          await runProcess('gh', [...args, '--body-file', bodyFile.path]);
+      if (result.exitCode != 0) {
+        return _fail('gh issue create failed:\n${result.stderr}'.trimRight());
+      }
+      final url = result.stdout.toString().trim();
+      return IssuePublishOutput(
+        ok: true,
+        message: 'Created issue for "${input.name}" in $repo:\n  $url',
+      );
+    } finally {
+      try {
+        bodyFile.parent.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  }
+
+  IssuePublishOutput _fail(String message) =>
+      IssuePublishOutput(ok: false, message: message);
+
+  /// Renders the gh args as a copy-pasteable command (quoting args with spaces).
+  String _display(List<String> args) => args
+      .map((a) => a.contains(' ') ? '"$a"' : a)
+      .join(' ');
+}

--- a/code/cli/lib/modules/issue/front_matter.dart
+++ b/code/cli/lib/modules/issue/front_matter.dart
@@ -1,0 +1,78 @@
+/// Parses an "issue as code" markdown document: a YAML front-matter block
+/// (between two `---` fences) followed by the markdown body.
+///
+/// The front-matter carries everything needed to create the GitHub issue —
+/// `title`, `repo` (owner/repo), `labels`, `spec`, `covers` (the AC ids), `lang`
+/// — so the `.md` is the single source of truth. The body (everything after the
+/// closing fence) is what gets published; the front-matter is not.
+library;
+
+import 'package:yaml/yaml.dart';
+
+class IssueDoc {
+  final Map<String, dynamic> meta;
+  final String body;
+
+  IssueDoc(this.meta, this.body);
+
+  String? get title => _string('title');
+  String? get repo => _string('repo');
+  String? get lang => _string('lang');
+
+  List<String> get labels => _stringList('labels');
+  List<String> get covers => _stringList('covers');
+
+  String? _string(String key) {
+    final v = meta[key];
+    if (v == null) return null;
+    final s = v.toString().trim();
+    return s.isEmpty ? null : s;
+  }
+
+  List<String> _stringList(String key) {
+    final v = meta[key];
+    if (v is List) {
+      return v.map((e) => e.toString().trim()).where((e) => e.isNotEmpty).toList();
+    }
+    return const [];
+  }
+}
+
+/// Parses [content] into an [IssueDoc], or returns `null` when it has no
+/// well-formed leading `---` front-matter fence.
+IssueDoc? parseIssueDoc(String content) {
+  final lines = content.split('\n');
+  if (lines.isEmpty || lines.first.trim() != '---') return null;
+
+  var end = -1;
+  for (var i = 1; i < lines.length; i++) {
+    if (lines[i].trim() == '---') {
+      end = i;
+      break;
+    }
+  }
+  if (end == -1) return null;
+
+  final fm = lines.sublist(1, end).join('\n');
+  final body = lines.sublist(end + 1).join('\n').trim();
+
+  final meta = <String, dynamic>{};
+  try {
+    final parsed = loadYaml(fm);
+    if (parsed is YamlMap) {
+      parsed.forEach((k, v) => meta[k.toString()] = _plain(v));
+    }
+  } catch (_) {
+    return null;
+  }
+
+  return IssueDoc(meta, body);
+}
+
+dynamic _plain(dynamic v) {
+  if (v is YamlList) return v.map(_plain).toList();
+  if (v is YamlMap) {
+    return v.map((k, val) => MapEntry(k.toString(), _plain(val)));
+  }
+  return v;
+}

--- a/code/cli/lib/modules/issue/issue_builder.dart
+++ b/code/cli/lib/modules/issue/issue_builder.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:modular_cli_sdk/modular_cli_sdk.dart';
+
+import '../../assets.dart';
+import '../../templates/template_resolver.dart';
+import 'commands/new.dart';
+import 'commands/publish.dart';
+
+/// Registers the `issue` module — "issue as code".
+///
+/// `iq issue new <slug> <name>` scaffolds `requisitions/<slug>/issue-<name>.md`
+/// from the single-source bilingual template (inheriting the spec's `iq:lang`),
+/// and `iq issue publish <slug> <name> [--plan|--apply]` turns that `.md` into a
+/// GitHub issue via `gh` (Terraform-style: `--plan` previews, `--apply` creates).
+void buildIssueModule(ModuleBuilder m, {required Assets assets}) {
+  final resolver = TemplateResolver(assets);
+
+  m.command<IssueNewInput, IssueNewOutput>(
+    'new <slug> <name>',
+    (req) => IssueNewCommand(
+      IssueNewInput.fromCliRequest(req),
+      resolver: resolver,
+      workingDirectory: Directory.current.path,
+    ),
+    description:
+        'Scaffold requisitions/<slug>/issue-<name>.md (issue as code). '
+        '--repo owner/repo pre-fills the target; language inherits from the spec.',
+  );
+
+  m.command<IssuePublishInput, IssuePublishOutput>(
+    'publish <slug> <name>',
+    (req) => IssuePublishCommand(
+      IssuePublishInput.fromCliRequest(req),
+      workingDirectory: Directory.current.path,
+    ),
+    description:
+        'Create the GitHub issue from issue-<name>.md via gh. '
+        '--plan (default) previews the command; --apply runs it.',
+  );
+}

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.16.1';
+const String inquiryVersion = '0.17.0';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.16.1
+version: 0.17.0
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/issue_command_test.dart
+++ b/code/cli/test/issue_command_test.dart
@@ -1,0 +1,182 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:inquiry_cli/assets.dart';
+import 'package:inquiry_cli/templates/template_resolver.dart';
+import 'package:inquiry_cli/modules/issue/front_matter.dart';
+import 'package:inquiry_cli/modules/issue/commands/new.dart';
+import 'package:inquiry_cli/modules/issue/commands/publish.dart';
+
+void main() {
+  final resolver = TemplateResolver(Assets(root: Directory.current.path));
+
+  late Directory tempDir;
+
+  setUp(() => tempDir = Directory.systemTemp.createTempSync('iq_issue_test_'));
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  // Scaffolds a requisition workspace with a spec carrying the given iq:lang.
+  void seedSpec(String slug, {String lang = 'es'}) {
+    final f = File(p.join(tempDir.path, 'requisitions', slug, 'specification.md'));
+    f.createSync(recursive: true);
+    f.writeAsStringSync('# Especificación\n\n<!-- iq:lang=$lang -->\n');
+  }
+
+  String issuePath(String slug, String name) =>
+      p.join(tempDir.path, 'requisitions', slug, 'issue-$name.md');
+
+  IssueNewCommand newCmd(String slug, String name, {String? repo, String? lang}) =>
+      IssueNewCommand(
+        IssueNewInput(slug: slug, name: name, repo: repo, lang: lang),
+        resolver: resolver,
+        workingDirectory: tempDir.path,
+      );
+
+  group('front matter', () {
+    test('parses title/repo/labels/covers and splits the body', () {
+      final doc = parseIssueDoc('''
+---
+kind: iq-issue
+lang: es
+title: "[db] Historial de tickets"
+repo: "owner/impulsa-db"
+labels: [tickets, db]
+covers: [AC-1, AC-2]
+---
+
+# Body heading
+
+Some content.
+''');
+      expect(doc, isNotNull);
+      expect(doc!.title, '[db] Historial de tickets');
+      expect(doc.repo, 'owner/impulsa-db');
+      expect(doc.labels, ['tickets', 'db']);
+      expect(doc.covers, ['AC-1', 'AC-2']);
+      expect(doc.body, startsWith('# Body heading'));
+      expect(doc.body, isNot(contains('kind: iq-issue')));
+    });
+
+    test('returns null without a front-matter fence', () {
+      expect(parseIssueDoc('# just markdown\n'), isNull);
+    });
+  });
+
+  group('IssueNewCommand', () {
+    test('scaffolds issue-<name>.md inheriting the spec language (es)', () async {
+      seedSpec('feature', lang: 'es');
+      final out = await newCmd('feature', 'db').execute();
+      expect(out.message, contains('(es)'));
+      final content = File(issuePath('feature', 'db')).readAsStringSync();
+      expect(content, contains('lang: es'));
+      expect(content, contains('spec: "requisitions/feature/specification.md"'));
+      expect(content, contains('kind: iq-issue'));
+    });
+
+    test('--repo pre-fills the front-matter repo', () async {
+      seedSpec('feature');
+      await newCmd('feature', 'api', repo: 'owner/impulsa-api').execute();
+      final doc = parseIssueDoc(File(issuePath('feature', 'api')).readAsStringSync());
+      expect(doc!.repo, 'owner/impulsa-api');
+    });
+
+    test('--lang overrides the inherited spec language', () async {
+      seedSpec('feature', lang: 'es');
+      await newCmd('feature', 'app', lang: 'en').execute();
+      expect(File(issuePath('feature', 'app')).readAsStringSync(),
+          contains('lang: en'));
+    });
+
+    test('is idempotent — an existing issue file is kept', () async {
+      seedSpec('feature');
+      final path = issuePath('feature', 'db');
+      await newCmd('feature', 'db').execute();
+      File(path).writeAsStringSync('EDITED');
+      final out = await newCmd('feature', 'db').execute();
+      expect(out.message, contains('already exists'));
+      expect(File(path).readAsStringSync(), 'EDITED');
+    });
+
+    test('validate rejects a missing workspace', () {
+      expect(newCmd('nope', 'db').validate(), contains('No requisition workspace'));
+    });
+  });
+
+  group('IssuePublishCommand', () {
+    void writeIssue(String slug, String name, String content) {
+      final f = File(issuePath(slug, name));
+      f.createSync(recursive: true);
+      f.writeAsStringSync(content);
+    }
+
+    IssuePublishCommand pub(String slug, String name,
+            {bool apply = false, ProcessRunner? runner}) =>
+        IssuePublishCommand(
+          IssuePublishInput(slug: slug, name: name, apply: apply),
+          workingDirectory: tempDir.path,
+          runProcess: runner,
+        );
+
+    const filled = '''
+---
+kind: iq-issue
+lang: es
+title: "[db] Historial de tickets"
+repo: "owner/impulsa-db"
+labels: [tickets, db]
+covers: [AC-1, AC-2]
+---
+
+# [db] Historial de tickets
+
+Cuerpo.
+''';
+
+    test('--plan previews the gh command without running it', () async {
+      writeIssue('feature', 'db', filled);
+      var ran = false;
+      final out = await pub('feature', 'db', runner: (e, a) async {
+        ran = true;
+        return ProcessResult(0, 0, '', '');
+      }).execute();
+      expect(ran, isFalse);
+      expect(out.ok, isTrue);
+      expect(out.message, contains('gh issue create'));
+      expect(out.message, contains('--repo owner/impulsa-db'));
+      expect(out.message, contains('AC-1, AC-2'));
+    });
+
+    test('--apply runs gh and reports the URL', () async {
+      writeIssue('feature', 'db', filled);
+      late List<String> gotArgs;
+      final out = await pub('feature', 'db', apply: true, runner: (e, a) async {
+        gotArgs = a;
+        return ProcessResult(0, 0, 'https://github.com/owner/impulsa-db/issues/7', '');
+      }).execute();
+      expect(out.ok, isTrue);
+      expect(out.message, contains('issues/7'));
+      expect(gotArgs, containsAllInOrder(['issue', 'create', '--repo', 'owner/impulsa-db']));
+      expect(gotArgs, containsAllInOrder(['--label', 'tickets']));
+      expect(gotArgs, contains('--body-file'));
+    });
+
+    test('fails when the front-matter has no repo', () async {
+      writeIssue('feature', 'db', '''
+---
+kind: iq-issue
+title: "no repo"
+repo: ""
+covers: [AC-1]
+---
+body
+''');
+      final out = await pub('feature', 'db').execute();
+      expect(out.ok, isFalse);
+      expect(out.message, contains('repo: owner/repo'));
+    });
+  });
+}

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.16.1</span>
+      <span class="badge">v0.17.0</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Why
Dogfooding the specification phase surfaced that deriving issues was **unstructured freehand** (no template, AC references ad-hoc), the **language was easy to get wrong** (issues came out in English from a Spanish spec), and there was **no path** from the local `.md` to a real GitHub issue.

## What — "issue as code"
The `.md` is the single source of truth (reviewable in git); publishing to GitHub is a derived step.

- **`iq issue new <slug> <name> [--repo owner/repo] [--lang <en|es>]`** — scaffolds `requisitions/<slug>/issue-<name>.md` from `issue.template.{en,es}.md`, **inheriting the spec's `iq:lang`** (Spanish spec → Spanish issue, no flag to remember). YAML front-matter (`title`, `repo`, `labels`, `spec`, `covers`, `lang`) + structured body (Context, Scope, Technical decisions/evidence, AC covered). Idempotent. `covers:` feeds the gate's AC→issue traceability.
- **`iq issue publish <slug> <name> [--plan|--apply]`** — turns it into a GitHub issue via `gh`, Terraform-style: **`--plan`** (default, safe) prints the exact `gh issue create` from the front-matter without creating anything; **`--apply`** runs it and returns the URL. Only the body is published; the front-matter is not.
- The **`/iq-specification` skill** now drives the issue step through these commands instead of freehand `gh issue create`.

## Verification
- **539** tests pass (11 new: front-matter parsing, `new` language inheritance / `--repo` / idempotence, `publish` `--plan` preview / `--apply` via injected runner / missing-repo failure).
- Smoke-tested the built binary end-to-end: `iq issue new demo db --repo owner/impulsa-db` (inherits `es`, prefills repo) → `iq issue publish demo db` (plan previews the `gh` command, warns on empty `covers:`).