### PR TITLE
feat(spec): lean the specification into a business charter (v0.18.0)

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.18.0]
+### Changed
+- **The specification is now a lean business charter — the PO ↔ team contract, in the domain's language (DDD), not a technical document** (found by dogfooding — Context, Decisions and Annexes read as noise in what is essentially a project charter; the document had drifted technical). It should carry only what a business contract needs: **when** (commitment date) and **what** (user stories + acceptance criteria), each in the ubiquitous language of the domain. Coordinated changes to `specification.template.{en,es}.md` and the `specification_ready` gate:
+  - **Testing strategy leaves the spec (→ development).** Each acceptance criterion is *already* its Given-When-Then test; the separate testing-strategy table was redundant. The `SPEC_NO_TESTING_STRATEGY` rule is removed — the tests that verify each AC are written in the dev cycle.
+  - **Technical decisions leave the spec (→ the issues).** Evidence-backed technical decisions now live in the issue bodies (which already have a *Technical decisions (evidence)* section), where the implementation is. The `SPEC_DECISION_EVIDENCE_MISSING` rule is removed; "evidence over inference" is preserved, relocated to where the technical work is.
+  - **`## Context and ground rules` becomes `## 4. Domain and business rules`** — a first-class, numbered home for the DDD ubiquitous language: domain glossary, cross-cutting business rules, and actors/permissions. Purified to business only (implementation detail moves to the issues), so it is signal, not noise.
+  - **Sections renumbered:** `1.` Commitment date, `2.` User Stories, `3.` Explicit Scope (was `4.`), `4.` Domain and business rules. The gate's number-based (language-agnostic) lookup moves with them, so `--lang es` specs keep working. Annexes is dropped; source references move to a `Sources` / `Fuentes` field in Metadata. A one-line charter/DDD framing opens the document.
+  - The gate still enforces the essentials: a committed ISO date (§1), ≥1 Given-When-Then AC per story (§2), an explicit includes/excludes scope (§3), ≥1 derived issue, and full AC→issue traceability via `covers:`.
+
 ## [0.17.1]
 ### Fixed
 - **AC→issue traceability now reads the issue's `covers:` front-matter, not a raw text scan of the whole body** (found by dogfooding the brand-new `iq issue` scaffold — its example comment `AC-1, AC-2` in the body made the gate report those two ACs as "traced" while the `covers:` list was still empty). For an "issue as code" file (with `---` front-matter) the gate now derives the traced ACs from its declared `covers:` — the canonical, machine-readable source — so prose, comments, or template examples in the body never trace falsely. A freehand issue with no front-matter still falls back to the raw-text scan (back-compat). The issue templates also drop the literal example ids.

--- a/code/cli/assets/artifacts/specification.template.en.md
+++ b/code/cli/assets/artifacts/specification.template.en.md
@@ -3,12 +3,12 @@
 <!-- iq:lang=en · Language of this specification and ALL its derived artifacts (issues, requirements, plans). Keep consistent. Not rendered in the PDF/DOCX. -->
 
 <!--
-  All fields are mandatory.
   User stories: User Stories Applied (Cohn, 2004).
   Acceptance Criteria: Given-When-Then — BDD (North, 2006).
-  Testing strategy: TDD (Beck, 2002).
-  Decisions: licensed by evidence from experiments, not by inference.
+  Domain language: Domain-Driven Design (Evans, 2003).
 -->
+
+_This specification is the **business agreement** — like a project charter — between the Product Owner and the team. Write it in the **domain language (DDD)**: business and behavior, not implementation (the technical part lives in the issues)._
 
 ## Metadata
 
@@ -22,14 +22,7 @@
 | QA Analyst    | <!-- Name -->                      |
 | Dev Analyst   | <!-- Name -->                      |
 | Issued        | {{DATE}}                           |
-
-## Context and ground rules
-
-<!-- First-class content (not an "aside"): a glossary of domain terms,
-     assumptions and cross-cutting rules that apply to every user story.
-     Optional but recommended — it avoids repeating context inside each AC. -->
-
-- <!-- Term, assumption, or cross-cutting rule -->
+| Sources       | <!-- PPT, mockups, emails, links --> |
 
 ## 1. Commitment date
 
