### PR TITLE
fix(host): retire deployed skills the CLI no longer ships

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.24.0]
+
+### Fixed
+- **Deployment could add but never retire.** A skill dropped from a release
+  survived forever in the host as a frozen copy nothing would ever update —
+  which is what left `iq-analyze`, `iq-plan`, `iq-execute` and
+  `iq-specification` behind when the lifecycle moved to MACSS in 0.22.0. Users
+  upgrading saw those alongside the `macss-*` ones, with no way to tell which
+  was live. `iq host get` now removes them.
+
+  Scoped by prefix rather than a hand-maintained list of retirements: the `iq-`
+  namespace is Inquiry's, so anything under it that Inquiry does not ship is
+  Inquiry's to remove. Skills outside it — `kritik`, `legion`, `research`, and
+  anything you wrote — are never touched.
+
 ## [0.23.1]
 
 ### Fixed

--- a/code/cli/lib/hosts/deployer.dart
+++ b/code/cli/lib/hosts/deployer.dart
@@ -6,6 +6,13 @@ import '../assets.dart';
 import 'agent_builder.dart';
 import 'host_adapter.dart';
 
+/// The prefix Inquiry's own skills carry in a host's skills directory.
+///
+/// It marks what Inquiry owns and may therefore retire. Skills without it —
+/// `kritik`, `legion`, `research`, and anything the user wrote — belong to
+/// someone else.
+const inquirySkillNamespace = 'iq-';
+
 /// Orchestrates deploying skills to host tool directories.
 class HostDeployer {
   final Assets assets;
@@ -23,8 +30,10 @@ class HostDeployer {
   /// (e.g. OpenCode + Claude) at once. Global host dirs are isolated, so there
   /// is no cross-host duplication (#280).
   ///
+  /// Returns the names of the skills it retired, so the caller can report them.
+  ///
   /// Throws [ArgumentError] if [hostName] is not in [adapters].
-  void deploy(String hostName) {
+  List<String> deploy(String hostName) {
     final validNames = adapters.map((a) => a.name).toSet();
     if (!validNames.contains(hostName)) {
       throw ArgumentError(
@@ -33,7 +42,9 @@ class HostDeployer {
     }
     final selected = adapters.firstWhere((a) => a.name == hostName);
     _deploySkills(selected);
+    final retired = _pruneRetiredSkills(selected);
     if (selected.deploysAgent) _deployAgent(selected);
+    return retired;
   }
 
   /// The deploy targets actually present on this machine.
@@ -68,6 +79,37 @@ class HostDeployer {
       hostFile.parent.createSync(recursive: true);
       hostFile.writeAsStringSync(content);
     }
+  }
+
+  /// Removes deployed skills that belong to Inquiry's namespace but are no
+  /// longer shipped.
+  ///
+  /// Deployment could add but never retire, so a skill dropped from a release
+  /// survived forever as a frozen copy nothing would update again — the
+  /// `iq-analyze` / `iq-plan` / `iq-execute` / `iq-specification` left behind
+  /// when the lifecycle moved to MACSS (#299). Users then saw both those and
+  /// the `macss-*` ones, with no way to tell which was live.
+  ///
+  /// Scoped by prefix rather than a hand-maintained list of retirements: the
+  /// `iq-` namespace is Inquiry's, so anything under it that Inquiry does not
+  /// ship is Inquiry's to remove. Skills outside the namespace — `kritik`,
+  /// `legion`, `research`, and anything a user wrote — are never touched.
+  List<String> _pruneRetiredSkills(HostAdapter adapter) {
+    final hostSkillsDir = Directory(adapter.skillsDirectory(homeDir));
+    if (!hostSkillsDir.existsSync()) return const [];
+
+    final shipped = assets.listDirectory('skills').toSet();
+    final retired = <String>[];
+
+    for (final entry in hostSkillsDir.listSync().whereType<Directory>()) {
+      final name = p.basename(entry.path);
+      if (!name.startsWith(inquirySkillNamespace)) continue;
+      if (shipped.contains(name)) continue;
+      entry.deleteSync(recursive: true);
+      retired.add(name);
+    }
+
+    return retired..sort();
   }
 
   /// Deploys the inquiry agent to the host's agent dir as `inquiry.md`,

--- a/code/cli/lib/modules/host/commands/get.dart
+++ b/code/cli/lib/modules/host/commands/get.dart
@@ -124,8 +124,11 @@ class HostGetCommand implements Command<HostGetInput, HostGetOutput> {
 
     final lines = <String>[];
     for (final host in targets) {
-      deployer.deploy(host);
+      final retired = deployer.deploy(host);
       lines.add('Inquiry agent + skills deployed (global) to host $host');
+      for (final skill in retired) {
+        lines.add('  removed  $skill (no longer shipped)');
+      }
 
       if (host == 'opencode' && input.configureOllama && configurator != null) {
         lines.addAll(await configurator!.configure());

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.23.1';
+const String inquiryVersion = '0.24.0';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.23.1
+version: 0.24.0
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/host_commands_test.dart
+++ b/code/cli/test/host_commands_test.dart
@@ -151,6 +151,79 @@ void main() {
       });
     });
 
+    group('retiring skills the CLI no longer ships', () {
+      /// Writes a skill directly into the host, as an older release would have.
+      void seedDeployed(String name) {
+        final f = File(
+          p.join(homeDir.path, '.fake', 'skills', name, 'SKILL.md'),
+        );
+        f.createSync(recursive: true);
+        f.writeAsStringSync('# frozen copy from an older release');
+      }
+
+      bool deployed(String name) => Directory(
+            p.join(homeDir.path, '.fake', 'skills', name),
+          ).existsSync();
+
+      test('removes namespaced skills that are no longer shipped', () async {
+        // Exactly the state a user upgrading from before the lifecycle moved
+        // to MACSS was left in: frozen copies nothing would update again.
+        for (final name in const [
+          'iq-analyze',
+          'iq-plan',
+          'iq-execute',
+          'iq-specification',
+        ]) {
+          seedDeployed(name);
+        }
+
+        final out = await HostGetCommand(
+          HostGetInput(host: 'fake'),
+          deployer: deployer,
+        ).execute();
+
+        expect(deployed('iq-analyze'), isFalse);
+        expect(deployed('iq-specification'), isFalse);
+        expect(out.message, contains('removed  iq-analyze (no longer shipped)'));
+      });
+
+      test('never touches skills outside the namespace', () async {
+        // Inquiry's own direct-use skills, and anything a user wrote.
+        seedDeployed('kritik');
+        seedDeployed('legion');
+        seedDeployed('my-own-skill');
+        seedDeployed('iq-analyze');
+
+        await HostGetCommand(
+          HostGetInput(host: 'fake'),
+          deployer: deployer,
+        ).execute();
+
+        expect(deployed('kritik'), isTrue);
+        expect(deployed('legion'), isTrue);
+        expect(deployed('my-own-skill'), isTrue);
+        expect(deployed('iq-analyze'), isFalse);
+      });
+
+      test('keeps a namespaced skill that is still shipped', () {
+        // Guards the rule: the prefix marks ownership, not obsolescence.
+        final shipped = Directory(
+          p.join(tempDir.path, 'assets', 'skills', 'iq-still-here'),
+        )..createSync(recursive: true);
+        File(p.join(shipped.path, 'SKILL.md')).writeAsStringSync('# live');
+
+        seedDeployed('iq-still-here');
+        final retired = deployer.deploy('fake');
+
+        expect(retired, isEmpty);
+        expect(deployed('iq-still-here'), isTrue);
+      });
+
+      test('reports nothing when there is nothing to retire', () {
+        expect(deployer.deploy('fake'), isEmpty);
+      });
+    });
+
     test('validate() returns error for unknown host', () {
       final command = HostGetCommand(
         HostGetInput(host: 'vscode'),

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.23.1</span>
+      <span class="badge">v0.24.0</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
> Stacked on #302. Merge that first — the base of this PR is its branch.

## The defect

Deployment could **add** but never **remove**. A skill dropped from a release
survived in the host forever as a frozen copy nothing would ever update again.

That is not hypothetical. When the lifecycle moved to MACSS in 0.22.0, this is
what an upgraded machine was left with:

```
~/.claude/skills/
  iq-analyze  iq-execute  iq-plan  iq-specification   ← frozen, never updated again
  kritik  legion  research                            ← live
  macss-analyze  macss-plan  ...                      ← live, from the other CLI
```

Eight skills, four of them dead, no way to tell which. The only fix was deleting
them by hand.

## The change

`iq host get` now removes skills in Inquiry's namespace that Inquiry no longer
ships:

```
❯ iq host get
Inquiry agent + skills deployed (global) to host claude
  removed  iq-analyze (no longer shipped)
  removed  iq-execute (no longer shipped)
  removed  iq-plan (no longer shipped)
  removed  iq-specification (no longer shipped)
```

**Scoped by prefix, not by a list of retirements.** The `iq-` namespace is
Inquiry's, so anything under it that Inquiry does not ship is Inquiry's to
remove. That makes it self-maintaining: a skill renamed or dropped in any future
release is cleaned without anyone remembering to add it to a list.

**Nothing outside the namespace is touched** — `kritik`, `legion`, `research`,
anything the user wrote, and another tool's `macss-*` skills. The last one is
the property that matters most and it is verified against the real observed
state:

| before | after |
|---|---|
| `iq-analyze`, `iq-execute`, `iq-plan`, `iq-specification` | *removed* |
| `kritik`, `legion`, `research` | untouched |
| `macss-analyze`, `macss-plan` | untouched |

`deploy()` returns what it retired so `host get` reports it, rather than files
disappearing silently.

## Tests

`dart analyze --fatal-infos` clean, **506 tests** green.

Four new cases: the real upgrade state is cleaned; skills outside the namespace
survive; a namespaced skill that *is* still shipped is kept — the prefix marks
ownership, not obsolescence; and nothing is reported when there is nothing to
retire.