### PR TITLE
fix(upgrade): report what the host deployment actually did

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.23.1]
+
+### Fixed
+- **`iq upgrade` said "Deploying hosts..." and nothing else.** The post-install
+  child's output was captured and discarded, so deploying to two hosts, to one,
+  or to none all printed the same thing — and a failure printed only the
+  exception. The step now echoes what it actually did, reports a non-zero exit
+  with the child's own message, and always ends by stating the CLI is upgraded
+  and how to retry. It still never blocks and never fails the upgrade.
+
 ## [0.23.0]
 
 ### Fixed

--- a/code/cli/lib/hosts/linux_platform_ops.dart
+++ b/code/cli/lib/hosts/linux_platform_ops.dart
@@ -70,11 +70,11 @@ class LinuxPlatformOps implements PlatformOps {
   }
 
   @override
-  Future<void> runPostInstall(String installDir) async {
+  Future<ProcessResult> runPostInstall(String installDir) async {
     // Bounded: `host get` only touches the filesystem now, but it runs the
     // freshly written binary and its output is buffered rather than streamed,
     // so an unbounded wait here is indistinguishable from a crash (#300).
-    await Process.run(p.join(installDir, 'bin', binaryName), const [
+    return Process.run(p.join(installDir, 'bin', binaryName), const [
       'host',
       'get',
     ]).timeout(

--- a/code/cli/lib/hosts/platform_ops.dart
+++ b/code/cli/lib/hosts/platform_ops.dart
@@ -6,7 +6,8 @@
 /// Path manipulation is NOT part of this abstraction — use `package:path`.
 library;
 
-import 'dart:io' show Platform;
+import 'dart:io';
+
 
 import 'linux_platform_ops.dart';
 import 'windows_platform_ops.dart';
@@ -41,9 +42,13 @@ abstract class PlatformOps {
 
   /// Run post-install steps (e.g. `iq host get`) using the correct binary.
   ///
+  /// Returns the child's result so the caller can report what was deployed —
+  /// a step whose output is swallowed is indistinguishable from one that did
+  /// nothing (#300).
+  ///
   /// Implementations must be bounded by [postInstallTimeout]: this runs after
   /// the upgrade has already succeeded, so it may fail but must never block.
-  Future<void> runPostInstall(String installDir);
+  Future<ProcessResult> runPostInstall(String installDir);
 
   /// Schedule deletion of a directory after the current process exits.
   ///

--- a/code/cli/lib/hosts/windows_platform_ops.dart
+++ b/code/cli/lib/hosts/windows_platform_ops.dart
@@ -82,11 +82,11 @@ class WindowsPlatformOps implements PlatformOps {
   }
 
   @override
-  Future<void> runPostInstall(String installDir) async {
+  Future<ProcessResult> runPostInstall(String installDir) async {
     // Bounded: `host get` only touches the filesystem now, but it runs the
     // freshly written binary and its output is buffered rather than streamed,
     // so an unbounded wait here is indistinguishable from a crash (#300).
-    await Process.run(p.join(installDir, 'bin', binaryName), const [
+    return Process.run(p.join(installDir, 'bin', binaryName), const [
       'host',
       'get',
     ]).timeout(

--- a/code/cli/lib/modules/global/commands/upgrade.dart
+++ b/code/cli/lib/modules/global/commands/upgrade.dart
@@ -206,13 +206,29 @@ class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
       // The binary and assets are already in place, so the upgrade has
       // succeeded by this point. Redeploying reaches into third-party tools'
       // directories and can fail or stall for reasons that have nothing to do
-      // with the upgrade — so it is reported and swallowed, never fatal (#300).
+      // with the upgrade — so it stops and reports, never blocks and never
+      // takes the upgrade down with it (#300).
       stderr.writeln('Deploying hosts...');
       try {
-        await platformOps.runPostInstall(installDir);
+        final result = await platformOps.runPostInstall(installDir);
+        // Echo what the child actually did. Swallowing it made a deploy to
+        // nothing look identical to a deploy to everything.
+        for (final line in postInstallOutputLines(result)) {
+          stderr.writeln('  $line');
+        }
+        if (result.exitCode != 0) {
+          stderr.writeln('Host deployment failed (exit ${result.exitCode}).');
+          stderr.writeln(
+            'The CLI is upgraded. Run `iq host get` to retry, '
+            'or `iq doctor` to inspect.',
+          );
+        }
       } catch (e) {
-        stderr.writeln('Host deployment skipped: $e');
-        stderr.writeln('Run `iq host get` to retry, or `iq doctor` to inspect.');
+        stderr.writeln('Host deployment stopped: $e');
+        stderr.writeln(
+          'The CLI is upgraded. Run `iq host get` to retry, '
+          'or `iq doctor` to inspect.',
+        );
       }
       stderr.writeln('Upgrade completed successfully.');
 
@@ -227,3 +243,19 @@ class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
     }
   }
 }
+
+/// The child's combined output, trimmed and split — stdout first, then stderr.
+///
+/// `Process.run` buffers both; printing them is what lets a user see which
+/// hosts were deployed to, or that none were. Blank lines are dropped so the
+/// echoed block stays tight under `Deploying hosts...`.
+///
+/// Visible for testing.
+List<String> postInstallOutputLines(ProcessResult result) => [
+      '${result.stdout}',
+      '${result.stderr}',
+    ]
+        .expand((s) => s.split('\n'))
+        .map((l) => l.trimRight())
+        .where((l) => l.isNotEmpty)
+        .toList(growable: false);

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.23.0';
+const String inquiryVersion = '0.23.1';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.23.0
+version: 0.23.1
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/platform_ops_test.dart
+++ b/code/cli/test/platform_ops_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:test/test.dart';
 
 import 'package:inquiry_cli/hosts/platform_ops.dart';
@@ -47,9 +49,15 @@ class FakePlatformOps implements PlatformOps {
     calls.add('selfReplace($newBinaryPath, $currentBinaryPath)');
   }
 
+  /// What the fake child reports back. `upgrade` echoes this, so a test can
+  /// assert the user is shown which hosts were deployed to.
+  ProcessResult postInstallResult =
+      ProcessResult(0, 0, 'Inquiry agent + skills deployed to host claude', '');
+
   @override
-  Future<void> runPostInstall(String installDir) async {
+  Future<ProcessResult> runPostInstall(String installDir) async {
     calls.add('runPostInstall($installDir)');
+    return postInstallResult;
   }
 
   @override
@@ -106,9 +114,12 @@ void main() {
       expect(fake.calls, contains('selfReplace(/new/ape, /old/ape)'));
     });
 
-    test('runPostInstall completes without error', () async {
-      await fake.runPostInstall('/opt/ape');
+    test('runPostInstall completes and returns the child result', () async {
+      final result = await fake.runPostInstall('/opt/ape');
       expect(fake.calls, contains('runPostInstall(/opt/ape)'));
+      // The caller needs the result to report what was deployed (#300).
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('deployed'));
     });
 
     test('scheduleDeletion records call', () {

--- a/code/cli/test/upgrade_test.dart
+++ b/code/cli/test/upgrade_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:test/test.dart';
 
 import 'package:inquiry_cli/modules/global/commands/upgrade.dart';
@@ -55,6 +57,50 @@ void main() {
         upgraded: false,
       );
       expect(output.toText(), equals('Already on the latest version'));
+    });
+  });
+
+  // `Deploying hosts...` used to be the last thing a user saw: the child's
+  // output was captured and thrown away, so deploying to two hosts, to one, or
+  // to none all looked identical (#300).
+  group('post-install output is echoed', () {
+    const nl = '\n';
+
+    test('reports what the child actually deployed', () {
+      final lines = postInstallOutputLines(
+        ProcessResult(
+          0,
+          0,
+          'deployed to host claude${nl}deployed to host opencode$nl',
+          '',
+        ),
+      );
+
+      expect(lines, ['deployed to host claude', 'deployed to host opencode']);
+    });
+
+    test('carries stderr too, so a failure explains itself', () {
+      final lines = postInstallOutputLines(
+        ProcessResult(0, 1, '', 'Unknown host: "vscode"'),
+      );
+
+      expect(lines, ['Unknown host: "vscode"']);
+    });
+
+    test('drops blank lines rather than echoing empty rows', () {
+      final lines = postInstallOutputLines(
+        ProcessResult(0, 0, '$nl${nl}first$nl$nl', nl),
+      );
+
+      expect(lines, ['first']);
+    });
+
+    test('a deploy to nothing is visible, not silent', () {
+      final lines = postInstallOutputLines(
+        ProcessResult(0, 0, 'No AI coding host found on this machine', ''),
+      );
+
+      expect(lines, ['No AI coding host found on this machine']);
     });
   });
 }

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.23.0</span>
+      <span class="badge">v0.23.1</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
Follow-up to #301, which stopped `iq upgrade` from hanging. It still did not
say what it was doing.

## The gap

```
Deploying hosts...
Upgrade completed successfully.
```

That is the entire output whether it deployed to two hosts, to one, or to none.
`Process.run` buffers the child's stdout and stderr, and the result was
discarded — so the command that knows what happened had no way to say it. A
failure printed only the exception, with no word from the command that failed.

## The change

`runPostInstall` returns the child's `ProcessResult`; `upgrade` echoes it.

```
Deploying hosts...
  Inquiry agent + skills deployed (global) to host claude
Upgrade completed successfully.
```

With nothing installed, the reason is now visible instead of implied:

```
Deploying hosts...
  No AI coding host found on this machine — nothing deployed.
  Supported: opencode, claude.
  Pass --host <host> to install into one anyway.
Upgrade completed successfully.
```

And a failure explains itself with the child's own message, then says plainly
that the CLI is upgraded and how to retry — because by then it is: the binary
and assets are in place before deployment runs.

```
Deploying hosts...
  Unknown host: "vscode"
Host deployment failed (exit 7).
The CLI is upgraded. Run `iq host get` to retry, or `iq doctor` to inspect.
Upgrade completed successfully.
```

Unchanged from #301: it is still bounded by a timeout, so it cannot block, and
a deployment problem never fails the upgrade.

## Tests

`dart analyze --fatal-infos` clean, **502 tests** green.

`postInstallOutputLines` is exposed for testing — it is the piece that makes the
echoed block legible, and it had no coverage. Four cases: multi-host output,
stderr on failure, blank-line trimming, and the deploy-to-nothing message being
visible rather than silent.

`FakePlatformOps` gains a configurable `postInstallResult`, so a test can assert
what the user is shown.