@@ -52,7 +45,8 @@
 
 <!-- The AC column holds ONLY the number (1, 2, …); the id is AC-<number>. Keep
      the separator dashes moderate — do not widen them to the text width, or the
-     PDF export splits the column. -->
+     PDF export splits the column. Each AC is also its acceptance test (tests are
+     written in development). -->
 
 | AC  | Given (context)         | When (action)        | Then (expected result) |
 | --- | ----------------------- | -------------------- | ---------------------- |
@@ -60,18 +54,7 @@
 
 <!-- Duplicate the US-N block for more stories. -->
 
-## 3. Testing Strategy
-
-<!-- Define WHICH kinds of tests are needed and WHAT they validate — no function
-     names or code. -->
-
-| Type        | What it must validate                       | Related AC      |
-| ----------- | ------------------------------------------- | --------------- |
-| Unit        | <!-- e.g. field validation, no-dup rule --> | <!-- AC-1 -->   |
-| Integration | <!-- e.g. correct DB persistence -->        | <!-- AC-2 -->   |
-| E2E         | <!-- e.g. full UI flow — or N/A -->         | <!-- AC-1 -->   |
-
-## 4. Explicit Scope
+## 3. Explicit Scope
 
 ### Includes
 
@@ -81,14 +64,12 @@
 
 - <!-- what is explicitly out of scope -->
 
-## 5. Decisions (evidence)
+## 4. Domain and business rules
 
-<!-- Each key decision must cite the experiment that licensed it (a throwaway
-     probe: a DB query, a container run, an API call), with a re-checkable
-     handle — not an assumption. -->
+<!-- Ubiquitous language (DDD): domain glossary, cross-cutting business rules and
+     actors/permissions that apply to the stories. Business only — the
+     implementation lives in the issues. -->
 
-- **Decision**: <!-- the decision made -->. **Evidence**: <!-- experiment + result, with a re-checkable handle: a query, a command, `inline-code`, or a file:line -->.
-
-## Annexes
-
-<!-- Diagrams, mockups, technical notes, references, or any supporting material. -->
+- **Actors / permissions:** <!-- who can do what -->
+- **Glossary:** <!-- domain term: definition (each term defined once) -->
+- **Rules:** <!-- cross-cutting business rule shared by the stories -->

--- a/code/cli/assets/artifacts/specification.template.es.md
+++ b/code/cli/assets/artifacts/specification.template.es.md
@@ -3,12 +3,12 @@
 <!-- iq:lang=es · Idioma de esta especificación y de TODOS sus artefactos derivados (issues, requirements, planes). Mantener consistente. No se renderiza en el PDF/DOCX. -->
 
 <!--
-  Todos los campos son obligatorios.
   Historias de usuario: User Stories Applied (Cohn, 2004).
   Acceptance Criteria: Given-When-Then — BDD (North, 2006).
-  Estrategia de testing: TDD (Beck, 2002).
-  Decisiones: licenciadas por evidencia de experimentos, no por inferencia.
+  Lenguaje del dominio: Domain-Driven Design (Evans, 2003).
 -->
+
+_Esta especificación es el **acuerdo de negocio** —a la manera de un project charter— entre el Product Owner y el equipo. Se escribe en el **lenguaje del dominio (DDD)**: negocio y comportamiento, no implementación (lo técnico vive en los issues)._
 
 ## Metadatos
 
@@ -22,14 +22,7 @@
 | Analista QA      | <!-- Nombre Apellido -->             |
 | Analista Dev     | <!-- Nombre Apellido -->             |
 | Fecha de emisión | {{DATE}}                             |
-
-## Contexto y reglas base
-
-<!-- Contenido de primera clase (no "cita"): glosario de términos del dominio,
-     supuestos y reglas transversales que aplican a todas las HU. Opcional pero
-     recomendado — evita repetir el contexto dentro de cada AC. -->
-
-- <!-- Término, supuesto o regla transversal -->
+| Fuentes          | <!-- PPT, mockups, correos, enlaces --> |
 
 ## 1. Fecha de compromiso
 
@@ -52,7 +45,8 @@
 
 <!-- La columna AC lleva SOLO el número (1, 2, …); el id es AC-<número>. Mantén
      los guiones del separador moderados — no los amplíes al ancho del texto, o
