### PR TITLE
docs(paper): dogfood field-evidence + roadmap items from real use

### DIFF
--- a/code/paper/exp-a-local-host-replication.md
+++ b/code/paper/exp-a-local-host-replication.md
@@ -1,0 +1,69 @@
+# Supplement: local-host experiments on the harness (Exp A) — corrected record
+
+Prepared 2026-06-17/18 to complement `manuscript.tex` (agenticdev-2026). This note
+records TWO studies and **a corrected interpretation**: the first was run autonomously
+and therefore mis-measures the harness on outcome; the second introduces a conductor and
+an abductive-trap task to test the harness's actual purpose.
+
+## Common setup
+
+- Artifact: Inquiry v0.10.0 (OpenCode host + ANALYZE/PLAN verifiability gates).
+- Host/model: OpenCode headless; local `ollama/qwen3-coder:30b-16k`. **Reproducibility
+  finding:** OpenCode tool-calling with Ollama needs `num_ctx >= 16384`; at the 4K default
+  the model behaves as if it has no tools and cannot drive any harness.
+
+## Study 1 — autonomous H vs F, outcome-only, N=30 (PARTIALLY RETRACTED)
+
+Each condition fixed a one-line off-by-one bug 30×; only the final code was scored by a
+hidden test. Result: F 29/30 (97%), H 14/30 (47%); H/F overhead ~12x (wall-clock and
+tool-calls); H reached END 0/30.
+
+**What stands:** overhead. The ~12x H/F asymmetry replicates and strengthens the paper's
+most stable result (4.6–9.9x on Windows/Copilot) on a second host and a local model.
+
+**What is RETRACTED:** the outcome and completion numbers do **not** measure harness value.
+The harness is **human-in-the-loop by design** — ANALYZE is a conductor↔harness dialogue,
+and ANALYZE→PLAN, PLAN→EXECUTE, EXECUTE→END each require explicit conductor confirmation.
+Study 1 ran the harness **autonomously, with no conductor**. The "stuck in ANALYZE / 0-END"
+behavior is therefore the *correct* behavior of a system waiting for a conductor that was
+never present, not a failure of the method. Comparing autonomous-F (a model's native mode)
+to autonomous-H (a system that cannot legitimately advance without a human) is a category
+error. The 97%→47% "outcome" gap is an artifact of removing the conductor and is withdrawn.
+
+## Study 2 — conductor-in-the-loop, abductive-trap task (preliminary, qualitative)
+
+The harness exists to govern the *abductive machine*: to stop it acting on thin premises.
+That can only be tested on a task where the plausible action is **wrong**, with a conductor
+present. Task: `average(nums)` "sometimes crashes — fix it." Hidden requirement (known only
+to the conductor, revealed if asked): the data contains `None` values that must be ignored,
+and empty/all-None must return `None` (not 0, not crash).
+
+- **Freestyle (F), N=3: 3/3 FAIL**, all with `TypeError: int + NoneType`. The model patched
+  its assumption (empty-list guard) and never discovered the `None` requirement — the
+  predicted abductive failure: acting on a thin premise without asking.
+- **Harness (H), conducted, turn 1 (qualitative):** the model did **not** patch-and-assume.
+  Under ANALYZE it **investigated**: wrote a probe, reproduced the failure modes empirically
+  (empty → `ZeroDivisionError`; non-numeric → `TypeError`), i.e. it **gathered evidence
+  before acting** — the discipline the harness is meant to induce. (It was slow and had not
+  yet reached a diagnosis/conductor question when the turn timed out.)
+
+**Reading:** the directional signal is in the harness's favour on the *right* question —
+freestyle assumes and fails; the harness makes the same model investigate. This is
+preliminary (N small, one task, single turn observed) and not yet an outcome result.
+
+## Honest limits / next steps
+
+- Study 1's overhead is real but contaminated by autonomous spin; overhead is explicitly
+  *not* the current priority.
+- Study 2 needs full conducted runs to a verified outcome. The local model is too slow for
+  tractable turn-by-turn conducting; the plan is to put a **faster model in the
+  harness-driven role** while a strong conductor (Claude) answers ANALYZE and approves gates,
+  then run complete H-vs-F pairs on abductive-trap tasks.
+- Still required before any generalization: operator-isolation arm (Exp B) and a model
+  matrix (Exp C).
+
+## One-line status
+
+Overhead replicates (~12x); the autonomous outcome comparison is withdrawn as a category
+error; with a conductor and an abductive-trap task, the harness shows the predicted
+behavioural difference (investigate vs assume) — to be confirmed with full conducted runs.

--- a/code/paper/exp-design-abductive-governance.md
+++ b/code/paper/exp-design-abductive-governance.md
@@ -1,0 +1,73 @@
+# Pre-registered design: does the harness govern the abductive machine?
+
+Protocol fixed BEFORE running, to anchor the paper's empirical core honestly.
+
+## Question
+
+Does an explicit human-in-the-loop harness (Inquiry) prevent the *abductive failures*
+of a capable code model — acting on a thin premise, jumping from guess to edit,
+hallucinating a fact — that the same model commits in freestyle use?
+
+## Subject and conductor
+
+- **Subject (harness-driven / freestyle):** `qwen3-coder:30b-16k`, local via OpenCode. Fixed across all conditions.
+- **Conductor (human role):** automated LLM conductor that (a) answers clarifying questions truthfully from each task's ground-truth, **never volunteering the fix**, and (b) approves a gate iff the produced artifact is adequate. Same conductor policy across all H/ask runs (isolates the harness, not the conductor).
+
+## Task set (8 tasks — varied by failure mode and by construct)
+
+Each task = buggy/underspecified code + a one-line request + a **hidden ground-truth**
+(known only to the conductor) + a **hidden test** (the real requirement, never shown to
+the subject). The "abductive answer" (the plausible guess) is wrong on the hidden test.
+
+| # | Task | Abductive failure probed | Hidden truth (conductor reveals if asked) | Construct |
+|---|------|--------------------------|-------------------------------------------|-----------|
+| T1 | `average()` crashes | thin premise | list contains None → ignore; empty/all-None → None | C1 maieutic |
+| T2 | `clamp(x,lo,hi)` bug | thin premise | if lo>hi must raise ValueError (not swap) | C1 |
+| T3 | `total_price(items)` wrong totals | wrong-cause / patch-the-symptom | quantities arrive as strings; must int-convert (bug is in the data contract, not the sum) | C2 evidence |
+| T4 | "dedupe list, keep order" | ambiguous spec | dedupe is case-insensitive for strings | C1 |
+| T5 | "use parse_date() in utils.py" | hallucination | parse_date returns None on invalid (does NOT raise); error handling must check None | C2 evidence |
+| T6 | `date_range(start,end)` bug | convention assumption | end is EXCLUSIVE per team convention | C1 |
+| **K1** | plain off-by-one (`sum_range` inclusive) | — (control, no trap) | none | control |
+| **K2** | crashes on empty input | — (control, obvious guard is correct) | none | control |
+
+T1–T6 are traps (harness expected to help). K1–K2 are controls (harness expected to
+show **no** outcome advantage, only overhead) — they prove the effect is *specific* to
+abductive traps, not generic structure.
+
+## Conditions (per task)
+
+1. **F-headless** (N=3): freestyle, one-shot, cannot ask. The model's native autonomous mode.
+2. **F-can-ask** (N=2): freestyle, interactive; if the model asks a clarifying question, the conductor answers (same answers as H). Isolates *forced* (H) vs *optional* (F) clarification.
+3. **H-conducted** (N=2): the Inquiry harness, conducted (questions answered, gates approved).
+
+Total: 8 × (3+2+2) = **56 runs**.
+
+## Metrics (outcome-only + behavioural)
+
+- **Primary — outcome:** hidden-test PASS/FAIL (objective; no capture asymmetry).
+- **Behavioural — did the subject ASK?** (yes/no, and did the question surface the hidden requirement). Tests the maieutic mechanism directly.
+- **Secondary — overhead:** wall-clock, tool-calls (the known ~12× C4 result; not the priority).
+
+## Pre-registered predictions (falsifiable)
+
+- **P1 (traps):** F-headless FAILs most trap tasks (commits the abductive failure).
+- **P2 (mechanism):** H-conducted PASSes trap tasks it would otherwise fail, *because* ANALYZE elicits the hidden requirement (the subject asks, conductor answers).
+- **P3 (forcing matters):** F-can-ask sits *between* F-headless and H — if the model often does NOT ask even when allowed, then the harness's value is *forcing* the clarification, not merely permitting it.
+- **P4 (specificity):** on controls K1/K2, H shows **no** outcome advantage over F (only overhead) — the effect is trap-specific.
+
+A result that would NARROW the thesis: if F-can-ask ≈ H on traps, the harness adds
+nothing beyond "let the model ask"; if H fails traps too, ANALYZE doesn't reliably
+elicit the requirement.
+
+## Analysis
+
+Per task and pooled: PASS-rate by condition; ask-rate by condition; trap-vs-control
+contrast. Report N honestly; treat as a small structured study, not a large-N claim.
+Operator-isolation (generic-structure arm) and a model matrix are explicit future work.
+
+## Feasibility note
+
+56 runs, many interactive/conducted, are infeasible to drive by hand. The conductor
+**must be automated** (an LLM the runner can call). Options: Haiku via Anthropic API
+(best quality, paid) or a local conductor model (free, weaker — adds conductor noise).
+The conductor choice is a protocol parameter to fix before running.

--- a/code/paper/field-evidence-dogfood-2026-07.md
+++ b/code/paper/field-evidence-dogfood-2026-07.md
@@ -1,0 +1,87 @@
+# Field evidence: dogfooding Inquiry on two real requirements (2026-07)
+
+Companion to the pre-registered controlled study
+([exp-design-abductive-governance](exp-design-abductive-governance.md)). That study asks
+whether the harness governs the *abductive machine* of a **weak** local model (qwen3-coder:30b)
+on synthetic traps. This note records the complementary arm: **naturalistic field evidence**
+of the same methodology driving a **capable** model (Claude) end-to-end on two real, messy,
+multi-system requirements. N is small and uncontrolled by design — it is a case record of the
+harness *in production use*, not a claim of effect size.
+
+## Cases
+
+- **Impulsa — "ticket purchase from credit history"** (`--lang es`): a full feature; 2 user
+  stories, 23 AC; issues fanned out to `impulsa_{db,api,app}` + an external ERP prerequisite.
+  Specification phase closed green; handed to a Dev.
+- **Socia — "observaciones-ahorro-canasta"** (`--lang es`): a 3-observation refinement of an
+  existing screen, taken **all the way through development**. Specification → 2 issues → 2 PRs,
+  every AC covered by a passing test. Cross-**org**: the app fix lives in `bitstream-sac/socia`,
+  the API fix in `cacsi-dev/impulsa_api`.
+
+Both requirements evolved the tool itself: Inquiry went **0.15.0 → 0.18.0 (8 releases)**, each
+driven by a concrete friction surfaced by real use — not by speculation.
+
+## Observations relevant to the thesis
+
+1. **Specification is a *definedness* gate, and it is separated on purpose.** The FSM
+   (ANALYZE → PLAN → EXECUTE) is for **complex** problems; the specification phase is lifted out
+   of it because its job is prior and different: decide whether a problem is *defined enough to
+   build*. `specification_ready` mechanically enforces that (commitment date, ≥1 Given-When-Then
+   AC per story, explicit scope, ≥1 traced issue). ANALYZE/PLAN/EXECUTE are **TDD applied**; for a
+   small, already-defined change we ran the TDD essence directly without the full state machine.
+   The lesson is not "the FSM is overhead" — it is that **definedness and construction are
+   separate concerns, and the tool models them as separate stages.**
+
+2. **A stable 3-layer model held under stress.** Specification = the business contract in domain
+   language (DDD); issues = the technical layer (where + how, with code handles); tests =
+   verification (one per AC). Under two real requirements — including cross-repo and cross-org
+   fan-out — the boundary never leaked: the spec stayed business-level, the technical decisions
+   and code handles stayed in the issues.
+
+3. **The traceability spine closed end-to-end.** requisition → AC → issue (`covers:`) → test.
+   In Socia this was literal: from an annotated screenshot to a green gate to two PRs where
+   **every one of 7 AC is verified by a passing test**. The discipline lived in the tool
+   (gate + template + controlled vocabulary), not in the operator's memory.
+
+4. **"The story is the actor's; the issue points at the repo."** A user story is written in the
+   voice of whoever receives the value (the socia member), independent of which repo implements
+   it. That decoupling is what let one requirement span two organizations without deforming the
+   method — the same shape as an external-ERP prerequisite.
+
+5. **Evidence-over-inference repeatedly pre-empted abductive failure — the paper's exact
+   mechanism, observed with a capable model.** Concrete instances this cycle:
+   - *Thin-premise / stale belief:* the operator "remembered" the amount-colour was already
+     fixed; execution against the code showed it was not (single commit, no sign logic). Verified
+     before acting.
+   - *Guess-to-edit:* both change sites were pinpointed by evidence (`detalle_canasta.dart:263`,
+     `cuenta.controllers.js:157`) **before** any edit.
+   - *Hallucinated risk assessment:* the "is this a breaking change?" question was answered by
+     `grep` (blast radius = one branch; zero other consumers of the literal), not by "probably
+     fine." This is the abductive-governance thesis operating on a strong model, self-imposed via
+     the methodology rather than forced by a weak-model harness.
+
+6. **CLI = hands, model = brain, empirically.** The gate is mechanical (is the field present?).
+   The thinking — Deweyan investigation, authoring, the content-vs-presentation layer decision —
+   was the model's. The tool never reasoned; it enforced completeness and left a reviewable trail.
+
+## Honest limitations and open items (antifragility inputs)
+
+- **Field N is tiny and uncontrolled.** These cases show the method *delivering*; they do not
+  measure it against a freestyle baseline. That is what the controlled qwen study is for. The two
+  arms answer different questions: *does the harness rescue a weak model from traps* (controlled)
+  vs *does the methodology deliver coherent, traceable work with a strong model* (field).
+- **`requisitions/` will accumulate.** Over time the per-requirement artifact directory grows and
+  may become noise. Needs an archival / lifecycle answer (open design question).
+- **`iq issue publish --plan` should validate labels** against the target repo and, when one is
+  missing, print the `gh label create …` command to fix it (surfaced twice; currently fails late
+  at `--apply`).
+- **Capability floor.** The method's value is realised *with* strong reasoning. Local-model runs
+  remain gated on a future version capable enough to clear the abductive traps; until then the
+  live dogfood runs on capable models, and CLI improvements continue in parallel.
+
+## One-line takeaway
+
+Across two real requirements, Inquiry behaved as a **coherent methodology for evidence-based,
+traceable delivery** whose separation of *definedness* (specification) from *construction*
+(TDD-applied FSM) held — and it is earning that design by use, which is precisely the claim an
+agentic-development paper must substantiate.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -57,6 +57,18 @@ These remain real possibilities, but they should land only when the harness earn
 - more opinionated website and distribution surfaces
 - durable metrics backends beyond local YAML when a real consumer exists
 
+### Dogfood-surfaced (2026-07)
+
+Concrete friction from real use (two live requirements; see
+[field-evidence-dogfood-2026-07](../code/paper/field-evidence-dogfood-2026-07.md)):
+
+- **`iq issue publish --plan` should validate labels** against the target repo and, when a
+  label is missing, print the `gh label create …` command to create it. Currently the check
+  fails late at `--apply`.
+- **`requisitions/` lifecycle.** The per-requirement artifact directory accumulates over time
+  and will become noise; it needs an archival/rollup answer (and the artifacts are currently
+  vulnerable when uncommitted). Open design question, not yet a decision.
+
 ## Anti-goals for 0.7.x
 
 - carrying historical planning files as if they were still live doctrine


### PR DESCRIPTION
## Qué

Insumo para el paper + dos items de roadmap surgidos del **dogfood real** de esta jornada (impulsa + socia).

- **`code/paper/field-evidence-dogfood-2026-07.md`** — registro de evidencia de campo (brazo complementario al estudio controlado con qwen): la metodología conduciendo a un **modelo capaz (Claude)** de punta a punta en dos requerimientos reales. Documenta las conclusiones refinadas:
  - la **especificación es un gate de *definedness* separado a propósito**; ANALYZE/PLAN/EXECUTE **son TDD aplicado** para problemas complejos (no "el FSM estorba").
  - el **modelo de 3 capas** (spec/issues/tests) y la **columna vertebral** requisición→AC→issue→test aguantaron con fan-out **cross-repo y cross-org**.
  - **evidence-over-inference** pre-emptó fallos abductivos incluso con un modelo fuerte (color-no-corregido, pinpoint-antes-de-editar, breaking-change-por-grep).
- **`docs/roadmap.md`** — subsección "Dogfood-surfaced (2026-07)": validación de labels en `iq issue publish --plan` (+ mostrar el `gh label create`), y el ciclo de vida de `requisitions/` (acumulación).
- Se **trackean** los dos borradores de experimentos del paper que estaban untracked (memory-as-code).

Solo documentación/paper — sin cambios de código, gate ni template.