### PR TITLE
fix(spec): AC traceability reads issue covers: front-matter, not raw body scan; release v0.17.1

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.17.1]
+### Fixed
+- **AC→issue traceability now reads the issue's `covers:` front-matter, not a raw text scan of the whole body** (found by dogfooding the brand-new `iq issue` scaffold — its example comment `AC-1, AC-2` in the body made the gate report those two ACs as "traced" while the `covers:` list was still empty). For an "issue as code" file (with `---` front-matter) the gate now derives the traced ACs from its declared `covers:` — the canonical, machine-readable source — so prose, comments, or template examples in the body never trace falsely. A freehand issue with no front-matter still falls back to the raw-text scan (back-compat). The issue templates also drop the literal example ids.
+
 ## [0.17.0]
 ### Added
 - **`iq issue` — "issue as code": derive an issue as a reviewable `.md`, then publish it to GitHub** (found by dogfooding — deriving issues was unstructured freehand, the language was easy to get wrong, and there was no path from the local `.md` to a real GitHub issue). Two commands plus bilingual templates:

--- a/code/cli/assets/artifacts/issue.template.en.md
+++ b/code/cli/assets/artifacts/issue.template.en.md
@@ -30,4 +30,4 @@ covers: []
 
 ## Acceptance criteria covered
 
-<!-- Echo here, for human reading, the AC from the front-matter (covers): AC-1, AC-2, … -->
+<!-- Echo here, for human reading, the AC listed in the front-matter `covers:`. The gate's traceability reads `covers:`, not this text. -->

--- a/code/cli/assets/artifacts/issue.template.es.md
+++ b/code/cli/assets/artifacts/issue.template.es.md
@@ -30,4 +30,4 @@ covers: []
 
 ## Criterios de aceptación cubiertos
 
-<!-- Repite aquí, para lectura humana, los AC del front-matter (covers): AC-1, AC-2, … -->
+<!-- Repite aquí, para lectura humana, los AC listados en el front-matter `covers:`. La trazabilidad del gate se toma del `covers:`, no de este texto. -->

--- a/code/cli/lib/modules/specification/specification_gate.dart
+++ b/code/cli/lib/modules/specification/specification_gate.dart
@@ -8,6 +8,8 @@
 /// least one decision cites evidence; and at least one issue is derived.
 library;
 
+import '../issue/front_matter.dart';
+
 /// One failed rule, with a stable [code] (mirrors the dev-cycle gate codes such
 /// as `DIAGNOSIS_EVIDENCE_MISSING`) and a human-readable [message].
 class SpecificationViolation {
@@ -173,8 +175,11 @@ class SpecificationGate {
   }
 
   /// Every filled AC declared in the User Stories must be referenced by at least
-  /// one derived issue — the AC → issue link of the traceability spine. An AC
-  /// `AC-N` is "traced" when the token `AC-N` appears in some issue body.
+  /// one derived issue — the AC → issue link of the traceability spine. For an
+  /// "issue as code" file (with `---` front-matter) the trace comes from its
+  /// declared `covers:` list — the canonical, machine-readable source — so prose
+  /// or template examples in the body never trace falsely. A freehand issue (no
+  /// front-matter) falls back to a raw-text scan.
   void _checkAcTraceability(
     Map<String, String> sections,
     List<String> issues,
@@ -188,9 +193,14 @@ class SpecificationGate {
       declared.addAll(_acRows(story.body)); // canonical AC-N ids
     }
 
+    final traceTexts = issues.map((issue) {
+      final doc = parseIssueDoc(issue);
+      return doc != null ? doc.covers.join(' ') : issue;
+    }).toList();
+
     for (final ac in declared) {
       final token = RegExp('\\b${RegExp.escape(ac)}\\b', caseSensitive: false);
-      final traced = issues.any((issue) => token.hasMatch(issue));
+      final traced = traceTexts.any((t) => token.hasMatch(t));
       if (!traced) {
         violations.add(SpecificationViolation(
           'SPEC_AC_NOT_TRACED',

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.17.0';
+const String inquiryVersion = '0.17.1';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.17.0
+version: 0.17.1
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/specification_gate_test.dart
+++ b/code/cli/test/specification_gate_test.dart
@@ -182,6 +182,28 @@ void main() {
           isNot(contains('SPEC_AC_NOT_TRACED')));
     });
 
+    test('issue-as-code traces via the front-matter covers: list', () {
+      const issue =
+          '---\nkind: iq-issue\ncovers: [AC-1, AC-2]\n---\n\nA body with no ids.\n';
+      final r = gate.evaluate(_filledSpec, issues: const [issue]);
+      expect(r.violations.map((v) => v.code),
+          isNot(contains('SPEC_AC_NOT_TRACED')));
+    });
+
+    test('an AC mentioned only in the body prose (not in covers:) does NOT trace',
+        () {
+      // covers declares AC-1; AC-2 appears in the body but is not declared —
+      // the fix: prose/examples must not trace falsely (issue-as-code source of
+      // truth is covers:).
+      const issue =
+          '---\nkind: iq-issue\ncovers: [AC-1]\n---\n\nRelated to AC-2 somehow.\n';
+      final r = gate.evaluate(_filledSpec, issues: const [issue]);
+      final untraced =
+          r.violations.where((v) => v.code == 'SPEC_AC_NOT_TRACED');
+      expect(untraced.map((v) => v.message).join('\n'), contains('AC-2'));
+      expect(untraced.map((v) => v.message).join('\n'), isNot(contains('AC-1')));
+    });
+
     test('a user story with no acceptance criterion → SPEC_STORY_MISSING_AC', () {
       final noAc = _filledSpec.replaceAll(
         RegExp(r'\| AC-\d+ .*\n'),

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.17.0</span>
+      <span class="badge">v0.17.1</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## Why
Dogfooding the brand-new `iq issue` scaffold surfaced a false-positive in the `specification_ready` gate: the issue template's **example comment `AC-1, AC-2`** in the body made the gate report those two ACs as **traced** even though the issue's `covers:` list was still empty. The gate was scanning the whole issue body for `AC-N` tokens, so prose/comments/examples traced falsely.

## Fix
- For an **"issue as code"** file (with `---` front-matter), traceability now comes from its declared **`covers:`** list — the canonical, machine-readable source — so nothing in the body (prose, comments, template examples) traces falsely.
- A **freehand** issue with no front-matter still falls back to the raw-text scan (back-compat).
- The `issue.template.{en,es}.md` drop the literal example ids.

## Verification
- **541** tests pass (2 new: `covers:` traces; an AC mentioned only in body prose does **not** trace).
- Re-ran the gate against the live dogfood spec: it now correctly reports **all 23** ACs untraced (empty `covers:`), instead of falsely sparing AC-1/AC-2.