-     la exportación a PDF parte la columna. -->
+     la exportación a PDF parte la columna. Cada AC es, además, su test de
+     aceptación (los tests se escriben en desarrollo). -->
 
 | AC  | Given (Dado que)        | When (Cuando)        | Then (Entonces)        |
 | --- | ----------------------- | -------------------- | ---------------------- |
@@ -60,18 +54,7 @@
 
 <!-- Duplicar el bloque HU-N para más historias. -->
 
-## 3. Estrategia de Testing
-
-<!-- Definir QUÉ tipos de tests se necesitan y QUÉ validan, sin nombres de
-     funciones ni código. -->
-
-| Tipo        | Qué debe validar                                            | AC asociados   |
-| ----------- | ----------------------------------------------------------- | -------------- |
-| Unit        | <!-- Ej. Validación de campos, regla de no-duplicados -->   | <!-- AC-1 -->  |
-| Integration | <!-- Ej. Persistencia correcta en base de datos -->         | <!-- AC-2 -->  |
-| E2E         | <!-- Ej. Flujo completo desde la UI — o N/A -->             | <!-- AC-1 -->  |
-
-## 4. Alcance Explícito
+## 3. Alcance Explícito
 
 ### Incluye
 
@@ -81,14 +64,12 @@
 
 - <!-- Qué queda fuera explícitamente -->
 
-## 5. Decisiones (evidencia)
+## 4. Dominio y reglas de negocio
 
-<!-- Cada decisión clave debe citar el experimento que la sustenta (una sonda
-     desechable: una consulta a BD, correr un contenedor, llamar un API), con un
-     handle re-verificable — no una suposición. -->
+<!-- Lenguaje ubicuo (DDD): glosario del dominio, reglas de negocio transversales
+     y actores/permisos que aplican a las historias. Solo negocio — la
+     implementación va en los issues. -->
 
-- **Decisión**: <!-- la decisión tomada -->. **Evidencia**: <!-- experimento + resultado, con handle re-verificable: una consulta, un comando, `inline-code`, o un archivo:línea -->.
-
-## Anexos
-
-<!-- Diagramas, mockups, notas técnicas, referencias o cualquier material de apoyo. -->
+- **Actores / permisos:** <!-- quién puede hacer qué -->
+- **Glosario:** <!-- término del dominio: definición (cada término una sola vez) -->
+- **Reglas:** <!-- regla de negocio transversal que comparten las historias -->

--- a/code/cli/lib/hosts/skill_builder.dart
+++ b/code/cli/lib/hosts/skill_builder.dart
@@ -164,8 +164,8 @@ Turn a raw requisition (email, document, chat) into a coherent, actionable speci
 1. `iq specification new <slug>` (add `--lang es` for Spanish) — the CLI scaffolds `requisitions/<slug>/requisition.md` + `specification.md`. Inputs/outputs are files on disk, not your memory.
 2. `iq ape prompt --name dewey` — read the method (Deweyan inquiry) and apply it.
 3. Gather the raw requisition from ALL its sources into `requisition.md` (AS-IS / TO-BE). Capture exactly what was asked — do not invent scope.
-4. For every decision you are unsure of, run a **throwaway experiment** to decide by EVIDENCE, not inference: read the DB, run code in a container, probe the API. These validate spec decisions; they are NOT product code. Record each under **Decisions (evidence)** with a re-checkable handle.
-5. Fill `specification.md` (see sections below). Set a committed delivery date (§1, ISO `YYYY-MM-DD` — the gate requires it); each user story needs ≥1 Given-When-Then acceptance criterion; state the testing strategy and the explicit scope (includes / does NOT include).
+4. For every decision you are unsure of, run a **throwaway experiment** to decide by EVIDENCE, not inference: read the DB, run code in a container, probe the API. These validate decisions; they are NOT product code. Record each **technical** decision with a re-checkable handle in the **issues** (step 6) — the specification stays business-level.
+5. Fill `specification.md` — a lean **business charter** in the domain language (DDD), not implementation. Set a committed delivery date (§1, ISO `YYYY-MM-DD` — the gate requires it); write each user story with ≥1 Given-When-Then acceptance criterion (§2); state the explicit scope (§3, includes / does NOT include); capture the domain glossary and business rules (§4).
 6. Derive the issues with **`iq issue new <slug> <name> [--repo owner/repo]`** — it scaffolds `requisitions/<slug>/issue-<name>.md` ("issue as code") **inheriting the spec's `iq:lang`** (so a Spanish spec yields Spanish issues). Fill each from evidence and list the acceptance criteria it covers in the front-matter `covers:`. One issue per unit of work (e.g. one per repo).
 7. `iq specification check <slug>` — the CLI runs the `specification_ready` gate. Fix exactly what it reports (do NOT skip a violation) until it exits 0.
 8. Dedup-check before creating: `gh issue list --search "<keywords>"`. If a too-similar issue exists, edit that one instead.
