### PR TITLE
fix(upgrade): survive a locked leftover backup on Windows

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.24.1]
+
+### Fixed
+- **A leftover `inquiry.exe.bak` could block every future upgrade on Windows.**
+  `selfReplace` renames the running exe out of the way, and it deleted any
+  previous backup **unguarded**. Windows refuses to remove the image of a
+  running process, so a backup left behind by an upgrade whose child process
+  outlived it stayed locked — and every later upgrade aborted with
+  `PathAccessException: Cannot delete file ... inquiry.exe.bak`, an error naming
+  a temp file rather than the cause.
+
+  The code had anticipated the leftover — the second cleanup was already
+  best-effort, with a comment saying it would be handled "on next upgrade" —
+  but the next upgrade removed it without a guard.
+
+  A locked leftover is now stepped over: numbered candidates are tried until
+  one is free. If none can be, the error says what is actually wrong and how to
+  check it.
+
 ## [0.24.0]
 
 ### Fixed

--- a/code/cli/lib/hosts/windows_platform_ops.dart
+++ b/code/cli/lib/hosts/windows_platform_ops.dart
@@ -61,11 +61,7 @@ class WindowsPlatformOps implements PlatformOps {
     String newBinaryPath,
     String currentBinaryPath,
   ) async {
-    final bakPath = '$currentBinaryPath.bak';
-    final bakFile = File(bakPath);
-
-    // Clean up leftover .bak from a previous upgrade
-    if (bakFile.existsSync()) bakFile.deleteSync();
+    final bakPath = freeBackupPath(currentBinaryPath);
 
     // Rename the running exe — Windows allows renaming a locked file
     File(currentBinaryPath).renameSync(bakPath);
@@ -75,11 +71,12 @@ class WindowsPlatformOps implements PlatformOps {
 
     // Best-effort cleanup
     try {
-      if (bakFile.existsSync()) bakFile.deleteSync();
+      File(bakPath).deleteSync();
     } on FileSystemException {
-      // Still locked — will be cleaned up on next upgrade
+      // Still locked — swept on a later upgrade.
     }
   }
+
 
   @override
   Future<ProcessResult> runPostInstall(String installDir) async {
@@ -124,4 +121,39 @@ class WindowsPlatformOps implements PlatformOps {
       mode: ProcessStartMode.detached,
     );
   }
+}
+
+/// A backup path the rename can use, sweeping what it can along the way.
+///
+/// `<exe>.bak` may exist *and* be undeletable: Windows refuses to remove the
+/// image of a running process, so a backup left by an upgrade whose child
+/// outlived it stays locked indefinitely. Deleting it unguarded aborted the
+/// entire upgrade — with an error naming a temp file rather than the cause,
+/// and no way forward short of finding the stray process by hand.
+///
+/// A locked leftover is now stepped over rather than fatal: numbered
+/// candidates are tried until one is free. Failing that, the error says what
+/// is actually wrong.
+String freeBackupPath(String currentBinaryPath) {
+  for (var i = 0; i < 20; i++) {
+    final path = '$currentBinaryPath.bak${i == 0 ? '' : i}';
+    // `File.existsSync` is false for a directory at the same path, which would
+    // report an occupied name as free and then fail the rename instead.
+    if (FileSystemEntity.typeSync(path) == FileSystemEntityType.notFound) {
+      return path;
+    }
+    try {
+      File(path).deleteSync();
+      return path;
+    } on FileSystemException {
+      // Locked by a live process — try the next name.
+    }
+  }
+
+  throw FileSystemException(
+    'Could not free a backup path for the running binary. An inquiry '
+    "process is probably still running: check with 'Get-Process inquiry', "
+    'stop it, and retry the upgrade',
+    currentBinaryPath,
+  );
 }

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.24.0';
+const String inquiryVersion = '0.24.1';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.24.0
+version: 0.24.1
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/windows_backup_path_test.dart
+++ b/code/cli/test/windows_backup_path_test.dart
@@ -1,0 +1,78 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:inquiry_cli/hosts/windows_platform_ops.dart';
+
+/// `selfReplace` renames the running exe out of the way before copying the new
+/// one in. Choosing that name used to assume any leftover `<exe>.bak` could be
+/// deleted — and when a stray `inquiry.exe host get` process still held it,
+/// the whole upgrade aborted with an error naming a temp file rather than the
+/// cause.
+void main() {
+  late Directory tempDir;
+  late String exePath;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('iq_bak_test_');
+    exePath = p.join(tempDir.path, 'inquiry.exe');
+    File(exePath).writeAsStringSync('binary');
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  group('freeBackupPath', () {
+    test('uses .bak when nothing is in the way', () {
+      expect(freeBackupPath(exePath), '$exePath.bak');
+    });
+
+    test('reclaims a leftover .bak that can be deleted', () {
+      File('$exePath.bak').writeAsStringSync('previous binary');
+
+      expect(freeBackupPath(exePath), '$exePath.bak');
+      expect(File('$exePath.bak').existsSync(), isFalse);
+    });
+
+    test(
+      'steps over a locked .bak instead of failing the upgrade',
+      () {
+        // A locked file is only reproducible on Windows: elsewhere an open
+        // handle does not prevent deletion, which is exactly why this defect
+        // was invisible until it ran on a real Windows machine.
+        final bak = File('$exePath.bak')..writeAsStringSync('locked binary');
+        final handle = bak.openSync(mode: FileMode.write);
+        addTearDown(() {
+          handle.closeSync();
+          if (bak.existsSync()) bak.deleteSync();
+        });
+
+        expect(freeBackupPath(exePath), '$exePath.bak1');
+        // The locked one is left alone rather than half-removed.
+        expect(bak.existsSync(), isTrue);
+      },
+      skip: Platform.isWindows ? false : 'file locking is Windows-only',
+    );
+
+    test('the error names the real cause when nothing can be freed', () {
+      // Simulated by exhausting every candidate with undeletable entries:
+      // a directory cannot be removed by File.deleteSync on any platform.
+      for (var i = 0; i < 20; i++) {
+        Directory('$exePath.bak${i == 0 ? '' : i}').createSync();
+      }
+
+      expect(
+        () => freeBackupPath(exePath),
+        throwsA(
+          isA<FileSystemException>().having(
+            (e) => e.message,
+            'message',
+            allOf(contains('still running'), contains('Get-Process inquiry')),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.24.0</span>
+      <span class="badge">v0.24.1</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
Reported in the field:

```
❯ iq upgrade
Applying update in: C:\Users\...\AppData\Local\inquiry
Upgrade failed during apply step: PathAccessException: Cannot delete file,
  path = '...\inquiry\bin\inquiry.exe.bak' (OS Error: Access is denied, errno = 5)
```

Every upgrade failed from then on, with an error naming a temp file rather than
the cause.

## Cause

`selfReplace` renames the running exe out of the way before copying the new one
in. Choosing that name deleted any previous `.bak` **unguarded**:

```dart
// Clean up leftover .bak from a previous upgrade
if (bakFile.existsSync()) bakFile.deleteSync();   // ← throws if locked
```

Windows refuses to remove the image of a running process. A backup left behind
by an upgrade whose child process outlived it stays locked indefinitely.

**The code had anticipated this.** Ten lines further down, the second cleanup
was already best-effort, with a comment saying the leftover would be handled
*"on next upgrade"* — and the next upgrade removed it without a guard.

### How the lock got there

The orphan was the post-install child from #300: an `inquiry.exe host get`
blocked on `ollama create`, which survived the `Ctrl+C` that killed its parent
and was still running hours later.

```
ProcessId   : 19728
CommandLine : ...\inquiry\bin\inquiry.exe host get
CreationDate: 2026-08-01 11:30:20 AM
```

#301 stopped that hang from happening again. This PR stops its residue from
poisoning every subsequent upgrade.

## The change

A locked leftover is stepped over instead of being fatal — numbered candidates
are tried until one is free. When none can be, the error says what is actually
wrong:

```
Could not free a backup path for the running binary. An inquiry process is
probably still running: check with 'Get-Process inquiry', stop it, and retry
the upgrade
```

## A second hole, found by writing the test

`File.existsSync` is **false** for a directory at the same path — so an occupied
name was reported free, and the rename would have failed instead. Freedom is now
decided by `FileSystemEntity.typeSync`.

## Tests

`dart analyze --fatal-infos` clean, **510 tests** green.

Four new cases: the clean path; a deletable leftover is reclaimed; a **locked**
leftover is stepped over; and the exhausted case names the real cause.

The locked case is only reproducible on Windows — elsewhere an open handle does
not prevent deletion, which is exactly why this stayed invisible until it ran on
a real machine. It is skipped off Windows and exercised by CI's `windows-latest`
job.