### PR TITLE
fix(upgrade): never hang or fail on post-install host deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ curl -fsSL https://inquiry.ccisne.dev/install.sh | bash
 
 # Setup
 iq doctor               # verify prerequisites
-iq host get             # deploy agent + skills to OpenCode (or: --host claude)
+iq host get             # deploy agent + skills to every host detected (or: --host claude)
 cd your-repo
 iq init                 # scaffold .inquiry/ workspace
 iq                      # show current state
@@ -101,7 +101,7 @@ For the current system model, see [`docs/architecture.md`](docs/architecture.md)
 - **Skills:** operational protocols such as `issue-create`, `inquiry-start`, `inquiry-end`, `doc-read`, `doc-write`, `inquiry-install`, plus direct-use skills such as `research`, `legion`, and `kritik`. The per-phase skills that drive a cycle by hand now ship with [MACSS](https://github.com/ccisnedev/macss) as `macss-analyze` / `macss-plan` / `macss-execute`; they delegate the mechanics back to `iq fsm state` and `iq fsm transition`, so this CLI stays the authority on the gates
 - **Memory:** `.inquiry/` (runtime state) and `cleanrooms/` (per-cycle artifacts the CLI scaffolds from single-source templates)
 - **Book:** Markdown-first manuscript and editorial pipeline under [`code/book/`](code/book)
-- **Host:** OpenCode (default) and Claude — `iq host get` deploys the agent + skills globally and additively
+- **Host:** OpenCode and Claude — `iq host get` deploys the agent + skills globally and additively, to the hosts actually present on the machine
 
 ## Documentation
 

--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.23.0]
+
+### Fixed
+- **`iq upgrade` could hang forever after the install already succeeded (#300).**
+  Post-install ran `iq host get` with no argument, which defaulted to `opencode`
+  and assumed it — even on a machine that only has Claude, or neither. That
+  pulled in the OpenCode/Ollama configurator, whose `ollama create` blocks
+  indefinitely when the daemon is not running. Two nested `Process.run` calls
+  buffered the output, so nothing was printed and a stalled step was
+  indistinguishable from a crash.
+
+  An upgrade now never fails or blocks on deployment: the binary and assets are
+  already in place by then, so a post-install failure is reported and swallowed,
+  and the step is bounded by a timeout.
+
+### Changed — BREAKING
+- **`iq host get` deploys to the hosts actually present**, detected by their own
+  config directory, instead of defaulting to `opencode`. With no host installed
+  it deploys nothing and says so — a machine may carry the CLI and no AI
+  assistant at all, which is a legitimate state and not a missing step.
+  `--host <host>` still installs into one whether or not it looks present, so a
+  fresh setup can be primed. `--host` no longer has a default.
+- **The Ollama model baking is opt-in**, behind `--configure-ollama`. Baking
+  `num_ctx` variants is an optimization, not part of installing a CLI, and it
+  must never sit on the critical path of an upgrade.
+- `iq doctor` reports a host that is **not installed** distinctly from one that
+  is installed but not deployed into. Only the second is a problem. This is
+  where host state belongs — read when you ask for it, not enforced inside an
+  unrelated command.
+
 ## [0.22.0]
 
 Inquiry goes back to being one thing: the state machine that drives an already

--- a/code/cli/lib/hosts/deployer.dart
+++ b/code/cli/lib/hosts/deployer.dart
@@ -36,6 +36,16 @@ class HostDeployer {
     if (selected.deploysAgent) _deployAgent(selected);
   }
 
+  /// The deploy targets actually present on this machine.
+  ///
+  /// A host counts as installed when its own config directory exists — the same
+  /// signal the host tool itself creates on first run. Deploying to a host the
+  /// user does not have writes a tree nothing will ever read, and asking a
+  /// third-party tool whether it is installed is what made `iq upgrade` hang
+  /// (#300).
+  List<HostAdapter> get detectedHosts =>
+      adapters.where((a) => a.exists(homeDir)).toList(growable: false);
+
   /// Removes all deployed files from **all** adapter directories.
   void clean() {
     for (final adapter in adapters) {

--- a/code/cli/lib/hosts/linux_platform_ops.dart
+++ b/code/cli/lib/hosts/linux_platform_ops.dart
@@ -3,6 +3,7 @@
 /// Uses tar for archive extraction and shell environment for variables.
 library;
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -70,10 +71,18 @@ class LinuxPlatformOps implements PlatformOps {
 
   @override
   Future<void> runPostInstall(String installDir) async {
-    await Process.run(p.join(installDir, 'bin', binaryName), [
+    // Bounded: `host get` only touches the filesystem now, but it runs the
+    // freshly written binary and its output is buffered rather than streamed,
+    // so an unbounded wait here is indistinguishable from a crash (#300).
+    await Process.run(p.join(installDir, 'bin', binaryName), const [
       'host',
       'get',
-    ]);
+    ]).timeout(
+      postInstallTimeout,
+      onTimeout: () => throw TimeoutException(
+        'host get did not finish within ${postInstallTimeout.inSeconds}s',
+      ),
+    );
   }
 
   @override

--- a/code/cli/lib/hosts/platform_ops.dart
+++ b/code/cli/lib/hosts/platform_ops.dart
@@ -40,6 +40,9 @@ abstract class PlatformOps {
   Future<void> selfReplace(String newBinaryPath, String currentBinaryPath);
 
   /// Run post-install steps (e.g. `iq host get`) using the correct binary.
+  ///
+  /// Implementations must be bounded by [postInstallTimeout]: this runs after
+  /// the upgrade has already succeeded, so it may fail but must never block.
   Future<void> runPostInstall(String installDir);
 
   /// Schedule deletion of a directory after the current process exits.
@@ -57,3 +60,9 @@ abstract class PlatformOps {
     );
   }
 }
+
+/// How long post-install deployment may take before it is abandoned.
+///
+/// Generous enough for a cold filesystem, short enough that a stalled step
+/// reports rather than hanging the terminal (#300).
+const postInstallTimeout = Duration(seconds: 60);

--- a/code/cli/lib/hosts/windows_platform_ops.dart
+++ b/code/cli/lib/hosts/windows_platform_ops.dart
@@ -3,6 +3,7 @@
 /// Uses PowerShell for archive extraction and environment variable management.
 library;
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -82,10 +83,18 @@ class WindowsPlatformOps implements PlatformOps {
 
   @override
   Future<void> runPostInstall(String installDir) async {
-    await Process.run(p.join(installDir, 'bin', binaryName), [
+    // Bounded: `host get` only touches the filesystem now, but it runs the
+    // freshly written binary and its output is buffered rather than streamed,
+    // so an unbounded wait here is indistinguishable from a crash (#300).
+    await Process.run(p.join(installDir, 'bin', binaryName), const [
       'host',
       'get',
-    ]);
+    ]).timeout(
+      postInstallTimeout,
+      onTimeout: () => throw TimeoutException(
+        'host get did not finish within ${postInstallTimeout.inSeconds}s',
+      ),
+    );
   }
 
   @override

--- a/code/cli/lib/modules/global/commands/doctor.dart
+++ b/code/cli/lib/modules/global/commands/doctor.dart
@@ -64,6 +64,13 @@ class HostCheck {
   /// inactive host is not a failure (it was simply not the chosen host).
   final bool active;
 
+  /// Whether the host tool itself is present on this machine.
+  ///
+  /// `iq host get` only deploys to hosts that are installed, so "not installed"
+  /// is the reason an absent deployment is fine — and reporting it here is what
+  /// makes that legible instead of looking like a missing step (#300).
+  final bool installed;
+
   HostCheck({
     required this.hostName,
     required this.agentExists,
@@ -71,11 +78,15 @@ class HostCheck {
     required this.totalSkills,
     this.error,
     this.active = true,
+    this.installed = true,
   });
 
-  /// An inactive host never fails the doctor; an active host must be complete.
+  /// A host that is not installed, or not the active one, never fails the
+  /// doctor. An active, installed host must be complete.
   bool get passed =>
-      !active || (agentExists && missingSkills.isEmpty && error == null);
+      !installed ||
+      !active ||
+      (agentExists && missingSkills.isEmpty && error == null);
 
   Map<String, dynamic> toJson() => {
     'hostName': hostName,
@@ -83,6 +94,7 @@ class HostCheck {
     'missingSkills': missingSkills,
     'totalSkills': totalSkills,
     'active': active,
+    'installed': installed,
     if (error != null) 'error': error,
   };
 }
@@ -156,6 +168,10 @@ class DoctorOutput extends Output {
       for (final tc in hostChecks) {
         if (tc.error != null) {
           buffer.writeln('  ✗ ${tc.hostName}: ${tc.error}');
+        } else if (!tc.installed) {
+          // The host tool is not on this machine. Nothing to deploy into, and
+          // nothing wrong: a machine may carry the CLI and no AI assistant.
+          buffer.writeln('  - ${tc.hostName}: not installed');
         } else if (!tc.active) {
           // Not the active host — informational, not a failure.
           buffer.writeln('  - ${tc.hostName}: not deployed (inactive)');
@@ -187,11 +203,11 @@ class DoctorOutput extends Output {
           }
         }
       }
-      if (!hostChecks.any((hc) => hc.active)) {
+      if (!hostChecks.any((hc) => hc.installed)) {
+        buffer.writeln('  - no AI coding host installed on this machine');
+      } else if (!hostChecks.any((hc) => hc.active)) {
         buffer.writeln('  ✗ no host deployed');
-        buffer.writeln(
-          "    → Run 'inquiry host get --host <opencode|claude>'",
-        );
+        buffer.writeln("    → Run 'iq host get'");
       }
     }
 
@@ -448,6 +464,7 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
   HostCheck _verifyHost(HostAdapter adapter) {
     final homeDir = _fileSystem.homeDirectory();
     final expectedSkills = _getExpectedSkills();
+    final installed = _fileSystem.directoryExists(adapter.baseDirectory(homeDir));
 
     // Agent + skills are installed GLOBALLY per host by `iq host get` (#280).
     final agentExists = _fileSystem.fileExists(
@@ -480,6 +497,7 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
       missingSkills: missingSkills,
       totalSkills: expectedSkills.length,
       active: active,
+      installed: installed,
     );
   }
 

--- a/code/cli/lib/modules/global/commands/upgrade.dart
+++ b/code/cli/lib/modules/global/commands/upgrade.dart
@@ -201,9 +201,19 @@ class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
 
       tempDir.deleteSync(recursive: true);
 
-      // 5. Redeploy hosts using the new binary
+      // 5. Redeploy hosts using the new binary.
+      //
+      // The binary and assets are already in place, so the upgrade has
+      // succeeded by this point. Redeploying reaches into third-party tools'
+      // directories and can fail or stall for reasons that have nothing to do
+      // with the upgrade — so it is reported and swallowed, never fatal (#300).
       stderr.writeln('Deploying hosts...');
-      await platformOps.runPostInstall(installDir);
+      try {
+        await platformOps.runPostInstall(installDir);
+      } catch (e) {
+        stderr.writeln('Host deployment skipped: $e');
+        stderr.writeln('Run `iq host get` to retry, or `iq doctor` to inspect.');
+      }
       stderr.writeln('Upgrade completed successfully.');
 
       return UpgradeOutput(

--- a/code/cli/lib/modules/host/commands/get.dart
+++ b/code/cli/lib/modules/host/commands/get.dart
@@ -1,8 +1,17 @@
-/// `iq host get` — installs the Inquiry agent + skills GLOBALLY for a host.
+/// `iq host get [--host <host>] [--configure-ollama]` — installs the Inquiry
+/// agent + skills GLOBALLY for a host.
 ///
 /// Additive (#280): other hosts are left untouched, so one machine can serve
 /// OpenCode + Claude at once. Global host dirs are isolated → no duplication.
 /// `iq init` (repo-scoped) only sets up the cleanroom workspace.
+///
+/// With no `--host`, every deploy target **detected on this machine** is
+/// installed. With `--host`, that one is installed whether or not it looks
+/// present, so a fresh setup can be primed before the tool first runs.
+///
+/// This used to default to `opencode` and assume it (#300), which deployed to a
+/// host the user might not have and dragged the OpenCode/Ollama configurator
+/// into every `iq upgrade`.
 library;
 
 import 'package:cli_router/cli_router.dart';
@@ -14,19 +23,34 @@ import '../../../hosts/opencode_ollama_configurator.dart';
 // ─── Input ──────────────────────────────────────────────────────────────────
 
 class HostGetInput extends Input {
-  final String host;
+  /// `null` → every detected host.
+  final String? host;
 
-  HostGetInput({this.host = 'opencode'});
+  /// Bake `num_ctx` variants of the configured Ollama models (OpenCode only).
+  ///
+  /// Opt-in: it shells out to `ollama create`, which is slow and blocks when the
+  /// daemon is not running. That is an optimization, not part of installing a
+  /// CLI.
+  final bool configureOllama;
 
-  factory HostGetInput.fromCliRequest(CliRequest req) =>
-      HostGetInput(host: req.flagString('host') ?? 'opencode');
+  HostGetInput({this.host, this.configureOllama = false});
+
+  factory HostGetInput.fromCliRequest(CliRequest req) => HostGetInput(
+        host: req.flagString('host'),
+        configureOllama: req.flagBool('configure-ollama'),
+      );
 
   static final List<CliParam> params = [
     CliParam.string(
       'host',
-      defaultValue: 'opencode',
       allowed: ['opencode', 'claude'],
-      description: 'AI coding host to install the agent + skills into',
+      description:
+          'AI coding host to install into; defaults to every one detected',
+    ),
+    CliParam.boolean(
+      'configure-ollama',
+      description:
+          'OpenCode only: bake num_ctx variants of the configured Ollama models',
     ),
   ];
 
@@ -34,7 +58,8 @@ class HostGetInput extends Input {
   List<CliParam> get schemaFields => params;
 
   @override
-  Map<String, dynamic> toJson() => {'host': host};
+  Map<String, dynamic> toJson() =>
+      {'host': host, 'configureOllama': configureOllama};
 }
 
 // ─── Output ─────────────────────────────────────────────────────────────────
@@ -42,13 +67,21 @@ class HostGetInput extends Input {
 class HostGetOutput extends Output {
   final String message;
 
-  HostGetOutput({required this.message});
+  /// The hosts actually installed into. Empty is a valid outcome: a machine may
+  /// carry the CLI and no AI assistant at all.
+  final List<String> hosts;
+
+  HostGetOutput({required this.message, this.hosts = const []});
 
   @override
-  Map<String, dynamic> toJson() => {'message': message};
+  Map<String, dynamic> toJson() => {'message': message, 'hosts': hosts};
 
+  /// Deploying to nothing is not a failure — see [hosts].
   @override
   int get exitCode => ExitCode.ok;
+
+  @override
+  String? toText() => message;
 }
 
 // ─── Command ────────────────────────────────────────────────────────────────
@@ -66,6 +99,7 @@ class HostGetCommand implements Command<HostGetInput, HostGetOutput> {
 
   @override
   String? validate() {
+    if (input.host == null) return null;
     final validNames = deployer.adapters.map((a) => a.name).toSet();
     if (!validNames.contains(input.host)) {
       return 'Unknown host: "${input.host}". '
@@ -76,11 +110,28 @@ class HostGetCommand implements Command<HostGetInput, HostGetOutput> {
 
   @override
   Future<HostGetOutput> execute() async {
-    deployer.deploy(input.host);
-    final lines = ['Inquiry agent + skills deployed (global) to host ${input.host}'];
-    if (input.host == 'opencode' && configurator != null) {
-      lines.addAll(await configurator!.configure());
+    final targets = input.host != null
+        ? [input.host!]
+        : deployer.detectedHosts.map((a) => a.name).toList();
+
+    if (targets.isEmpty) {
+      return HostGetOutput(
+        message: 'No AI coding host found on this machine — nothing deployed.\n'
+            'Supported: ${deployer.adapters.map((a) => a.name).join(', ')}.\n'
+            'Pass --host <host> to install into one anyway.',
+      );
     }
-    return HostGetOutput(message: lines.join('\n'));
+
+    final lines = <String>[];
+    for (final host in targets) {
+      deployer.deploy(host);
+      lines.add('Inquiry agent + skills deployed (global) to host $host');
+
+      if (host == 'opencode' && input.configureOllama && configurator != null) {
+        lines.addAll(await configurator!.configure());
+      }
+    }
+
+    return HostGetOutput(message: lines.join('\n'), hosts: targets);
   }
 }

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.22.0';
+const String inquiryVersion = '0.23.0';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.22.0
+version: 0.23.0
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/cli_contract_test.dart
+++ b/code/cli/test/cli_contract_test.dart
@@ -96,17 +96,23 @@ void main() {
         containsAll(<String>['complete_analysis', 'approve_plan']),
       );
 
-      // And a declared default reaches it too.
+      // Param kinds reach it too, so a caller can tell a flag from an option.
       final hostGet = commands.firstWhere((c) => c['route'] == 'host get');
       final hostParams =
           (hostGet['params'] as List).cast<Map<String, dynamic>>();
       expect(
+        hostParams.firstWhere((p) => p['name'] == 'configure-ollama')['kind'],
+        'flag',
+      );
+      // `--host` deliberately carries no default: defaulting to one made
+      // `iq host get` deploy to a host the user might not have (#300).
+      expect(
         hostParams.firstWhere((p) => p['name'] == 'host')['default'],
-        'opencode',
+        isNull,
       );
 
-      // Positional parameters are no longer exercised here: inquiry has none
-      // left. That coverage moved to macss with `specification new <slug>`.
+      // Defaults and positionals are no longer exercised here: no inquiry
+      // command declares either. That coverage lives in macss.
     });
   });
 }

--- a/code/cli/test/doctor_test.dart
+++ b/code/cli/test/doctor_test.dart
@@ -115,6 +115,9 @@ void main() {
     MockFileSystemOps allPassFs(String wd, String home, List<String> skills) {
       final fs = MockFileSystemOps()..setHome(home);
       fs.setDirectoryExists('.inquiry', true);
+      // The host tool itself is present: `iq host get` only deploys where the
+      // host exists, so a deployed fixture implies an installed one (#300).
+      fs.setDirectoryExists(p.join(home, '.config', 'opencode'), true);
       fs.setFileExists(
         p.join(home, '.config', 'opencode', 'agent', 'inquiry.md'),
         true,
@@ -375,28 +378,47 @@ void main() {
         final text = output.toText()!;
         expect(text, contains('Checking hosts...'));
         expect(text, contains('✓ opencode: agent + ${deployedSkills.length} skills deployed'));
-        expect(text, contains('- claude: not deployed (inactive)'));
+        expect(text, contains('- claude: not installed'));
         expect(text, contains('All checks passed.'));
       });
 
-      test('Scenario B: nothing deployed → exit 1', () async {
+      test('Scenario B1: host installed but nothing deployed → exit 1',
+          () async {
         final fs = MockFileSystemOps()..setHome(homeDir);
         fs.setDirectoryExists('.inquiry', true);
-        // Agent and skills do NOT exist
+        // OpenCode is on the machine; inquiry was never deployed into it.
+        fs.setDirectoryExists(p.join(homeDir, '.config', 'opencode'), true);
 
         final cmd = makeCmd(fs: fs);
         final output = await cmd.execute();
 
         expect(output.passed, isFalse);
         expect(output.exitCode, 1);
-        // No host has skills → none active.
         expect(output.hostChecks.every((h) => !h.active), isTrue);
 
         final text = output.toText()!;
         expect(text, contains('✗ no host deployed'));
-        expect(text,
-            contains("Run 'inquiry host get --host <opencode|claude>'"));
+        expect(text, contains("Run 'iq host get'"));
         expect(text, contains('Some checks failed.'));
+      });
+
+      test('Scenario B2: no host installed → not a failure', () async {
+        // A machine may carry the CLI and no AI assistant at all. Nothing to
+        // deploy into is a legitimate state, not a missing step (#300).
+        final fs = MockFileSystemOps()..setHome(homeDir);
+        fs.setDirectoryExists('.inquiry', true);
+
+        final cmd = makeCmd(fs: fs);
+        final output = await cmd.execute();
+
+        expect(output.hostChecks.every((h) => !h.installed), isTrue);
+        expect(output.hostChecks.every((h) => h.passed), isTrue);
+
+        final text = output.toText()!;
+        expect(text, contains('- opencode: not installed'));
+        expect(text, contains('- claude: not installed'));
+        expect(text, contains('no AI coding host installed on this machine'));
+        expect(text, isNot(contains('✗ no host deployed')));
       });
 
       test('Scenario C: no .inquiry/ directory → exit 1', () async {
@@ -418,13 +440,15 @@ void main() {
         final text = output.toText()!;
         expect(text, contains('✗ inquiry init'));
         expect(text, contains("Run 'inquiry init' to initialize"));
-        // Nothing deployed → no active host.
-        expect(text, contains('✗ no host deployed'));
+        // The hosts are simply absent from this machine, which is not what
+        // this scenario is about.
+        expect(text, contains('no AI coding host installed on this machine'));
       });
 
       test('Scenario D: partial deployment → exit 1', () async {
         final fs = MockFileSystemOps()..setHome(homeDir);
         fs.setDirectoryExists('.inquiry', true);
+        fs.setDirectoryExists(p.join(homeDir, '.config', 'opencode'), true);
         // OpenCode global agent present
         fs.setFileExists(
           p.join(homeDir, '.config', 'opencode', 'agent', 'inquiry.md'),
@@ -546,20 +570,25 @@ void main() {
       test('doctor remediation suggests host get when no host is deployed', () async {
         final fs = MockFileSystemOps()..setHome(homeDir);
         fs.setDirectoryExists('.inquiry', true);
-        // No agent, no skills → no active host
+        // A host exists to deploy into; no agent, no skills → no active host.
+        fs.setDirectoryExists(p.join(homeDir, '.claude'), true);
 
         final cmd = makeCmd(fs: fs);
         final output = await cmd.execute();
         final text = output.toText()!;
 
         expect(text, contains('✗ no host deployed'));
-        expect(text, contains('inquiry host get --host'));
+        expect(text, contains("Run 'iq host get'"));
         expect(text, isNot(contains("'inquiry target get'")));
       });
 
       test('Scenario E: OpenCode active (global), Claude inactive → exit 0', () async {
         final fs = MockFileSystemOps()..setHome(homeDir);
         fs.setDirectoryExists('.inquiry', true);
+        // Both hosts are on the machine; only OpenCode was deployed into. This
+        // is what distinguishes "inactive" from "not installed" (#300).
+        fs.setDirectoryExists(p.join(homeDir, '.config', 'opencode'), true);
+        fs.setDirectoryExists(p.join(homeDir, '.claude'), true);
         // OpenCode installed globally: agent + skills (#280).
         fs.setFileExists(
           p.join(homeDir, '.config', 'opencode', 'agent', 'inquiry.md'),

--- a/code/cli/test/host_commands_test.dart
+++ b/code/cli/test/host_commands_test.dart
@@ -82,8 +82,73 @@ void main() {
       );
     });
 
-    test('HostGetInput defaults host to opencode (#280)', () {
-      expect(HostGetInput().host, equals('opencode'));
+    test('HostGetInput defaults to no host, meaning every detected one (#300)',
+        () {
+      // Defaulting to opencode deployed into a host the user might not have,
+      // and dragged the OpenCode/Ollama configurator into every `iq upgrade`.
+      expect(HostGetInput().host, isNull);
+      expect(HostGetInput().configureOllama, isFalse);
+    });
+
+    group('host detection (#300)', () {
+      /// The host tool is present when its own config directory exists — the
+      /// directory the tool itself creates on first run.
+      void installFakeHost() =>
+          Directory(p.join(homeDir.path, '.fake')).createSync(recursive: true);
+
+      test('no host installed → nothing deployed, and that is not a failure',
+          () async {
+        final out = await HostGetCommand(
+          HostGetInput(),
+          deployer: deployer,
+        ).execute();
+
+        expect(out.exitCode, ExitCode.ok);
+        expect(out.hosts, isEmpty);
+        expect(out.message, contains('No AI coding host found'));
+        expect(out.message, contains('--host'));
+        expect(
+          Directory(p.join(homeDir.path, '.fake', 'skills')).existsSync(),
+          isFalse,
+        );
+      });
+
+      test('a detected host is deployed into without being named', () async {
+        installFakeHost();
+
+        final out = await HostGetCommand(
+          HostGetInput(),
+          deployer: deployer,
+        ).execute();
+
+        expect(out.hosts, ['fake']);
+        expect(
+          File(p.join(homeDir.path, '.fake', 'skills', 'doc-read', 'SKILL.md'))
+              .existsSync(),
+          isTrue,
+        );
+      });
+
+      test('--host deploys even when the host looks absent', () async {
+        // Priming a machine before the host tool has ever run.
+        final out = await HostGetCommand(
+          HostGetInput(host: 'fake'),
+          deployer: deployer,
+        ).execute();
+
+        expect(out.hosts, ['fake']);
+        expect(
+          File(p.join(homeDir.path, '.fake', 'skills', 'doc-read', 'SKILL.md'))
+              .existsSync(),
+          isTrue,
+        );
+      });
+
+      test('detectedHosts reports only what exists on disk', () {
+        expect(deployer.detectedHosts, isEmpty);
+        installFakeHost();
+        expect(deployer.detectedHosts.map((a) => a.name), ['fake']);
+      });
     });
 
     test('validate() returns error for unknown host', () {

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.22.0</span>
+      <span class="badge">v0.23.0</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">
@@ -111,7 +111,7 @@
         <li class="cmd"><code>iq</code><span class="desc">Print ASCII banner + version</span></li>
         <li class="cmd"><code>iq init</code><span class="desc">Scaffold repo-scoped Inquiry files (<code>.inquiry/config.yaml</code>, ignore rules, agent)</span></li>
         <li class="cmd"><code>iq doctor</code><span class="desc">Verify prerequisites</span></li>
-        <li class="cmd"><code>iq host get</code><span class="desc">Deploy skills to the active AI host</span></li>
+        <li class="cmd"><code>iq host get</code><span class="desc">Deploy skills to every AI host detected</span></li>
         <li class="cmd"><code>iq fsm transition</code><span class="desc">Execute a deterministic FSM transition</span></li>
         <li class="cmd"><code>iq fsm state</code><span class="desc">Show current FSM state as JSON</span></li>
         <li class="cmd"><code>iq ape prompt</code><span class="desc">Assemble sub-agent prompt from state</span></li>


### PR DESCRIPTION
Closes #300.

## The chain

```
iq upgrade
  → binary + assets applied            ← upgrade has already succeeded here
  → runPostInstall(installDir)
      → Process.run(inquiry.exe, ['host','get'])   ← no --host ⇒ default: opencode
          → OpenCodeOllamaConfigurator
              → await run('ollama', ['create', ...])   ← blocks with no timeout
```

Three problems compounded: `upgrade` chose the host for the user, an optional
optimization sat on the critical path, and two nested `Process.run` calls
buffered the output so a stalled step printed nothing. The result was an upgrade
that looked crashed while its install had already completed.

## Three changes, one per link

**`host get` deploys to the hosts actually present**, detected by their own
config directory — the one the tool itself creates on first run. With none
installed it deploys nothing and says so:

```
❯ iq host get
No AI coding host found on this machine — nothing deployed.
Supported: opencode, claude.
Pass --host <host> to install into one anyway.
```

A machine may carry the CLI and no AI assistant. That is a legitimate state, not
a missing step. `--host` still forces one regardless of detection, so a fresh
setup can be primed before the tool first runs.

**The Ollama model baking moves behind `--configure-ollama`.** Baking `num_ctx`
variants is an optimization, not part of installing a CLI, and must never sit on
the critical path of an upgrade.

**Post-install is bounded and non-fatal.** A timeout caps it, and failures are
reported and swallowed — the binary and assets are in place before it runs, so
the upgrade has already succeeded. A third-party tool's directory failing is not
the upgrade's failure.

## `iq doctor` is where host state belongs

It now distinguishes a host that is **not installed** from one installed but
**not deployed into**. Only the second is a problem:

```
Checking hosts...              Checking hosts...
  - opencode: not installed      - opencode: not installed
  - claude: not deployed (inactive)   - claude: not installed
  ✗ no host deployed             - no AI coding host installed on this machine
    → Run 'iq host get'
```

## BREAKING

`iq host get --host` no longer defaults to `opencode`. Scripts relying on a bare
`iq host get` meaning "deploy to opencode" must pass `--host opencode`.

## Tests

`dart analyze --fatal-infos` clean, **498 tests** green.

`doctor_test` Scenario B conflated "no host installed" with "host installed but
inquiry not deployed into it" — it is split into B1 (a failure) and B2 (not a
failure), which is exactly the distinction this fix introduces. Scenario E now
marks both hosts installed, since it is specifically about the *inactive* case.

`cli_contract_test` loses its default-value assertion: with `--host`'s default
removed, no inquiry command declares one. Recorded in the test, alongside the
same note about positionals from #299.

## Verified against a compiled binary

- No host: `host get` writes zero files and exits 0.
- `~/.claude` present: deploys the agent plus `kritik`, `legion`, `research`.
- `doctor` renders `not installed` and `not deployed (inactive)` distinctly.