@@ -174,11 +174,11 @@ Turn a raw requisition (email, document, chat) into a coherent, actionable speci
 ## specification.md — fill these sections
 ${sections.map((s) => '- **$s**').join('\n')}
 
-Each user story MUST carry ≥1 Given-When-Then AC; each key decision MUST cite its experiment evidence; the scope MUST state what is excluded; and ≥1 issue MUST be derived.
+Each user story MUST carry ≥1 Given-When-Then AC; the scope MUST state what is excluded; and ≥1 issue MUST be derived (tracing every AC). Keep it business-level — tests are written in development and technical decisions live in the issues.
 
 ## Done when
 - [ ] `requisition.md` captures the need (AS-IS / TO-BE) from all sources.
-- [ ] `specification.md` is filled — every user story has ≥1 Given-When-Then AC, explicit scope, testing strategy, and Decisions (evidence) with handles.
+- [ ] `specification.md` is filled — committed date, every user story with ≥1 Given-When-Then AC, explicit scope (includes/excludes), and the domain glossary + business rules.
 - [ ] `iq specification check <slug>` exits 0.
 - [ ] At least one `issue-<slug>.md` is derived, dedup-checked, with its `gh` command printed.
 - [ ] The specification is presented to the human for review.

--- a/code/cli/lib/modules/specification/specification_gate.dart
+++ b/code/cli/lib/modules/specification/specification_gate.dart
@@ -3,9 +3,12 @@
 ///
 /// The specification phase is outside the dev FSM, so this gate is not an
 /// `iq fsm transition` event; it is run by `iq specification check <slug>`. The
-/// rules mirror the locked design: each user story carries ≥1 Given-When-Then
-/// acceptance criterion; the testing strategy and explicit scope are filled; at
-/// least one decision cites evidence; and at least one issue is derived.
+/// specification is a lean **business charter** (PO ↔ team contract, in the
+/// domain's ubiquitous language): a committed delivery date; each user story
+/// carries ≥1 Given-When-Then acceptance criterion; the explicit scope is
+/// filled; and at least one issue is derived, tracing every AC. Testing (each AC
+/// is already a test) moves to development, and technical decisions to the
+/// issues — neither is gated here.
 library;
 
 import '../issue/front_matter.dart';
@@ -44,9 +47,7 @@ class SpecificationGate {
 
     _checkCommitmentDate(sections, violations);
     _checkUserStories(sections, violations);
-    _checkTestingStrategy(sections, violations);
     _checkScope(sections, violations);
-    _checkDecisions(sections, violations);
 
     final realIssues = issues.where((i) => i.trim().isNotEmpty).toList();
     if (realIssues.isEmpty) {
@@ -116,28 +117,11 @@ class SpecificationGate {
     }
   }
 
-  void _checkTestingStrategy(
-    Map<String, String> sections,
-    List<SpecificationViolation> violations,
-  ) {
-    final body = _section(sections, 3);
-    final hasFilledRow = body != null &&
-        _tableDataRows(body).any((cells) =>
-            cells.length >= 2 && _isFilled(cells[1]));
-    if (!hasFilledRow) {
-      violations.add(const SpecificationViolation(
-        'SPEC_NO_TESTING_STRATEGY',
-        'Testing strategy has no filled row — state at least one test type and '
-            'what it must validate.',
-      ));
-    }
-  }
-
   void _checkScope(
     Map<String, String> sections,
     List<SpecificationViolation> violations,
   ) {
-    final body = _section(sections, 4);
+    final body = _section(sections, 3);
     final includes =
         body == null ? false : _hasFilledBullet(body, _includesHeadings);
     final excludes =
@@ -147,29 +131,6 @@ class SpecificationGate {
         'SPEC_SCOPE_INCOMPLETE',
         'Explicit scope is incomplete — both "Includes" and "Does NOT include" '
             'need at least one real bullet.',
-      ));
-    }
-  }
-
-  void _checkDecisions(
-    Map<String, String> sections,
-    List<SpecificationViolation> violations,
-  ) {
-    final body = _section(sections, 5);
-    final hasEvidence = body != null &&
-        body.split('\n').any((line) {
-          final decision = _valueAfterAnyMarker(line, _decisionMarkers);
-          final evidence = _valueAfterAnyMarker(line, _evidenceMarkers);
-          return decision != null &&
-              evidence != null &&
-              _isFilled(decision) &&
-              _isFilled(evidence);
-        });
-    if (!hasEvidence) {
-      violations.add(const SpecificationViolation(
-        'SPEC_DECISION_EVIDENCE_MISSING',
-        'No decision cites evidence — at least one Decisions (evidence) bullet '
-            'must carry a filled Decision and Evidence (an experiment handle).',
       ));
     }
   }
@@ -238,9 +199,9 @@ class SpecificationGate {
 
   /// Looks up a section by its leading number (`## 1. …`). The templates number
   /// the sections identically in every language (`1.` Commitment date / Fecha de
-  /// compromiso, `2.` User Stories / Historias de Usuario, `3.` Testing Strategy
-  /// / Estrategia de Testing, `4.` Scope, `5.` Decisions), so this is
-  /// language-agnostic — the gate works on `--lang es` specs too.
+  /// compromiso, `2.` User Stories / Historias de Usuario, `3.` Explicit Scope /
+  /// Alcance Explícito, `4.` Domain and business rules / Dominio y reglas de
+  /// negocio), so this is language-agnostic — the gate works on `--lang es` too.
   String? _section(Map<String, String> sections, int number) {
     for (final entry in sections.entries) {
       if (entry.key.startsWith('$number.')) return entry.value;
@@ -327,25 +288,6 @@ class SpecificationGate {
     return null;
   }
 
-  /// Data rows of any markdown table in [block] (skips header + separator).
-  List<List<String>> _tableDataRows(String block) {
-    final rows = <List<String>>[];
-    for (final line in block.split('\n')) {
-      final t = line.trim();
-      if (!t.startsWith('|')) continue;
-      if (RegExp(r'^\|[\s\-:|]+\|?$').hasMatch(t)) continue; // separator
-      final cells = _cells(line);
-      if (cells.isEmpty) continue;
-      // Skip the header row (first cell is a known column label, en or es).
-      final first = cells.first.toLowerCase();
-      if (const {'type', 'tipo', '#', 'field', 'campo'}.contains(first)) {
-        continue;
-      }
-      rows.add(cells);
-    }
-    return rows;
-  }
-
   bool _hasFilledBullet(String scopeBody, List<String> subheadings) {
     final lines = scopeBody.split('\n');
     var inSub = false;
@@ -384,28 +326,9 @@ class SpecificationGate {
     return rest;
   }
 
-  /// The value after the first matching bold [markers] label (e.g. `**Decision**`
-  /// or `**Decisión**`), stopping at the next bold span. Returns null when no
-  /// marker is present on the line.
-  String? _valueAfterAnyMarker(String line, List<String> markers) {
-    for (final marker in markers) {
-      final token = '**$marker**';
-      final i = line.indexOf(token);
-      if (i < 0) continue;
-      var rest = line.substring(i + token.length);
-      if (rest.startsWith(':')) rest = rest.substring(1);
-      final next = rest.indexOf('**');
-      if (next >= 0) rest = rest.substring(0, next);
-      return rest;
-    }
-    return null;
-  }
-
-  // Bilingual headings/markers (en + es) the templates ship.
+  // Bilingual scope subheadings (en + es) the templates ship.
   static const _includesHeadings = ['Includes', 'Incluye'];
   static const _excludesHeadings = ['Does NOT include', 'NO incluye'];
-  static const _decisionMarkers = ['Decision', 'Decisión'];
-  static const _evidenceMarkers = ['Evidence', 'Evidencia'];
 
   /// A value is "filled" when, after removing HTML comments and trailing
   /// punctuation/whitespace, something real remains.

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.17.1';
+const String inquiryVersion = '0.18.0';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.17.1
+version: 0.18.0
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/skill_builder_test.dart
+++ b/code/cli/test/skill_builder_test.dart
@@ -54,12 +54,10 @@ void main() {
       test('lists the specification.md sections (from template, not embedded)',
           () {
         for (final section in const [
-          '- **Context and ground rules**',
           '- **1. Commitment date**',
           '- **2. User Stories**',
-          '- **3. Testing Strategy**',
-          '- **4. Explicit Scope**',
-          '- **5. Decisions (evidence)**',
+          '- **3. Explicit Scope**',
+          '- **4. Domain and business rules**',
         ]) {
           expect(md, contains(section));
         }

--- a/code/cli/test/specification_check_command_test.dart
+++ b/code/cli/test/specification_check_command_test.dart
@@ -28,13 +28,7 @@ const _filledSpec = '''
 | ---- | ---------------- | -------------- | --------------- |
 | AC-1 | the form is open | I submit data  | it is stored    |
 
-## 3. Testing Strategy
-
-| Type | What it must validate | Related AC |
-| ---- | --------------------- | ---------- |
-| Unit | the no-duplicate rule | AC-1       |
-
-## 4. Explicit Scope
+## 3. Explicit Scope
 
 ### Includes
 
@@ -44,9 +38,9 @@ const _filledSpec = '''
 
 - The approval workflow.
 
-## 5. Decisions (evidence)
+## 4. Domain and business rules
 
-- **Decision**: reuse the billing table. **Evidence**: `psql -c "\\d billing"` (run 2026-06-30).
+- **Glossary:** an *invoice* is a billing document with a unique number.
 ''';
 
 void main() {

--- a/code/cli/test/specification_gate_test.dart
+++ b/code/cli/test/specification_gate_test.dart
@@ -37,13 +37,7 @@ const _filledSpec = '''
 | AC-1 | the form is open       | I submit valid data | the invoice is stored |
 | AC-2 | a duplicate number     | I submit it       | it is rejected         |
 
-## 3. Testing Strategy
-
-| Type | What it must validate | Related AC |
-| ---- | --------------------- | ---------- |
-| Unit | the no-duplicate rule | AC-2       |
-
-## 4. Explicit Scope
+## 3. Explicit Scope
 
 ### Includes
 
@@ -53,11 +47,9 @@ const _filledSpec = '''
 
 - Invoice approval workflow.
 
-## 5. Decisions (evidence)
+## 4. Domain and business rules
 
-- **Decision**: store invoices in the existing `billing` table. **Evidence**: `psql -c "\\d billing"` shows the columns already exist (run 2026-06-30).
-
-## Annexes
+- **Glossary:** an *invoice* is a billing document identified by a unique number.
 ''';
 
 /// A fully-filled Spanish (`--lang es`) specification — the gate must accept it
@@ -92,13 +84,7 @@ const _filledSpecEs = '''
 | ---- | ------------------ | -------------------- | ---------------------- |
 | AC-1 | el formulario abre | envío datos válidos  | la factura se almacena |
 
-## 3. Estrategia de Testing
-
-| Tipo | Qué debe validar          | AC asociados |
-| ---- | ------------------------- | ------------ |
-| Unit | la regla de no-duplicados | AC-1         |
-
-## 4. Alcance Explícito
+## 3. Alcance Explícito
 
 ### Incluye
 
@@ -108,11 +94,9 @@ const _filledSpecEs = '''
 
 - El flujo de aprobación de facturas.
 
-## 5. Decisiones (evidencia)
+## 4. Dominio y reglas de negocio
 
-- **Decisión**: reusar la tabla `billing`. **Evidencia**: `psql -c "\\d billing"` muestra las columnas (corrido 2026-06-30).
-
-## Anexos
+- **Glosario:** una *factura* es un documento de facturación con número único.
 ''';
 
 void main() {
@@ -222,14 +206,17 @@ void main() {
       expect(r.violations.map((v) => v.code), contains('SPEC_SCOPE_INCOMPLETE'));
     });
 
-    test('a decision without evidence → SPEC_DECISION_EVIDENCE_MISSING', () {
-      final noEvidence = _filledSpec.replaceAll(
-        RegExp(r'\*\*Evidence\*\*:.*'),
-        '**Evidence**: <!-- experiment + result -->.',
-      );
-      final r = gate.evaluate(noEvidence, issues: tracingIssues);
+    test('a lean charter without Testing or Decisions sections is still ready',
+        () {
+      // The spec is a business charter: testing moves to development (each AC is
+      // already a Given-When-Then test), and technical decisions move to the
+      // issues. Neither is gated any more.
+      final r = gate.evaluate(_filledSpec, issues: tracingIssues);
+      expect(r.passed, isTrue, reason: r.violations.join('\n'));
       expect(r.violations.map((v) => v.code),
-          contains('SPEC_DECISION_EVIDENCE_MISSING'));
+          isNot(contains('SPEC_NO_TESTING_STRATEGY')));
+      expect(r.violations.map((v) => v.code),
+          isNot(contains('SPEC_DECISION_EVIDENCE_MISSING')));
     });
 
     test('no user story at all → SPEC_NO_USER_STORY', () {
@@ -253,14 +240,5 @@ void main() {
           isNot(contains('SPEC_NO_COMMITMENT_DATE')));
     });
 
-    test('missing testing strategy rows → SPEC_NO_TESTING_STRATEGY', () {
-      final noStrategy = _filledSpec.replaceAll(
-        '| Unit | the no-duplicate rule | AC-2       |',
-        '| Unit | <!-- e.g. field validation --> | AC-2 |',
-      );
-      final r = gate.evaluate(noStrategy, issues: tracingIssues);
-      expect(r.violations.map((v) => v.code),
-          contains('SPEC_NO_TESTING_STRATEGY'));
-    });
   });
 }

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.17.1</span>
+      <span class="badge">v0.18.0</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
## What & why

The `specification.md` is the **PO ↔ team contract** — a lightweight project charter, written in the **domain's language (DDD)**, not a technical document. Dogfooding surfaced that **Context, Decisions and Annexes read as noise**: the spec had drifted technical. This release keeps only what a business contract needs — **when** (commitment date) and **what** (user stories + acceptance criteria) — each in the ubiquitous language of the domain. Technical detail moves to the layers where it belongs.

### The 3-layer model this settles

| Layer | Artifact | Audience | Language |
| --- | --- | --- | --- |
| **Contract** | `specification.md` (charter) | PO ↔ team | **business / domain (DDD)** |
| **Technical** | `issue-*.md` | dev team | implementation, code handles |
| **Verification** | tests | dev team | unit / integration / e2e per AC |

## Changes

- **Testing strategy leaves the spec (→ development).** Each acceptance criterion is *already* its Given-When-Then test; the separate table was redundant. **`SPEC_NO_TESTING_STRATEGY` removed.**
- **Technical decisions leave the spec (→ the issues).** They already have a *Technical decisions (evidence)* section. **`SPEC_DECISION_EVIDENCE_MISSING` removed** — "evidence over inference" is preserved, relocated to the technical layer.
- **`## Context and ground rules` → `## 4. Domain and business rules`** — a first-class, numbered home for the DDD ubiquitous language (glossary, cross-cutting rules, actors/permissions), purified to business only.
- **Renumbered:** `1.` Commitment date · `2.` User Stories · `3.` Explicit Scope (was `4.`) · `4.` Domain and business rules. Annexes dropped; source references move to a **`Sources` / `Fuentes`** metadata field. A one-line charter/DDD framing opens the document.
- The **name stays `specification.md`** (per-requisition; a PMI charter is per-project) — only its *character* shifts to business-facing.

The gate still enforces the essentials: a committed ISO date (§1), ≥1 Given-When-Then AC per story (§2), an explicit includes/excludes scope (§3), ≥1 derived issue, and full AC→issue traceability via `covers:`. Language-agnostic (en + es) throughout.

## How it was built (TDD)

1. **Red** — migrated the gate/command/skill tests to the lean structure first: a "lean charter without Testing or Decisions is still ready" test (failed against the old gate), removed the two obsolete violation tests, moved scope to §3.
2. **Green** — removed the two checks + their dead helpers, renumbered scope, updated templates and the `/iq-specification` skill.

- **540 tests pass**, `dart analyze` clean (one pre-existing benign doc-comment hint).
- Smoke-tested the built binary: the new template scaffolds §1–§4 (no Testing/Decisions), and `iq specification check` reports only the right violations — no `SPEC_NO_TESTING_STRATEGY` / `SPEC_DECISION_EVIDENCE_MISSING`.