### PR TITLE
Ask before changing what the CLI does not own

### DIFF
--- a/.macss/.gitignore
+++ b/.macss/.gitignore
@@ -1,0 +1,6 @@
+# MACSS — this workspace ignores itself.
+# Everything here is machine-written and reproducible, except what is named
+# below: those are decisions a human made, and they travel with the repository.
+*
+!.gitignore
+!config.yaml

--- a/.macss/config.yaml
+++ b/.macss/config.yaml
@@ -1,0 +1,3 @@
+# MACSS — this project's configuration. Versioned: the answer travels
+# with the repository rather than living on one machine.
+language: en

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
+and the project adheres to [Semantic Versioning](https://semver.org/).
+
+This file records delivery history at the **project** level: what changed for
+the people who use the system, not every commit. Architectural decisions and
+their rationale belong in `docs/adr/`.
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed

--- a/README.md
+++ b/README.md
@@ -80,11 +80,12 @@ irm https://inquiry.ccisne.dev/install.ps1 | iex
 curl -fsSL https://inquiry.ccisne.dev/install.sh | bash
 
 # Setup
-iq doctor               # verify prerequisites
-iq host get             # deploy agent + skills to every host detected (or: --host claude)
+iq doctor                # verify prerequisites
+iq host get --plan       # what deploying would change — nothing is touched
+iq host get --apply      # show it, ask for approval, then do it (or: --host claude)
 cd your-repo
-iq init                 # scaffold .inquiry/ workspace
-iq                      # show current state
+iq init                  # scaffold .inquiry/ workspace
+iq                       # show current state
 
 # Run a phase by hand (no scheduler agent): use the MACSS lifecycle skills
 #   /macss-analyze   /macss-plan   /macss-execute
@@ -101,7 +102,7 @@ For the current system model, see [`docs/architecture.md`](docs/architecture.md)
 - **Skills:** operational protocols such as `issue-create`, `inquiry-start`, `inquiry-end`, `doc-read`, `doc-write`, `inquiry-install`, plus direct-use skills such as `research`, `legion`, and `kritik`. The per-phase skills that drive a cycle by hand now ship with [MACSS](https://github.com/ccisnedev/macss) as `macss-analyze` / `macss-plan` / `macss-execute`; they delegate the mechanics back to `iq fsm state` and `iq fsm transition`, so this CLI stays the authority on the gates
 - **Memory:** `.inquiry/` (runtime state) and `cleanrooms/` (per-cycle artifacts the CLI scaffolds from single-source templates)
 - **Book:** Markdown-first manuscript and editorial pipeline under [`code/book/`](code/book)
-- **Host:** OpenCode and Claude — `iq host get` deploys the agent + skills globally and additively, to the hosts actually present on the machine
+- **Host:** OpenCode and Claude — `iq host get` deploys the agent + skills globally and additively, to the hosts actually present on the machine. It writes into those tools' own directories, so like `upgrade`, `uninstall`, `host clean` and `implementation start` it says what it would do and takes approval first (`--plan` / `--apply`); every other route answers on the spot. See [ADR 0002](docs/adr/0002-a-query-may-write-what-the-cli-itself-owns.md)
 
 ## Documentation
 

--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,71 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.25.0]
+
+### Changed — BREAKING
+
+- **Five commands now refuse to act until you say `--plan` or `--apply`.**
+  `iq upgrade`, `iq uninstall`, `iq host get`, `iq host clean` and
+  `iq implementation start` install, remove, or write into your repository.
+  Each now shows what it would do and takes approval before doing it:
+
+  ```
+  iq host get --plan                 # say what would change; change nothing
+  iq host get --apply                # say it, ask for approval, then do it
+  iq host get --apply --autoapprove  # act without asking — agents and CI
+  ```
+
+  Neither mode is the default. A command that changes things does not decide
+  for you which one you wanted, so `iq host get` on its own is now a usage
+  error that names both options. **Every script, alias or agent instruction
+  that invokes one of these five must add a mode.** The installers, the
+  post-upgrade redeploy, `iq doctor`'s remediation hints, the branch-policy
+  error and `inquiry-start.md` were all updated.
+
+  Every other route is unchanged: `iq fsm transition`, `iq ape prompt`,
+  `iq init`, `iq doctor` and the rest answer on the spot and **reject** the two
+  flags. Which kind a route is, is now a fact about its registration rather
+  than a comment — see
+  [ADR 0002](../../docs/adr/0002-a-query-may-write-what-the-cli-itself-owns.md)
+  for where the line falls and why `iq fsm transition` stays a query despite
+  writing `.iq.state.yaml`.
+
+- **`iq host get --host opencode` no longer configures Ollama unless asked.**
+  Baking `num_ctx` variants shells out to `ollama create`, which is slow and
+  blocks when the daemon is not running — an optimization, not part of
+  installing a CLI. It moved behind `--configure-ollama`, where it is a named
+  step of its own in the plan. `iq doctor`'s remediation now suggests the flag.
+
+### Added
+
+- **A plan is a list of steps, each of which says what it would do.** Commands
+  are built on [`preview_executor`](https://pub.dev/packages/preview_executor)
+  through `modular_cli_sdk` 0.4: a command declares an ordered list of steps,
+  and under `--apply` the executor previews each one again immediately before
+  running it and compares. What you approved and what ran are held together by
+  the engine rather than by everyone remembering. An upgrade that resolves the
+  releases API **once** — at plan time — can no longer download a release
+  published between the plan and the approval.
+
+- **Orderings that were comments are now assertable.** `iq uninstall` takes
+  PATH off *before* scheduling the installation for deletion, and cleans the
+  hosts *first*, while the assets they were deployed from are still there. That
+  was a paragraph; it is now a list a test reads.
+
+### Fixed
+
+- **`iq upgrade`'s redeploy would have reported failure on every upgrade.** The
+  post-install child runs the freshly written binary as `host get`, which is a
+  command now — without a mode it would exit with a usage error into a pipe
+  nobody reads. Both platforms now share one named argument list
+  (`postInstallArguments`), pinned by a test.
+
+- **The CLI README's command table was split in half** by an unrelated
+  benchmark section, leaving ten command rows orphaned below it and rendering
+  as loose pipes. Repaired, and it now lists `iq implementation start` and
+  marks which routes take `--plan`/`--apply`.
+
 ## [0.24.1]
 
 ### Fixed

--- a/code/cli/README.md
+++ b/code/cli/README.md
@@ -24,11 +24,40 @@ curl -fsSL https://inquiry.ccisne.dev/install.sh | bash
 
 ## Commands
 
+Most routes answer on the spot. Five change something outside the CLI's own
+files — they install, remove, or write into your repository — and those refuse
+to act until you say which of `--plan` and `--apply` you meant. They are marked
+below.
+
 | Command | Purpose |
 |---|---|
 | `iq` | TUI banner with current FSM state |
 | `iq init` | Scaffold `cleanrooms/` and repo-scoped `.inquiry/config.yaml` |
 | `iq doctor` | Verify prerequisites: `inquiry`, `git`, `gh`, `gh auth` |
+| `iq version` | Print CLI version |
+| `iq upgrade` | Download and install the latest release — `--plan`/`--apply` |
+| `iq uninstall` | Remove the `inquiry` binary and deployed assets — `--plan`/`--apply` |
+| `iq host get` | Deploy Inquiry skills to every detected AI host — `--plan`/`--apply` |
+| `iq host clean` | Remove deployed Inquiry skills from all known hosts — `--plan`/`--apply` |
+| `iq implementation start --issue <N>` | Open a cycle: branch, cleanroom, ANALYZE — `--plan`/`--apply` |
+| `iq fsm transition --event <e>` | Execute a deterministic FSM transition |
+| `iq fsm state [--json]` | Show current FSM state, transitions, and active APE |
+| `iq ape prompt --name <name>` | Assemble sub-agent prompt from YAML + current state |
+| `iq ape state` | Show active APE sub-state and valid transitions |
+| `iq ape transition --event <e>` | Advance the active APE's internal FSM |
+
+### `--plan` and `--apply`
+
+```bash
+iq host get --plan               # say what would change; change nothing
+iq host get --apply              # say it, ask for approval, then do it
+iq host get --apply --autoapprove  # act without asking — for agents and CI
+```
+
+Neither is the default: a command that changes things does not decide for you
+which one you wanted. See
+[ADR 0002](../../docs/adr/0002-a-query-may-write-what-the-cli-itself-owns.md)
+for where the line between the two kinds falls.
 
 ## H/F Full-Flow Benchmark (Gemma4)
 
@@ -44,13 +73,3 @@ The runner prepares a benchmark cleanroom, executes both modes against the same 
 - per-mode session and API duration
 - whether each state was reached (`IDLE`, `ANALYZE`, `PLAN`, `EXECUTE`, `END`)
 - exact-token compliance for the final run marker
-| `iq version` | Print CLI version |
-| `iq upgrade` | Download and install latest release |
-| `iq uninstall` | Remove `inquiry` binary and deployed assets |
-| `iq host get` | Deploy Inquiry skills to the active AI host |
-| `iq host clean` | Remove deployed Inquiry skills from all known hosts |
-| `iq fsm transition --event <e>` | Execute a deterministic FSM transition |
-| `iq fsm state [--json]` | Show current FSM state, transitions, and active APE |
-| `iq ape prompt --name <name>` | Assemble sub-agent prompt from YAML + current state |
-| `iq ape state` | Show active APE sub-state and valid transitions |
-| `iq ape transition --event <e>` | Advance the active APE's internal FSM |

--- a/code/cli/assets/instructions/inquiry-start.md
+++ b/code/cli/assets/instructions/inquiry-start.md
@@ -9,7 +9,7 @@ description: 'Protocol for starting work on an existing GitHub issue. Verifies t
 
 Run iq doctor first and stop on any failed check.
 Verify the issue already exists with gh issue view.
-Open the implementation with iq implementation start --issue NNN, which derives the NNN-slug branch, checks it out, scaffolds the cleanroom, and transitions to ANALYZE.
+Open the implementation with iq implementation start --issue NNN --apply --autoapprove, which derives the NNN-slug branch, checks it out, scaffolds the cleanroom, and transitions to ANALYZE.
 Confirm iq fsm state reports ANALYZE for that issue.
 
 ## When to Use
@@ -53,7 +53,7 @@ branch name — `iq implementation start` derives it from the issue itself.
 ### Step 3: Open the Cycle
 
 ```bash
-iq implementation start --issue <NNN>
+iq implementation start --issue <NNN> --apply --autoapprove
 ```
 
 This single command owns every mechanical step of the bootstrap — there is no
@@ -70,6 +70,14 @@ This single command owns every mechanical step of the bootstrap — there is no
 The command reports the branch, the cleanroom path, and the new state. Do NOT
 write `.inquiry` state directly — all state mutations go through `iq` commands.
 
+**Why `--apply --autoapprove`.** This command writes into the user's own
+repository — a branch and a cleanroom — so it will not act unless told which of
+`--plan` (say what would happen, change nothing) and `--apply` (say it, take
+approval, then do it) was meant. `--autoapprove` carries the approval, because
+the scheduler has no terminal to be asked on; Inquiry gates at state completion,
+not at every command. Run it with `--plan` alone first if you want to see the
+branch name it derived before anything is created.
+
 ### Step 4: Verify
 
 ```bash
@@ -83,7 +91,7 @@ Confirm the state is now ANALYZE with the correct issue number.
 After completing all steps, verify:
 
 - [ ] The issue already exists and `gh issue view <NNN> --json number,title,state` succeeds
-- [ ] `iq implementation start --issue <NNN>` reported ANALYZE
+- [ ] `iq implementation start --issue <NNN> --apply --autoapprove` reported ANALYZE
 - [ ] Branch exists: `git branch --show-current` returns `<NNN>-<slug>`
 - [ ] Directory exists: `cleanrooms/<NNN>-<slug>/analyze/`
 - [ ] State updated: `iq fsm state` shows ANALYZE with the issue number

--- a/code/cli/lib/hosts/linux_platform_ops.dart
+++ b/code/cli/lib/hosts/linux_platform_ops.dart
@@ -74,10 +74,10 @@ class LinuxPlatformOps implements PlatformOps {
     // Bounded: `host get` only touches the filesystem now, but it runs the
     // freshly written binary and its output is buffered rather than streamed,
     // so an unbounded wait here is indistinguishable from a crash (#300).
-    return Process.run(p.join(installDir, 'bin', binaryName), const [
-      'host',
-      'get',
-    ]).timeout(
+    return Process.run(
+      p.join(installDir, 'bin', binaryName),
+      postInstallArguments,
+    ).timeout(
       postInstallTimeout,
       onTimeout: () => throw TimeoutException(
         'host get did not finish within ${postInstallTimeout.inSeconds}s',

--- a/code/cli/lib/hosts/platform_ops.dart
+++ b/code/cli/lib/hosts/platform_ops.dart
@@ -40,7 +40,7 @@ abstract class PlatformOps {
   /// Handles OS-specific locking and permission issues.
   Future<void> selfReplace(String newBinaryPath, String currentBinaryPath);
 
-  /// Run post-install steps (e.g. `iq host get`) using the correct binary.
+  /// Run post-install steps ([postInstallArguments]) using the correct binary.
   ///
   /// Returns the child's result so the caller can report what was deployed —
   /// a step whose output is swallowed is indistinguishable from one that did
@@ -71,3 +71,16 @@ abstract class PlatformOps {
 /// Generous enough for a cold filesystem, short enough that a stalled step
 /// reports rather than hanging the terminal (#300).
 const postInstallTimeout = Duration(seconds: 60);
+
+/// What the freshly installed binary is asked to do after an upgrade.
+///
+/// `--apply --autoapprove` is not a shortcut past the gate — it is the gate,
+/// honored. The user already approved this upgrade, of which redeploying the
+/// hosts is a named step; there is no second decision to take, and no terminal
+/// to take it on. Without the flags the child would ask "--plan or --apply?"
+/// into a pipe nobody reads and exit non-zero, and every upgrade would report a
+/// failed redeploy.
+///
+/// Shared by both platforms so the two cannot drift, and named so a test can
+/// pin it.
+const postInstallArguments = ['host', 'get', '--apply', '--autoapprove'];

--- a/code/cli/lib/hosts/windows_platform_ops.dart
+++ b/code/cli/lib/hosts/windows_platform_ops.dart
@@ -83,10 +83,10 @@ class WindowsPlatformOps implements PlatformOps {
     // Bounded: `host get` only touches the filesystem now, but it runs the
     // freshly written binary and its output is buffered rather than streamed,
     // so an unbounded wait here is indistinguishable from a crash (#300).
-    return Process.run(p.join(installDir, 'bin', binaryName), const [
-      'host',
-      'get',
-    ]).timeout(
+    return Process.run(
+      p.join(installDir, 'bin', binaryName),
+      postInstallArguments,
+    ).timeout(
       postInstallTimeout,
       onTimeout: () => throw TimeoutException(
         'host get did not finish within ${postInstallTimeout.inSeconds}s',

--- a/code/cli/lib/modules/ape/ape_builder.dart
+++ b/code/cli/lib/modules/ape/ape_builder.dart
@@ -6,21 +6,21 @@ import 'commands/state.dart';
 import 'commands/transition.dart';
 
 void buildApeModule(ModuleBuilder m, {Assets? assets}) {
-  m.command<ApePromptInput, ApePromptOutput>(
+  m.query<ApePromptInput, ApePromptOutput>(
     'prompt',
     (req) => ApePromptCommand(ApePromptInput.fromCliRequest(req), assets: assets),
     description: 'Assemble a sub-agent prompt from YAML + current FSM state',
     params: ApePromptInput.params,
   );
 
-  m.command<ApeStateInput, ApeStateOutput>(
+  m.query<ApeStateInput, ApeStateOutput>(
     'state',
     (req) => ApeStateCommand(ApeStateInput.fromCliRequest(req), assets: assets),
     description: 'Show current APE sub-state and valid internal transitions',
     params: ApeStateInput.params,
   );
 
-  m.command<ApeTransitionInput, ApeTransitionOutput>(
+  m.query<ApeTransitionInput, ApeTransitionOutput>(
     'transition',
     (req) => ApeTransitionCommand(ApeTransitionInput.fromCliRequest(req), assets: assets),
     description: 'Execute an APE-internal transition',

--- a/code/cli/lib/modules/ape/commands/prompt.dart
+++ b/code/cli/lib/modules/ape/commands/prompt.dart
@@ -99,7 +99,7 @@ class ApePromptOutput extends Output {
 // ─── Command ────────────────────────────────────────────────────────────────
 
 /// Assembles a sub-agent prompt from its YAML definition + current FSM state.
-class ApePromptCommand implements Command<ApePromptInput, ApePromptOutput> {
+class ApePromptCommand implements Query<ApePromptInput, ApePromptOutput> {
   @override
   final ApePromptInput input;
   final Assets? _assets;

--- a/code/cli/lib/modules/ape/commands/state.dart
+++ b/code/cli/lib/modules/ape/commands/state.dart
@@ -84,7 +84,7 @@ class ApeStateOutput extends Output {
 
 // ─── Command ────────────────────────────────────────────────────────────────
 
-class ApeStateCommand implements Command<ApeStateInput, ApeStateOutput> {
+class ApeStateCommand implements Query<ApeStateInput, ApeStateOutput> {
   @override
   final ApeStateInput input;
   final Assets? _assets;

--- a/code/cli/lib/modules/ape/commands/transition.dart
+++ b/code/cli/lib/modules/ape/commands/transition.dart
@@ -77,7 +77,7 @@ class ApeTransitionOutput extends Output {
 
 // ─── Command ────────────────────────────────────────────────────────────────
 
-class ApeTransitionCommand implements Command<ApeTransitionInput, ApeTransitionOutput> {
+class ApeTransitionCommand implements Query<ApeTransitionInput, ApeTransitionOutput> {
   @override
   final ApeTransitionInput input;
   final Assets? _assets;

--- a/code/cli/lib/modules/fsm/commands/state.dart
+++ b/code/cli/lib/modules/fsm/commands/state.dart
@@ -104,7 +104,7 @@ class FsmStateOutput extends Output {
   String toJsonString() => const JsonEncoder.withIndent('  ').convert(toJson());
 }
 
-class FsmStateCommand implements Command<FsmStateInput, FsmStateOutput> {
+class FsmStateCommand implements Query<FsmStateInput, FsmStateOutput> {
   @override
   final FsmStateInput input;
   final Assets? _assets;

--- a/code/cli/lib/modules/fsm/commands/transition.dart
+++ b/code/cli/lib/modules/fsm/commands/transition.dart
@@ -261,7 +261,7 @@ class StateTransitionOutput extends Output {
 }
 
 class StateTransitionCommand
-    implements Command<StateTransitionInput, StateTransitionOutput> {
+    implements Query<StateTransitionInput, StateTransitionOutput> {
   @override
   final StateTransitionInput input;
   final BranchProvider branchProvider;
@@ -1277,7 +1277,14 @@ class StateTransitionCommand
         'Expected a branch named "<NNN>-<slug>" that starts with "$issueRef-" '
         '(e.g. "$issueRef-fix-login"). A branch under a prefix like '
         '"feat/$issueRef-…" does NOT qualify — the name must be a single segment.\n'
-        'Create it and enter ANALYZE in one step with: iq implementation start --issue $issueRef';
+        // `--apply --autoapprove`: this message is acted on by the scheduler,
+        // which has no terminal to be asked on. Inquiry gates at state
+        // completion, not at every command — an approval prompt here would
+        // stall the very agent the remediation is written for. A person typing
+        // it by hand can drop `--autoapprove` to be asked, or pass `--plan` to
+        // only look.
+        'Create it and enter ANALYZE in one step with: '
+        'iq implementation start --issue $issueRef --apply --autoapprove';
   }
 
   bool _isIssueLinkedFeatureBranch(String branch, String? issue) {

--- a/code/cli/lib/modules/fsm/fsm_builder.dart
+++ b/code/cli/lib/modules/fsm/fsm_builder.dart
@@ -5,14 +5,14 @@ import 'commands/state.dart';
 import 'commands/transition.dart';
 
 void buildFsmModule(ModuleBuilder m, {Assets? assets}) {
-  m.command<FsmStateInput, FsmStateOutput>(
+  m.query<FsmStateInput, FsmStateOutput>(
     'state',
     (req) => FsmStateCommand(FsmStateInput.fromCliRequest(req), assets: assets),
     description: 'Show current FSM state, valid transitions, and active APEs',
     params: FsmStateInput.params,
   );
 
-  m.command<StateTransitionInput, StateTransitionOutput>(
+  m.query<StateTransitionInput, StateTransitionOutput>(
     'transition',
     (req) => StateTransitionCommand(StateTransitionInput.fromCliRequest(req), assets: assets),
     description:

--- a/code/cli/lib/modules/global/commands/doctor.dart
+++ b/code/cli/lib/modules/global/commands/doctor.dart
@@ -184,7 +184,7 @@ class DoctorOutput extends Output {
           if (!tc.agentExists) {
             buffer.writeln('  ✗ ${tc.hostName}: agent not deployed');
             buffer.writeln(
-              "    → Run 'inquiry host get --host ${tc.hostName}' to install the agent",
+              "    → Run 'iq host get --host ${tc.hostName} --apply' to install the agent",
             );
           } else {
             buffer.writeln('  ✓ ${tc.hostName}: agent deployed');
@@ -197,7 +197,7 @@ class DoctorOutput extends Output {
             // Only suggest host get when agent is already deployed
             if (tc.agentExists) {
               buffer.writeln(
-                "    → Run 'inquiry host get --host ${tc.hostName}' to deploy skills",
+                "    → Run 'iq host get --host ${tc.hostName} --apply' to deploy skills",
               );
             }
           }
@@ -207,7 +207,7 @@ class DoctorOutput extends Output {
         buffer.writeln('  - no AI coding host installed on this machine');
       } else if (!hostChecks.any((hc) => hc.active)) {
         buffer.writeln('  ✗ no host deployed');
-        buffer.writeln("    → Run 'iq host get'");
+        buffer.writeln("    → Run 'iq host get --apply'");
       }
     }
 
@@ -251,7 +251,7 @@ class RealFileSystemOps implements FileSystemOps {
 }
 
 /// Command that verifies all prerequisites and host deployment.
-class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
+class DoctorCommand implements Query<DoctorInput, DoctorOutput> {
   @override
   final DoctorInput input;
 
@@ -440,7 +440,7 @@ class DoctorCommand implements Command<DoctorInput, DoctorOutput> {
           "harness fails silently. Bake a variant — Modelfile 'FROM <model>\\n"
           "PARAMETER num_ctx 16384' then 'ollama create <model>-16k -f Modelfile' "
           "(32768 recommended) — and point opencode.jsonc at it. "
-          "Or run 'iq host get --host opencode' to configure it.",
+          "Or run 'iq host get --host opencode --configure-ollama --apply' to configure it.",
     );
   }
 

--- a/code/cli/lib/modules/global/commands/init.dart
+++ b/code/cli/lib/modules/global/commands/init.dart
@@ -62,7 +62,7 @@ class InitOutput extends Output {
 // ─── Command ────────────────────────────────────────────────────────────────
 
 /// Sets up the repo workspace (cleanrooms + .inquiry). Idempotent.
-class InitCommand implements Command<InitInput, InitOutput> {
+class InitCommand implements Query<InitInput, InitOutput> {
   @override
   final InitInput input;
 

--- a/code/cli/lib/modules/global/commands/tui.dart
+++ b/code/cli/lib/modules/global/commands/tui.dart
@@ -53,7 +53,7 @@ class TuiOutput extends Output {
 // ─── Command ────────────────────────────────────────────────────────────────
 
 /// Command that displays the APE FSM diagram and version.
-class TuiCommand implements Command<TuiInput, TuiOutput> {
+class TuiCommand implements Query<TuiInput, TuiOutput> {
   @override
   final TuiInput input;
   final Future<VersionCheckResult> Function({required String currentVersion})?

--- a/code/cli/lib/modules/global/commands/uninstall.dart
+++ b/code/cli/lib/modules/global/commands/uninstall.dart
@@ -39,18 +39,123 @@ class UninstallInput extends Input {
   Map<String, dynamic> toJson() => {'installDir': installDir};
 }
 
+// ─── Steps ──────────────────────────────────────────────────────────────────
+
+/// Removes the agent and skills deployed into every host.
+class CleanDeployedHosts implements Step {
+  CleanDeployedHosts(this.deployer);
+
+  final HostDeployer deployer;
+
+  @override
+  Preview preview() => Preview(
+    verb: 'clean',
+    target: 'every host this machine deployed to',
+    detail: 'the Inquiry agent and its skills',
+  );
+
+  @override
+  Future<Outcome> perform(StepContext context) async {
+    deployer.clean();
+    return Outcome(verb: 'clean', target: 'every host this machine deployed to');
+  }
+}
+
+/// Removes the repository-scoped agent file, when one is there.
+class RemoveRepoScopedAgent implements Step {
+  RemoveRepoScopedAgent(this.path);
+
+  final String path;
+
+  bool get _exists => File(path).existsSync();
+
+  @override
+  Preview preview() => _exists
+      ? Preview(verb: 'remove', target: path)
+      : Preview(verb: 'absent', target: path);
+
+  @override
+  Future<Outcome> perform(StepContext context) async {
+    if (!_exists) return Outcome(verb: 'absent', target: path);
+    File(path).deleteSync();
+    return Outcome(verb: 'remove', target: path);
+  }
+}
+
+/// Takes the CLI's `bin/` off the user's PATH.
+class UnsetFromPath implements Step {
+  UnsetFromPath({required this.platformOps, required this.binDir});
+
+  final PlatformOps platformOps;
+  final String binDir;
+
+  String get _target => '$binDir from your PATH';
+
+  @override
+  Preview preview() => Preview(verb: 'unset', target: _target);
+
+  @override
+  Future<Outcome> perform(StepContext context) async {
+    final userPath = platformOps.getEnvVariable('PATH') ?? '';
+    final separator = Platform.isWindows ? ';' : ':';
+    final parts = userPath
+        .split(separator)
+        .where((part) => part.isNotEmpty)
+        .where((part) => !_pathEquals(part, binDir))
+        .toList();
+    final newPath = parts.join(separator);
+
+    if (newPath != userPath) {
+      platformOps.setEnvVariable('PATH', newPath);
+    }
+    return Outcome(verb: 'unset', target: _target);
+  }
+
+  bool _pathEquals(String a, String b) =>
+      p.normalize(a).toLowerCase() == p.normalize(b).toLowerCase();
+}
+
+/// Schedules the installation directory for deletion.
+///
+/// Scheduled rather than done: on Windows the running executable lives inside
+/// it and cannot delete itself.
+class DeleteInstallation implements Step {
+  DeleteInstallation({required this.platformOps, required this.installDir});
+
+  final PlatformOps platformOps;
+  final String installDir;
+
+  @override
+  Preview preview() => Preview(
+    verb: 'delete',
+    target: installDir,
+    detail: 'your repositories and their cleanrooms are not touched — this '
+        'removes the tool, not your work',
+  );
+
+  @override
+  Future<Outcome> perform(StepContext context) async {
+    await platformOps.scheduleDeletion(installDir);
+    return Outcome(verb: 'delete', target: installDir);
+  }
+}
+
 // ─── Output ─────────────────────────────────────────────────────────────────
 
 class UninstallOutput extends Output {
-  final String message;
+  UninstallOutput({required this.installDir});
 
-  UninstallOutput({required this.message});
+  final String installDir;
 
   @override
-  Map<String, dynamic> toJson() => {'message': message};
+  Map<String, dynamic> toJson() => {'installDir': installDir};
 
   @override
   int get exitCode => ExitCode.ok;
+
+  @override
+  String? toText() =>
+      'Inquiry uninstalled. Restart your terminal to apply PATH changes.';
 }
 
 // ─── Command ────────────────────────────────────────────────────────────────
@@ -73,46 +178,29 @@ class UninstallCommand implements Command<UninstallInput, UninstallOutput> {
   @override
   String? validate() => null;
 
+  /// Hosts, then the repository's agent, then PATH, then the directory.
+  ///
+  /// The order is not cosmetic. PATH is unset before the installation is
+  /// scheduled for deletion, so there is never a window in which the entry
+  /// points at a directory already on its way out. And the hosts are cleaned
+  /// first, while the assets they were deployed from are still there.
   @override
-  Future<UninstallOutput> execute() async {
-    // 1. Clean all hosts (adapter paths + old global agent paths)
-    deployer.clean();
-
-    // 2. Clean repo-scoped agent
-    _cleanRepoScopedAgent();
-
-    // 3. Remove ape\bin\ from user PATH (via PlatformOps)
-    _removeFromPath(p.join(input.installDir, 'bin'));
-
-    // 4. Spawn background process to delete install directory
-    await platformOps.scheduleDeletion(input.installDir);
-
-    return UninstallOutput(
-      message: 'Inquiry uninstalled. Restart your terminal to apply PATH changes.',
-    );
-  }
-
-  void _cleanRepoScopedAgent() {
-    final agentFile = File(
+  Future<List<Step>> steps() async => [
+    CleanDeployedHosts(deployer),
+    RemoveRepoScopedAgent(
       p.join(_workingDirectory, '.github', 'agents', 'inquiry.agent.md'),
-    );
-    if (agentFile.existsSync()) agentFile.deleteSync();
-  }
+    ),
+    UnsetFromPath(
+      platformOps: platformOps,
+      binDir: p.join(input.installDir, 'bin'),
+    ),
+    DeleteInstallation(
+      platformOps: platformOps,
+      installDir: input.installDir,
+    ),
+  ];
 
-  void _removeFromPath(String binDir) {
-    final userPath = platformOps.getEnvVariable('PATH') ?? '';
-    final parts = userPath
-        .split(Platform.isWindows ? ';' : ':')
-        .where((p) => p.isNotEmpty)
-        .where((p) => !_pathEquals(p, binDir))
-        .toList();
-    final newPath = parts.join(Platform.isWindows ? ';' : ':');
-
-    if (newPath != userPath) {
-      platformOps.setEnvVariable('PATH', newPath);
-    }
-  }
-
-  bool _pathEquals(String a, String b) =>
-      p.normalize(a).toLowerCase() == p.normalize(b).toLowerCase();
+  @override
+  UninstallOutput describe(Execution execution) =>
+      UninstallOutput(installDir: input.installDir);
 }

--- a/code/cli/lib/modules/global/commands/upgrade.dart
+++ b/code/cli/lib/modules/global/commands/upgrade.dart
@@ -1,7 +1,7 @@
 /// `inquiry upgrade` — downloads and installs the latest Inquiry release.
 ///
-/// Fetches the latest release from GitHub, downloads the zip,
-/// extracts it over the current installation, and redeploys hosts.
+/// Fetches the latest release from GitHub, downloads the zip, extracts it over
+/// the current installation, and redeploys hosts.
 library;
 
 import 'dart:convert';
@@ -28,10 +28,10 @@ class UpgradeInput extends Input {
     return UpgradeInput(installDir: installDir);
   }
 
-    /// Declares an EMPTY contract: this command accepts no option at all, so any
-  /// option passed to it is refused. Omitting `params` would mean "declares
-  /// nothing" — which is how `iq init --host claude` used to run, doing nothing
-  /// the flag implied.
+  /// Declares an EMPTY contract: this command accepts no option of its own, so
+  /// any option beyond `--plan` / `--apply` / `--autoapprove` is refused.
+  /// Omitting `params` would mean "declares nothing" — which is how
+  /// `iq init --host claude` used to run, doing nothing the flag implied.
   static const List<CliParam> params = [];
 
   @override
@@ -41,38 +41,222 @@ class UpgradeInput extends Input {
   Map<String, dynamic> toJson() => {'installDir': installDir};
 }
 
+// ─── Steps ──────────────────────────────────────────────────────────────────
+
+/// Fetches [url] into the file at [destination].
+///
+/// A function rather than an `HttpClient`, so the step that replaces the
+/// installation does not have to know how bytes arrive — and so a test can
+/// stand in for the network without faking an interface it never uses.
+typedef Downloader = Future<void> Function(String url, String destination);
+
+/// Downloads over HTTP, which is how it happens outside a test.
+Future<void> downloadOverHttp(String url, String destination) async {
+  final client = HttpClient();
+  try {
+    final request = await client.getUrl(Uri.parse(url));
+    request.headers.set('User-Agent', 'inquiry-cli/$inquiryVersion');
+    final response = await request.close();
+    await response.pipe(File(destination).openWrite());
+  } finally {
+    client.close();
+  }
+}
+
+/// Downloads a release and extracts it over the installation.
+///
+/// Everything this needs — which version, which asset, which URL — was settled
+/// when the step was built, from **one** call to the releases API. Asking again
+/// at perform time could answer differently: a release published in between
+/// would be downloaded without ever having been approved.
+///
+/// **It says what it is doing while it does it.** The plan states what *will*
+/// happen; this states that it *is* happening, which is a different thing and
+/// the only one that helps during a download of several megabytes. It goes to
+/// [progress] — stderr by default — so `--json` stays machine-readable.
+class ReplaceInstallation implements Step {
+  ReplaceInstallation({
+    required this.platformOps,
+    required this.installDir,
+    required this.from,
+    required this.to,
+    required this.asset,
+    required this.downloadUrl,
+    Downloader? download,
+    IOSink? progress,
+    String? runningExecutable,
+  }) : download = download ?? downloadOverHttp,
+       progress = progress ?? stderr,
+       runningExecutable = runningExecutable ?? Platform.resolvedExecutable;
+
+  final PlatformOps platformOps;
+  final Downloader download;
+  final String installDir;
+  final String from;
+  final String to;
+  final String asset;
+  final String downloadUrl;
+  final IOSink progress;
+
+  /// The binary this step is replacing, which on Windows has to be moved aside
+  /// before it can be overwritten.
+  ///
+  /// **Injected, and that is not optional.** `Platform.resolvedExecutable` is
+  /// the Inquiry binary only when a compiled binary is what runs. Under
+  /// `dart test` and `dart run` it is the Dart VM — so a test that reached the
+  /// default would rename the Dart SDK's own `dart.exe` and take the toolchain
+  /// down with it.
+  final String runningExecutable;
+
+  @override
+  Preview preview() => Preview(
+    verb: 'replace',
+    target: installDir,
+    detail: ['$from → $to', 'asset $asset', 'from $downloadUrl'].join('; '),
+  );
+
+  @override
+  Future<Outcome> perform(StepContext context) async {
+    final tempDir = Directory.systemTemp.createTempSync('inquiry_upgrade_');
+    try {
+      progress.writeln('Downloading $asset ($from → $to)...');
+      final zipFile = File(p.join(tempDir.path, asset));
+      await download(downloadUrl, zipFile.path);
+
+      if (Platform.isWindows) {
+        // Windows locks running executables, so the outgoing binary is moved
+        // aside before extraction and cleaned up afterwards — or on the next
+        // upgrade, if the file is still locked.
+        final bak = File('$runningExecutable.bak');
+        if (bak.existsSync()) bak.deleteSync();
+        File(runningExecutable).renameSync(bak.path);
+      }
+
+      progress.writeln('Extracting into $installDir...');
+      await platformOps.expandArchive(zipFile.path, installDir);
+
+      if (Platform.isWindows) {
+        try {
+          final bak = File('$runningExecutable.bak');
+          if (bak.existsSync()) bak.deleteSync();
+        } on FileSystemException {
+          // Still locked — cleaned up on the next upgrade.
+        }
+      }
+    } finally {
+      tempDir.deleteSync(recursive: true);
+    }
+
+    return Outcome(
+      verb: 'replace',
+      target: installDir,
+      values: {'from': from, 'to': to},
+    );
+  }
+}
+
+/// Redeploys the agent and skills into every host, using the new binary.
+///
+/// **Best effort, and that is deliberate (#300).** By the time this runs the
+/// binary and its assets are in place, so the upgrade has already succeeded.
+/// Redeploying reaches into third-party tools' directories and can fail or
+/// stall for reasons that have nothing to do with the upgrade — so this reports
+/// and never throws. A failure here must not take the upgrade down with it.
+class RedeployHosts implements Step {
+  RedeployHosts({
+    required this.platformOps,
+    required this.installDir,
+    IOSink? progress,
+  }) : progress = progress ?? stderr;
+
+  final PlatformOps platformOps;
+  final String installDir;
+  final IOSink progress;
+
+  @override
+  Preview preview() => Preview(
+    verb: 'deploy',
+    target: 'every host on this machine',
+    detail: 'best effort — the upgrade stands whether or not this succeeds',
+  );
+
+  @override
+  Future<Outcome> perform(StepContext context) async {
+    progress.writeln('Deploying hosts...');
+    try {
+      final result = await platformOps.runPostInstall(installDir);
+      // Echo what the child actually did. Swallowing it made a deploy to
+      // nothing look identical to a deploy to everything.
+      for (final line in postInstallOutputLines(result)) {
+        progress.writeln('  $line');
+      }
+      if (result.exitCode != 0) {
+        return Outcome(
+          verb: 'deploy',
+          target: 'every host on this machine',
+          detail: 'failed (exit ${result.exitCode}) — run `iq host get` to '
+              'retry, or `iq doctor` to inspect',
+          values: {'deployed': false},
+        );
+      }
+      return Outcome(
+        verb: 'deploy',
+        target: 'every host on this machine',
+        values: {'deployed': true},
+      );
+    } on Object catch (error) {
+      return Outcome(
+        verb: 'deploy',
+        target: 'every host on this machine',
+        detail: 'stopped: $error — run `iq host get` to retry, or `iq doctor` '
+            'to inspect',
+        values: {'deployed': false},
+      );
+    }
+  }
+}
+
 // ─── Output ─────────────────────────────────────────────────────────────────
 
 class UpgradeOutput extends Output {
-  final String message;
+  UpgradeOutput({
+    required this.previousVersion,
+    required this.newVersion,
+    required this.upgraded,
+    this.deployed = true,
+    this.reason,
+  });
+
   final String previousVersion;
   final String newVersion;
   final bool upgraded;
 
-  UpgradeOutput({
-    required this.message,
-    required this.previousVersion,
-    required this.newVersion,
-    required this.upgraded,
-  });
+  /// Whether the hosts were redeployed. False does not mean the upgrade failed.
+  final bool deployed;
+
+  /// Why nothing happened, when nothing did.
+  final String? reason;
 
   @override
   Map<String, dynamic> toJson() => {
-    'message': message,
     'previousVersion': previousVersion,
     'newVersion': newVersion,
     'upgraded': upgraded,
+    'deployed': deployed,
+    if (reason != null) 'reason': reason,
   };
 
   @override
   int get exitCode => ExitCode.ok;
 
-  /// Returns human-friendly upgrade status.
   @override
-  String? toText() {
-    if (!upgraded) return message;
-    return '✓ Upgraded: $previousVersion → $newVersion';
-  }
+  String? toText() => upgraded
+      ? [
+          '✓ Upgraded: $previousVersion → $newVersion',
+          if (!deployed)
+            '  The CLI is upgraded. Run `iq host get` to deploy the hosts.',
+        ].join('\n')
+      : (reason ?? 'Already on the latest version');
 }
 
 // ─── Command ────────────────────────────────────────────────────────────────
@@ -81,25 +265,51 @@ class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
   @override
   final UpgradeInput input;
   final PlatformOps platformOps;
+
+  /// Answers the releases API. Overridden by the tests that exercise what the
+  /// lookup returns.
   final HttpClient? httpClientOverride;
+
+  /// How the release archive is fetched. A seam for the tests, and the reason
+  /// the step itself knows nothing about HTTP.
+  final Downloader? download;
+
+  /// Where the steps' running commentary goes. A seam for the tests.
+  final IOSink? progress;
+
+  /// The binary being replaced. A seam for the tests, and never optional —
+  /// see [ReplaceInstallation.runningExecutable].
+  final String? runningExecutable;
 
   UpgradeCommand(
     this.input, {
     PlatformOps? platformOps,
     this.httpClientOverride,
+    this.download,
+    this.progress,
+    this.runningExecutable,
   }) : platformOps = platformOps ?? PlatformOps.current();
 
   @override
   String? validate() => null;
 
-  @override
-  Future<UpgradeOutput> execute() async {
-    final client = httpClientOverride ?? HttpClient();
-    try {
-      // 1. Fetch latest release metadata
-      stderr.writeln('Current version: $inquiryVersion');
-      stderr.writeln('Checking for updates...');
+  String _latest = inquiryVersion;
+  String? _reason;
 
+  /// Two steps, and everything they need read before the plan is built.
+  ///
+  /// The releases API is asked **once**, here. That is what makes the plan
+  /// honest: the version, the asset and the URL a person approves are the ones
+  /// that get downloaded. Asking again inside the step could resolve a release
+  /// published in the meantime, and the upgrade would not be the one shown.
+  ///
+  /// Nothing to upgrade to is not a failure, so it builds no steps and says
+  /// why.
+  @override
+  Future<List<Step>> steps() async {
+    final client = httpClientOverride ?? HttpClient();
+    final Map<String, dynamic> release;
+    try {
       final releaseUrl = Uri.parse(
         'https://api.github.com/repos/$_repo/releases/latest',
       );
@@ -109,138 +319,74 @@ class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
       final metaResponse = await metaRequest.close();
 
       if (metaResponse.statusCode != 200) {
-        return UpgradeOutput(
+        throw CommandException(
+          code: 'RELEASE_LOOKUP_FAILED',
           message:
               'Failed to fetch release info (HTTP ${metaResponse.statusCode})',
-          previousVersion: inquiryVersion,
-          newVersion: inquiryVersion,
-          upgraded: false,
+          exitCode: ExitCode.apiError,
+          isRetryable: true,
         );
       }
 
-      final body = await metaResponse.transform(utf8.decoder).join();
-      final release = jsonDecode(body) as Map<String, dynamic>;
-      final tagName = release['tag_name'] as String;
-      final latestVersion = tagName.startsWith('v')
-          ? tagName.substring(1)
-          : tagName;
-
-      stderr.writeln('Latest version available: $latestVersion');
-
-      if (latestVersion == inquiryVersion) {
-        return UpgradeOutput(
-          message: 'Already on the latest version',
-          previousVersion: inquiryVersion,
-          newVersion: inquiryVersion,
-          upgraded: false,
-        );
-      }
-
-      stderr.writeln('Found v$latestVersion, downloading...');
-
-      // 2. Find the asset for this platform
-      final expectedAsset = platformOps.assetName;
-      final assets = release['assets'] as List<dynamic>;
-      final asset = assets.cast<Map<String, dynamic>>().firstWhere(
-        (a) => (a['name'] as String) == expectedAsset,
-        orElse: () => throw CommandException(
-          code: 'ASSET_NOT_FOUND',
-          message: 'No $expectedAsset asset in release $tagName',
-          exitCode: ExitCode.notFound,
-        ),
-      );
-
-      final downloadUrl = asset['browser_download_url'] as String;
-
-      // 3. Download to temp
-      final tempDir = Directory.systemTemp.createTempSync('ape_upgrade_');
-      final zipFile = File(p.join(tempDir.path, expectedAsset));
-
-      final dlRequest = await client.getUrl(Uri.parse(downloadUrl));
-      dlRequest.headers.set('User-Agent', 'inquiry-cli/$inquiryVersion');
-      final dlResponse = await dlRequest.close();
-
-      // Follow redirect if needed
-      stderr.writeln('Downloading asset: $expectedAsset');
-      final sink = zipFile.openWrite();
-      await dlResponse.pipe(sink);
-
-      // 4. Extract over current installation via PlatformOps
-      final installDir = input.installDir;
-      stderr.writeln('Applying update in: $installDir');
-
-      try {
-        // Windows locks running executables — rename before extraction
-        if (Platform.isWindows) {
-          final bakFile = File('${Platform.resolvedExecutable}.bak');
-          if (bakFile.existsSync()) bakFile.deleteSync();
-          File(Platform.resolvedExecutable).renameSync(bakFile.path);
-        }
-
-        await platformOps.expandArchive(zipFile.path, installDir);
-
-        // Best-effort cleanup of old binary
-        if (Platform.isWindows) {
-          try {
-            final bakFile = File('${Platform.resolvedExecutable}.bak');
-            if (bakFile.existsSync()) bakFile.deleteSync();
-          } on FileSystemException {
-            // Still locked — will be cleaned up on next upgrade
-          }
-        }
-      } catch (e) {
-        stderr.writeln('Upgrade failed during apply step: $e');
-        tempDir.deleteSync(recursive: true);
-        return UpgradeOutput(
-          message: 'Failed to extract: $e',
-          previousVersion: inquiryVersion,
-          newVersion: latestVersion,
-          upgraded: false,
-        );
-      }
-
-      tempDir.deleteSync(recursive: true);
-
-      // 5. Redeploy hosts using the new binary.
-      //
-      // The binary and assets are already in place, so the upgrade has
-      // succeeded by this point. Redeploying reaches into third-party tools'
-      // directories and can fail or stall for reasons that have nothing to do
-      // with the upgrade — so it stops and reports, never blocks and never
-      // takes the upgrade down with it (#300).
-      stderr.writeln('Deploying hosts...');
-      try {
-        final result = await platformOps.runPostInstall(installDir);
-        // Echo what the child actually did. Swallowing it made a deploy to
-        // nothing look identical to a deploy to everything.
-        for (final line in postInstallOutputLines(result)) {
-          stderr.writeln('  $line');
-        }
-        if (result.exitCode != 0) {
-          stderr.writeln('Host deployment failed (exit ${result.exitCode}).');
-          stderr.writeln(
-            'The CLI is upgraded. Run `iq host get` to retry, '
-            'or `iq doctor` to inspect.',
-          );
-        }
-      } catch (e) {
-        stderr.writeln('Host deployment stopped: $e');
-        stderr.writeln(
-          'The CLI is upgraded. Run `iq host get` to retry, '
-          'or `iq doctor` to inspect.',
-        );
-      }
-      stderr.writeln('Upgrade completed successfully.');
-
-      return UpgradeOutput(
-        message: 'Upgraded from $inquiryVersion to $latestVersion',
-        previousVersion: inquiryVersion,
-        newVersion: latestVersion,
-        upgraded: true,
-      );
+      release =
+          jsonDecode(await metaResponse.transform(utf8.decoder).join())
+              as Map<String, dynamic>;
     } finally {
       if (httpClientOverride == null) client.close();
     }
+
+    final tagName = release['tag_name'] as String;
+    _latest = tagName.startsWith('v') ? tagName.substring(1) : tagName;
+    if (_latest == inquiryVersion) {
+      _reason = 'Already on the latest version';
+      return const [];
+    }
+
+    final expectedAsset = platformOps.assetName;
+    final asset = (release['assets'] as List<dynamic>)
+        .cast<Map<String, dynamic>>()
+        .where((a) => a['name'] == expectedAsset)
+        .firstOrNull;
+    if (asset == null) {
+      throw CommandException(
+        code: 'ASSET_NOT_FOUND',
+        message: 'No $expectedAsset asset in release $tagName',
+        exitCode: ExitCode.notFound,
+      );
+    }
+
+    return [
+      ReplaceInstallation(
+        platformOps: platformOps,
+        download: download,
+        installDir: input.installDir,
+        from: inquiryVersion,
+        to: _latest,
+        asset: expectedAsset,
+        downloadUrl: asset['browser_download_url'] as String,
+        progress: progress,
+        runningExecutable: runningExecutable,
+      ),
+      RedeployHosts(
+        platformOps: platformOps,
+        installDir: input.installDir,
+        progress: progress,
+      ),
+    ];
+  }
+
+  @override
+  UpgradeOutput describe(Execution execution) {
+    final deploy = execution.outcomes
+        .where((o) => o.verb == 'deploy')
+        .firstOrNull;
+    return UpgradeOutput(
+      previousVersion: inquiryVersion,
+      newVersion: _latest,
+      upgraded: execution.outcomes.any((o) => o.verb == 'replace'),
+      deployed: deploy?.values['deployed'] as bool? ?? true,
+      reason: _reason,
+    );
   }
 }
 
@@ -252,10 +398,6 @@ class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
 ///
 /// Visible for testing.
 List<String> postInstallOutputLines(ProcessResult result) => [
-      '${result.stdout}',
-      '${result.stderr}',
-    ]
-        .expand((s) => s.split('\n'))
-        .map((l) => l.trimRight())
-        .where((l) => l.isNotEmpty)
-        .toList(growable: false);
+  '${result.stdout}',
+  '${result.stderr}',
+].expand((s) => s.split('\n')).map((l) => l.trimRight()).where((l) => l.isNotEmpty).toList(growable: false);

--- a/code/cli/lib/modules/global/commands/version.dart
+++ b/code/cli/lib/modules/global/commands/version.dart
@@ -44,7 +44,7 @@ class VersionOutput extends Output {
 
 // ─── Command ────────────────────────────────────────────────────────────────
 
-class VersionCommand implements Command<VersionInput, VersionOutput> {
+class VersionCommand implements Query<VersionInput, VersionOutput> {
   @override
   final VersionInput input;
 

--- a/code/cli/lib/modules/global/global_builder.dart
+++ b/code/cli/lib/modules/global/global_builder.dart
@@ -18,14 +18,14 @@ void buildGlobalModule(
   required HostDeployer cleaner,
   Assets? assets,
 }) {
-  m.command<TuiInput, TuiOutput>(
+  m.query<TuiInput, TuiOutput>(
     '',
     (req) => TuiCommand(TuiInput.fromCliRequest(req)),
     description: 'Display Inquiry status and FSM diagram',
     params: TuiInput.params,
   );
 
-  m.command<InitInput, InitOutput>(
+  m.query<InitInput, InitOutput>(
     'init',
     (req) => InitCommand(InitInput.fromCliRequest(req)),
     description:
@@ -33,14 +33,14 @@ void buildGlobalModule(
     params: InitInput.params,
   );
 
-  m.command<VersionInput, VersionOutput>(
+  m.query<VersionInput, VersionOutput>(
     'version',
     (req) => VersionCommand(VersionInput.fromCliRequest(req)),
     description: 'Print the current CLI version',
     params: VersionInput.params,
   );
 
-  m.command<DoctorInput, DoctorOutput>(
+  m.query<DoctorInput, DoctorOutput>(
     'doctor',
     (req) => DoctorCommand(DoctorInput.fromCliRequest(req), assets: assets),
     description: 'Verify prerequisites (inquiry, git, gh, gh auth, gh copilot)',

--- a/code/cli/lib/modules/host/commands/clean.dart
+++ b/code/cli/lib/modules/host/commands/clean.dart
@@ -33,15 +33,65 @@ class HostCleanInput extends Input {
 // ─── Output ─────────────────────────────────────────────────────────────────
 
 class HostCleanOutput extends Output {
-  final String message;
+  HostCleanOutput({required this.removedRepoAgent});
 
-  HostCleanOutput({required this.message});
+  /// Whether a repository-scoped agent file was there to remove.
+  final bool removedRepoAgent;
 
   @override
-  Map<String, dynamic> toJson() => {'message': message};
+  Map<String, dynamic> toJson() => {'removedRepoAgent': removedRepoAgent};
 
   @override
   int get exitCode => ExitCode.ok;
+
+  @override
+  String? toText() => [
+    'Inquiry cleaned from all hosts',
+    if (removedRepoAgent) '  removed the repository-scoped agent too',
+  ].join('\n');
+}
+
+// ─── Steps ──────────────────────────────────────────────────────────────────
+
+/// Removes the agent and skills deployed into every host.
+class CleanDeployedHosts implements Step {
+  CleanDeployedHosts(this.deployer);
+
+  final HostDeployer deployer;
+
+  @override
+  Preview preview() => Preview(
+    verb: 'clean',
+    target: 'every host this machine deployed to',
+    detail: 'the Inquiry agent and its skills',
+  );
+
+  @override
+  Future<Outcome> perform(StepContext context) async {
+    deployer.clean();
+    return Outcome(verb: 'clean', target: 'every host this machine deployed to');
+  }
+}
+
+/// Removes the repository-scoped agent file, when one is there.
+class RemoveRepoScopedAgent implements Step {
+  RemoveRepoScopedAgent(this.path);
+
+  final String path;
+
+  bool get _exists => File(path).existsSync();
+
+  @override
+  Preview preview() => _exists
+      ? Preview(verb: 'remove', target: path)
+      : Preview(verb: 'absent', target: path);
+
+  @override
+  Future<Outcome> perform(StepContext context) async {
+    if (!_exists) return Outcome(verb: 'absent', target: path);
+    File(path).deleteSync();
+    return Outcome(verb: 'remove', target: path);
+  }
 }
 
 // ─── Command ────────────────────────────────────────────────────────────────
@@ -63,17 +113,18 @@ class HostCleanCommand
   String? validate() => null;
 
   @override
-  Future<HostCleanOutput> execute() async {
-    deployer.clean();
-    _cleanRepoScopedAgent();
-    return HostCleanOutput(message: 'Inquiry cleaned from all hosts');
+  Future<List<Step>> steps() async {
+    final projectRoot = getProjectRoot(_workingDirectory) ?? _workingDirectory;
+    return [
+      CleanDeployedHosts(deployer),
+      RemoveRepoScopedAgent(
+        p.join(projectRoot, '.github', 'agents', 'inquiry.agent.md'),
+      ),
+    ];
   }
 
-  void _cleanRepoScopedAgent() {
-    final projectRoot = getProjectRoot(_workingDirectory) ?? _workingDirectory;
-    final agentFile = File(
-      p.join(projectRoot, '.github', 'agents', 'inquiry.agent.md'),
-    );
-    if (agentFile.existsSync()) agentFile.deleteSync();
-  }
+  @override
+  HostCleanOutput describe(Execution execution) => HostCleanOutput(
+    removedRepoAgent: execution.outcomes.any((o) => o.verb == 'remove'),
+  );
 }

--- a/code/cli/lib/modules/host/commands/get.dart
+++ b/code/cli/lib/modules/host/commands/get.dart
@@ -65,23 +65,113 @@ class HostGetInput extends Input {
 // ─── Output ─────────────────────────────────────────────────────────────────
 
 class HostGetOutput extends Output {
-  final String message;
+  HostGetOutput({
+    required this.hosts,
+    this.retired = const {},
+    this.ollamaLines = const [],
+    this.supported = const [],
+  });
 
   /// The hosts actually installed into. Empty is a valid outcome: a machine may
   /// carry the CLI and no AI assistant at all.
   final List<String> hosts;
 
-  HostGetOutput({required this.message, this.hosts = const []});
+  /// Host → the skills it no longer ships, which the deploy retired.
+  final Map<String, List<String>> retired;
+
+  /// What the Ollama configurator had to say, when it ran.
+  final List<String> ollamaLines;
+
+  /// Every host this CLI knows how to install into, for the empty case.
+  final List<String> supported;
 
   @override
-  Map<String, dynamic> toJson() => {'message': message, 'hosts': hosts};
+  Map<String, dynamic> toJson() => {
+    'hosts': hosts,
+    if (retired.isNotEmpty) 'retired': retired,
+    if (ollamaLines.isNotEmpty) 'ollama': ollamaLines,
+  };
 
   /// Deploying to nothing is not a failure — see [hosts].
   @override
   int get exitCode => ExitCode.ok;
 
   @override
-  String? toText() => message;
+  String? toText() => hosts.isEmpty
+      ? 'No AI coding host found on this machine — nothing deployed.\n'
+            'Supported: ${supported.join(', ')}.\n'
+            'Pass --host <host> to install into one anyway.'
+      : [
+          for (final host in hosts) ...[
+            'Inquiry agent + skills deployed (global) to host $host',
+            for (final skill in retired[host] ?? const <String>[])
+              '  removed  $skill (no longer shipped)',
+          ],
+          ...ollamaLines,
+        ].join('\n');
+}
+
+// ─── Steps ──────────────────────────────────────────────────────────────────
+
+/// Deploys the agent and skills into one host, retiring what it no longer
+/// ships.
+///
+/// One step per host, so the plan names each of them: deploying to two
+/// assistants and deploying to none look nothing alike, and a single line
+/// saying "deploy hosts" would hide the difference.
+class DeployToHost implements Step {
+  DeployToHost({required this.deployer, required this.host});
+
+  final HostDeployer deployer;
+  final String host;
+
+  @override
+  Preview preview() => Preview(
+    verb: 'deploy',
+    target: 'host $host',
+    detail: 'the Inquiry agent and its skills, globally; skills no longer '
+        'shipped are retired',
+  );
+
+  @override
+  Future<Outcome> perform(StepContext context) async {
+    final retired = deployer.deploy(host);
+    return Outcome(
+      verb: 'deploy',
+      target: 'host $host',
+      values: {'host': host, 'retired': retired},
+    );
+  }
+}
+
+/// Bakes `num_ctx` variants of the configured Ollama models.
+///
+/// Opt-in behind `--configure-ollama`: it shells out to `ollama create`, which
+/// is slow and blocks when the daemon is not running. That is an optimization,
+/// not part of installing a CLI — which is exactly why it is a step of its own
+/// and named in the plan.
+class ConfigureOllama implements Step {
+  ConfigureOllama(this.configurator);
+
+  final OpenCodeOllamaConfigurator configurator;
+
+  @override
+  Preview preview() => Preview(
+    verb: 'configure',
+    target: 'the Ollama models OpenCode uses',
+    detail: 'bakes num_ctx variants — shells out to `ollama create`, which is '
+        'slow and needs the daemon running',
+  );
+
+  @override
+  Future<Outcome> perform(StepContext context) async {
+    final lines = await configurator.configure();
+    return Outcome(
+      verb: 'configure',
+      target: 'the Ollama models OpenCode uses',
+      values: {'lines': lines},
+    );
+  }
 }
 
 // ─── Command ────────────────────────────────────────────────────────────────
@@ -108,33 +198,45 @@ class HostGetCommand implements Command<HostGetInput, HostGetOutput> {
     return null;
   }
 
+  /// One step per host, and the Ollama configuration after the host it belongs
+  /// to.
+  ///
+  /// Deploying to nothing builds no steps: a machine may carry the CLI and no
+  /// AI assistant at all, and that is an answer rather than a failure.
   @override
-  Future<HostGetOutput> execute() async {
+  Future<List<Step>> steps() async {
     final targets = input.host != null
         ? [input.host!]
         : deployer.detectedHosts.map((a) => a.name).toList();
 
-    if (targets.isEmpty) {
-      return HostGetOutput(
-        message: 'No AI coding host found on this machine — nothing deployed.\n'
-            'Supported: ${deployer.adapters.map((a) => a.name).join(', ')}.\n'
-            'Pass --host <host> to install into one anyway.',
-      );
-    }
-
-    final lines = <String>[];
-    for (final host in targets) {
-      final retired = deployer.deploy(host);
-      lines.add('Inquiry agent + skills deployed (global) to host $host');
-      for (final skill in retired) {
-        lines.add('  removed  $skill (no longer shipped)');
-      }
-
-      if (host == 'opencode' && input.configureOllama && configurator != null) {
-        lines.addAll(await configurator!.configure());
-      }
-    }
-
-    return HostGetOutput(message: lines.join('\n'), hosts: targets);
+    return [
+      for (final host in targets) ...[
+        DeployToHost(deployer: deployer, host: host),
+        if (host == 'opencode' &&
+            input.configureOllama &&
+            configurator != null)
+          ConfigureOllama(configurator!),
+      ],
+    ];
   }
+
+  @override
+  HostGetOutput describe(Execution execution) => HostGetOutput(
+    hosts: [
+      for (final o in execution.outcomes)
+        if (o.verb == 'deploy') o.values['host'] as String,
+    ],
+    retired: {
+      for (final o in execution.outcomes)
+        if (o.verb == 'deploy')
+          o.values['host'] as String:
+              (o.values['retired'] as List).cast<String>(),
+    },
+    ollamaLines: [
+      for (final o in execution.outcomes)
+        if (o.verb == 'configure')
+          ...(o.values['lines'] as List).cast<String>(),
+    ],
+    supported: deployer.adapters.map((a) => a.name).toList(),
+  );
 }

--- a/code/cli/lib/modules/implementation/commands/start.dart
+++ b/code/cli/lib/modules/implementation/commands/start.dart
@@ -165,8 +165,20 @@ class ImplementationStartCommand
     return null;
   }
 
+  String _branch = '';
+
+  /// Three steps, over a branch name settled before the plan is built.
+  ///
+  /// **The issue's title is read once, here.** The branch name derives from it,
+  /// so reading it again at perform time could produce a different branch from
+  /// the one that was approved — a renamed issue between plan and apply, and
+  /// the cycle opens somewhere nobody asked for.
+  ///
+  /// What comes first are preconditions, not steps: not a git repository, an
+  /// issue `gh` cannot see, a title with nothing to slug. A plan built from any
+  /// of them would describe work that will never happen.
   @override
-  Future<ImplementationStartOutput> execute() async {
+  Future<List<Step>> steps() async {
     final projectRoot = getProjectRoot(input.workingDirectory);
     if (projectRoot == null) {
       throw CommandException(
@@ -179,11 +191,6 @@ class ImplementationStartCommand
       );
     }
 
-    // AC3 — the workspace initializes itself when missing; the user never has
-    // to remember `iq init`.
-    final initialized = _ensureWorkspace(projectRoot);
-
-    // Read the issue so the branch slug comes from its real title.
     final info = _issueInfo(input.issue, projectRoot);
     if (info == null) {
       throw CommandException(
@@ -197,9 +204,8 @@ class ImplementationStartCommand
       );
     }
 
-    final String branch;
     try {
-      branch = branchNameFor(issue: input.issue, title: info.title);
+      _branch = branchNameFor(issue: input.issue, title: info.title);
     } on ArgumentError catch (e) {
       throw CommandException(
         code: 'EMPTY_SLUG',
@@ -210,79 +216,38 @@ class ImplementationStartCommand
       );
     }
 
-    final branchCreated = _checkoutBranch(projectRoot, branch);
+    return [
+      // AC3 — the workspace initializes itself when missing; the user never
+      // has to remember `iq init`.
+      EnsureWorkspace(projectRoot),
+      CheckoutBranch(
+        projectRoot: projectRoot,
+        branch: _branch,
+        git: _git,
+        issue: input.issue,
+      ),
+      StartAnalyze(
+        issue: input.issue,
+        projectRoot: projectRoot,
+        assets: _assets,
+        run: _startAnalyze,
+        branch: _branch,
+      ),
+    ];
+  }
 
-    // Fire the real transition; its open_analysis_context effect scaffolds the
-    // cleanroom under cleanrooms/<branch>/.
-    final result = await _startAnalyze(
-      issue: input.issue,
-      workingDirectory: projectRoot,
-      assets: _assets,
-    );
-    if (!result.ok) {
-      throw CommandException(
-        code: 'TRANSITION_FAILED',
-        message:
-            'Branch "$branch" is ready but the transition to ANALYZE failed:\n'
-            '${result.message}',
-        exitCode: ExitCode.genericError,
-      );
-    }
-
+  @override
+  ImplementationStartOutput describe(Execution execution) {
+    final checkout = execution.outcomes
+        .where((o) => o.values.containsKey('created'))
+        .firstOrNull;
     return ImplementationStartOutput(
       issue: input.issue,
-      branch: branch,
-      cleanroom: p.posix.join('cleanrooms', branch),
-      branchCreated: branchCreated,
-      initialized: initialized,
+      branch: _branch,
+      cleanroom: p.posix.join('cleanrooms', _branch),
+      branchCreated: checkout?.values['created'] as bool? ?? false,
+      initialized: execution.outcomes.any((o) => o.verb == 'initialize'),
     );
-  }
-
-  /// Ensures `.inquiry/config.yaml` exists; returns whether it had to create it.
-  bool _ensureWorkspace(String projectRoot) {
-    final config = File(p.join(projectRoot, '.inquiry', 'config.yaml'));
-    if (config.existsSync()) return false;
-    // InitCommand is idempotent and repo-scoped; reuse it rather than
-    // reimplementing the workspace layout.
-    InitCommand(InitInput(workingDirectory: projectRoot)).execute();
-    return true;
-  }
-
-  /// Checks out [branch], creating it when it does not yet exist. Returns
-  /// whether the branch was newly created.
-  bool _checkoutBranch(String projectRoot, String branch) {
-    final current = getCurrentBranch(projectRoot);
-    if (current == branch) return false;
-
-    final exists = _git(projectRoot, [
-      'rev-parse',
-      '--verify',
-      '--quiet',
-      'refs/heads/$branch',
-    ]).exitCode == 0;
-
-    final checkout = exists
-        ? _git(projectRoot, ['checkout', branch])
-        : _git(projectRoot, ['checkout', '-b', branch]);
-
-    if (checkout.exitCode != 0) {
-      throw CommandException(
-        code: 'BRANCH_CHECKOUT_FAILED',
-        message:
-            'Could not switch to branch "$branch":\n'
-            '${_gitError(checkout)}\n'
-            'Commit or stash your changes, then retry `iq implementation start --issue ${input.issue}`.',
-        exitCode: ExitCode.genericError,
-      );
-    }
-    return !exists;
-  }
-
-  static String _gitError(ProcessResult r) {
-    final err = r.stderr.toString().trim();
-    if (err.isNotEmpty) return err;
-    final out = r.stdout.toString().trim();
-    return out.isNotEmpty ? out : 'git exited with code ${r.exitCode}';
   }
 
   static ProcessResult _defaultGit(
@@ -329,5 +294,165 @@ class ImplementationStartCommand
     );
     final output = await command.execute();
     return (ok: output.allowed, message: output.message);
+  }
+}
+
+// ─── Steps ──────────────────────────────────────────────────────────────────
+
+/// Creates the Inquiry workspace when the repository has none.
+///
+/// The user never has to remember `iq init`: opening a cycle in a repository
+/// that never had one is the ordinary first run, not an error.
+class EnsureWorkspace implements Step {
+  EnsureWorkspace(this.projectRoot);
+
+  final String projectRoot;
+
+  bool get _exists =>
+      File(p.join(projectRoot, '.inquiry', 'config.yaml')).existsSync();
+
+  @override
+  Preview preview() => _exists
+      ? Preview(verb: 'exists', target: '.inquiry/config.yaml')
+      : Preview(
+          verb: 'initialize',
+          target: '.inquiry/',
+          detail: 'the repository has no Inquiry workspace yet',
+        );
+
+  @override
+  Future<Outcome> perform(StepContext context) async {
+    if (_exists) return Outcome(verb: 'exists', target: '.inquiry/config.yaml');
+    // InitCommand is idempotent and repo-scoped; reuse it rather than
+    // reimplementing the workspace layout.
+    InitCommand(InitInput(workingDirectory: projectRoot)).execute();
+    return Outcome(verb: 'initialize', target: '.inquiry/');
+  }
+}
+
+/// Checks out the cycle's branch, creating it when it does not yet exist.
+class CheckoutBranch implements Step {
+  CheckoutBranch({
+    required this.projectRoot,
+    required this.branch,
+    required this.git,
+    required this.issue,
+  });
+
+  final String projectRoot;
+  final String branch;
+  final GitCommandRunner git;
+  final String issue;
+
+  bool get _onIt => getCurrentBranch(projectRoot) == branch;
+
+  bool get _exists =>
+      git(projectRoot, [
+        'rev-parse',
+        '--verify',
+        '--quiet',
+        'refs/heads/$branch',
+      ]).exitCode ==
+      0;
+
+  @override
+  Preview preview() {
+    if (_onIt) {
+      return Preview(verb: 'stay', target: 'branch $branch', detail: 'already on it');
+    }
+    return _exists
+        ? Preview(verb: 'checkout', target: 'branch $branch')
+        : Preview(
+            verb: 'create',
+            target: 'branch $branch',
+            detail: 'derived from the title of issue #$issue',
+          );
+  }
+
+  @override
+  Future<Outcome> perform(StepContext context) async {
+    if (_onIt) {
+      return Outcome(
+        verb: 'stay',
+        target: 'branch $branch',
+        values: {'created': false},
+      );
+    }
+
+    final exists = _exists;
+    final checkout = exists
+        ? git(projectRoot, ['checkout', branch])
+        : git(projectRoot, ['checkout', '-b', branch]);
+
+    if (checkout.exitCode != 0) {
+      throw CommandException(
+        code: 'BRANCH_CHECKOUT_FAILED',
+        message:
+            'Could not switch to branch "$branch":\n'
+            '${_gitErrorOf(checkout)}\n'
+            'Commit or stash your changes, then retry `iq implementation start --issue $issue`.',
+        exitCode: ExitCode.genericError,
+      );
+    }
+
+    return Outcome(
+      verb: exists ? 'checkout' : 'create',
+      target: 'branch $branch',
+      values: {'created': !exists},
+    );
+  }
+
+  static String _gitErrorOf(ProcessResult r) {
+    final err = r.stderr.toString().trim();
+    if (err.isNotEmpty) return err;
+    final out = r.stdout.toString().trim();
+    return out.isNotEmpty ? out : 'git exited with code ${r.exitCode}';
+  }
+}
+
+/// Fires the `start_analyze` transition.
+///
+/// Its `open_analysis_context` effect scaffolds the cleanroom under
+/// `cleanrooms/<branch>/`. Last, because the branch has to exist first: the
+/// cleanroom is named after it.
+class StartAnalyze implements Step {
+  StartAnalyze({
+    required this.issue,
+    required this.projectRoot,
+    required this.assets,
+    required this.run,
+    required this.branch,
+  });
+
+  final String issue;
+  final String projectRoot;
+  final Assets? assets;
+  final StartAnalyzeRunner run;
+  final String branch;
+
+  @override
+  Preview preview() => Preview(
+    verb: 'transition',
+    target: 'to ANALYZE',
+    detail: 'scaffolds cleanrooms/$branch/analyze/ for issue #$issue',
+  );
+
+  @override
+  Future<Outcome> perform(StepContext context) async {
+    final result = await run(
+      issue: issue,
+      workingDirectory: projectRoot,
+      assets: assets,
+    );
+    if (!result.ok) {
+      throw CommandException(
+        code: 'TRANSITION_FAILED',
+        message:
+            'Branch "$branch" is ready but the transition to ANALYZE failed:\n'
+            '${result.message}',
+        exitCode: ExitCode.genericError,
+      );
+    }
+    return Outcome(verb: 'transition', target: 'to ANALYZE');
   }
 }

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.24.1';
+const String inquiryVersion = '0.25.0';

--- a/code/cli/pubspec.lock
+++ b/code/cli/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: "direct main"
     description:
       name: modular_cli_sdk
-      sha256: e88a11929fc54f0610cbbf3461d57f95aa69dba22ce29d249a9402377cd84008
+      sha256: "2b7e9767fe9d838d3a407a5f907ff1d7d36102ce4615ec02e57e2849962546fb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3"
+    version: "0.4.1"
   node_preamble:
     dependency: transitive
     description:
@@ -217,6 +217,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  preview_executor:
+    dependency: transitive
+    description:
+      name: preview_executor
+      sha256: "05afa0124bbd4a360d414c9a5f3ed5860952833c02e712d188611c27fe9ade1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   pub_semver:
     dependency: transitive
     description:

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.24.1
+version: 0.25.0
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.8.1
 dependencies:
   cli_router: ^0.1.0
-  modular_cli_sdk: ^0.3.3
+  modular_cli_sdk: ^0.4.1
   path: ^1.9.1
   yaml: ^3.1.3
 dev_dependencies:

--- a/code/cli/scripts/install.ps1
+++ b/code/cli/scripts/install.ps1
@@ -9,7 +9,7 @@
 #   3. Extracts to $env:LOCALAPPDATA\inquiry\
 #   4. Adds inquiry\bin\ to the user PATH
 #   5. Creates `iq.cmd` batch shim
-#   6. Runs `inquiry host get`
+#   6. Runs `inquiry host get --apply --autoapprove`
 #   7. Verifies with `inquiry version`
 
 $ErrorActionPreference = 'Stop'
@@ -90,7 +90,9 @@ if ($userPath -notlike "*$binDir*") {
 # ─── Deploy and verify ───────────────────────────────────────────────────────
 
 Write-Host '>>> Deploying Inquiry skills to the active host...'
-& (Join-Path $binDir 'inquiry.exe') host get
+# `--apply --autoapprove`: the user approved this by running the installer,
+# and there is no terminal to ask on inside `irm ... | iex`.
+& (Join-Path $binDir 'inquiry.exe') host get --apply --autoapprove
 
 Write-Host '>>> Verifying installation...'
 $versionOutput = & (Join-Path $binDir 'inquiry.exe') version

--- a/code/cli/test/doctor_test.dart
+++ b/code/cli/test/doctor_test.dart
@@ -398,7 +398,7 @@ void main() {
 
         final text = output.toText()!;
         expect(text, contains('✗ no host deployed'));
-        expect(text, contains("Run 'iq host get'"));
+        expect(text, contains("Run 'iq host get --apply'"));
         expect(text, contains('Some checks failed.'));
       });
 
@@ -478,7 +478,7 @@ void main() {
         expect(text, contains('✓ opencode: agent deployed'));
         expect(text, contains('✗ opencode: missing skills: issue-create'));
         expect(text,
-            contains("Run 'inquiry host get --host opencode' to deploy skills"));
+            contains("Run 'iq host get --host opencode --apply' to deploy skills"));
       });
 
       test('HostCheck.toJson() includes all fields', () {
@@ -578,7 +578,7 @@ void main() {
         final text = output.toText()!;
 
         expect(text, contains('✗ no host deployed'));
-        expect(text, contains("Run 'iq host get'"));
+        expect(text, contains("Run 'iq host get --apply'"));
         expect(text, isNot(contains("'inquiry target get'")));
       });
 

--- a/code/cli/test/fsm_transition_test.dart
+++ b/code/cli/test/fsm_transition_test.dart
@@ -455,6 +455,33 @@ void main() {
       },
     );
 
+    // The remediation is acted on by the scheduler, which has no terminal to
+    // be asked on. A remediation that names neither mode would send the agent
+    // straight into "Choose --plan or --apply" and leave the cycle unopened.
+    test(
+      'the branch-policy remediation is runnable as written',
+      () async {
+        _initGitRepo(tempDir.path, branch: 't1-pilot-h');
+        _writeState(tempDir.path, 'IDLE', issue: '231');
+
+        final output = await StateTransitionCommand(
+          StateTransitionInput(
+            currentState: null,
+            event: 'start_analyze',
+            workingDirectory: tempDir.path,
+          ),
+          branchProvider: (_) async => 't1-pilot-h',
+        ).execute();
+
+        expect(
+          output.message,
+          contains(
+            'iq implementation start --issue 231 --apply --autoapprove',
+          ),
+        );
+      },
+    );
+
     test('allows IDLE to ANALYZE with issue and feature branch', () async {
       _initGitRepo(tempDir.path, branch: '152-feature-branch');
       _writeState(tempDir.path, 'IDLE');

--- a/code/cli/test/host_commands_test.dart
+++ b/code/cli/test/host_commands_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
+import 'package:modular_cli_sdk/testing.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -64,7 +65,7 @@ void main() {
         deployer: deployer,
       );
 
-      final output = await command.execute();
+      final output = await applyCommand(command);
 
       expect(output.exitCode, ExitCode.ok);
       expect(
@@ -82,13 +83,15 @@ void main() {
       );
     });
 
-    test('HostGetInput defaults to no host, meaning every detected one (#300)',
-        () {
-      // Defaulting to opencode deployed into a host the user might not have,
-      // and dragged the OpenCode/Ollama configurator into every `iq upgrade`.
-      expect(HostGetInput().host, isNull);
-      expect(HostGetInput().configureOllama, isFalse);
-    });
+    test(
+      'HostGetInput defaults to no host, meaning every detected one (#300)',
+      () {
+        // Defaulting to opencode deployed into a host the user might not have,
+        // and dragged the OpenCode/Ollama configurator into every `iq upgrade`.
+        expect(HostGetInput().host, isNull);
+        expect(HostGetInput().configureOllama, isFalse);
+      },
+    );
 
     group('host detection (#300)', () {
       /// The host tool is present when its own config directory exists — the
@@ -96,50 +99,51 @@ void main() {
       void installFakeHost() =>
           Directory(p.join(homeDir.path, '.fake')).createSync(recursive: true);
 
-      test('no host installed → nothing deployed, and that is not a failure',
-          () async {
-        final out = await HostGetCommand(
-          HostGetInput(),
-          deployer: deployer,
-        ).execute();
+      test(
+        'no host installed → nothing deployed, and that is not a failure',
+        () async {
+          final out = await applyCommand(
+            HostGetCommand(HostGetInput(), deployer: deployer),
+          );
 
-        expect(out.exitCode, ExitCode.ok);
-        expect(out.hosts, isEmpty);
-        expect(out.message, contains('No AI coding host found'));
-        expect(out.message, contains('--host'));
-        expect(
-          Directory(p.join(homeDir.path, '.fake', 'skills')).existsSync(),
-          isFalse,
-        );
-      });
+          expect(out.exitCode, ExitCode.ok);
+          expect(out.hosts, isEmpty);
+          expect(out.toText(), contains('No AI coding host found'));
+          expect(out.toText(), contains('--host'));
+          expect(
+            Directory(p.join(homeDir.path, '.fake', 'skills')).existsSync(),
+            isFalse,
+          );
+        },
+      );
 
       test('a detected host is deployed into without being named', () async {
         installFakeHost();
 
-        final out = await HostGetCommand(
-          HostGetInput(),
-          deployer: deployer,
-        ).execute();
+        final out = await applyCommand(
+          HostGetCommand(HostGetInput(), deployer: deployer),
+        );
 
         expect(out.hosts, ['fake']);
         expect(
-          File(p.join(homeDir.path, '.fake', 'skills', 'doc-read', 'SKILL.md'))
-              .existsSync(),
+          File(
+            p.join(homeDir.path, '.fake', 'skills', 'doc-read', 'SKILL.md'),
+          ).existsSync(),
           isTrue,
         );
       });
 
       test('--host deploys even when the host looks absent', () async {
         // Priming a machine before the host tool has ever run.
-        final out = await HostGetCommand(
-          HostGetInput(host: 'fake'),
-          deployer: deployer,
-        ).execute();
+        final out = await applyCommand(
+          HostGetCommand(HostGetInput(host: 'fake'), deployer: deployer),
+        );
 
         expect(out.hosts, ['fake']);
         expect(
-          File(p.join(homeDir.path, '.fake', 'skills', 'doc-read', 'SKILL.md'))
-              .existsSync(),
+          File(
+            p.join(homeDir.path, '.fake', 'skills', 'doc-read', 'SKILL.md'),
+          ).existsSync(),
           isTrue,
         );
       });
@@ -161,9 +165,8 @@ void main() {
         f.writeAsStringSync('# frozen copy from an older release');
       }
 
-      bool deployed(String name) => Directory(
-            p.join(homeDir.path, '.fake', 'skills', name),
-          ).existsSync();
+      bool deployed(String name) =>
+          Directory(p.join(homeDir.path, '.fake', 'skills', name)).existsSync();
 
       test('removes namespaced skills that are no longer shipped', () async {
         // Exactly the state a user upgrading from before the lifecycle moved
@@ -177,14 +180,16 @@ void main() {
           seedDeployed(name);
         }
 
-        final out = await HostGetCommand(
-          HostGetInput(host: 'fake'),
-          deployer: deployer,
-        ).execute();
+        final out = await applyCommand(
+          HostGetCommand(HostGetInput(host: 'fake'), deployer: deployer),
+        );
 
         expect(deployed('iq-analyze'), isFalse);
         expect(deployed('iq-specification'), isFalse);
-        expect(out.message, contains('removed  iq-analyze (no longer shipped)'));
+        expect(
+          out.toText(),
+          contains('removed  iq-analyze (no longer shipped)'),
+        );
       });
 
       test('never touches skills outside the namespace', () async {
@@ -194,10 +199,9 @@ void main() {
         seedDeployed('my-own-skill');
         seedDeployed('iq-analyze');
 
-        await HostGetCommand(
-          HostGetInput(host: 'fake'),
-          deployer: deployer,
-        ).execute();
+        await applyCommand(
+          HostGetCommand(HostGetInput(host: 'fake'), deployer: deployer),
+        );
 
         expect(deployed('kritik'), isTrue);
         expect(deployed('legion'), isTrue);
@@ -246,8 +250,8 @@ void main() {
         deployer: deployer,
       );
 
-      await command.execute();
-      final output = await command.execute();
+      await applyCommand(command);
+      final output = await applyCommand(command);
 
       expect(output.exitCode, ExitCode.ok);
     });
@@ -258,12 +262,9 @@ void main() {
       // Deploy first using deploy
       deployer.deploy('fake');
 
-      final command = HostCleanCommand(
-        HostCleanInput(),
-        deployer: deployer,
-      );
+      final command = HostCleanCommand(HostCleanInput(), deployer: deployer);
 
-      final output = await command.execute();
+      final output = await applyCommand(command);
 
       expect(output.exitCode, ExitCode.ok);
       expect(
@@ -273,12 +274,9 @@ void main() {
     });
 
     test('exits 0 when nothing to clean', () async {
-      final command = HostCleanCommand(
-        HostCleanInput(),
-        deployer: deployer,
-      );
+      final command = HostCleanCommand(HostCleanInput(), deployer: deployer);
 
-      final output = await command.execute();
+      final output = await applyCommand(command);
 
       expect(output.exitCode, ExitCode.ok);
     });
@@ -296,10 +294,13 @@ void main() {
         workingDirectory: tempDir.path,
       );
 
-      await command.execute();
+      await applyCommand(command);
 
-      expect(agentFile.existsSync(), isFalse,
-      reason: 'iq host clean must remove repo-scoped agent');
+      expect(
+        agentFile.existsSync(),
+        isFalse,
+        reason: 'iq host clean must remove repo-scoped agent',
+      );
     });
 
     test('removes repo-scoped agent when invoked from nested subdir', () async {
@@ -319,20 +320,91 @@ void main() {
         workingDirectory: nestedDir.path,
       );
 
-      await command.execute();
+      await applyCommand(command);
 
       expect(agentFile.existsSync(), isFalse);
     });
 
-    test('does not fail if .github/agents/inquiry.agent.md does not exist',
-        () async {
-      final command = HostCleanCommand(
-        HostCleanInput(),
-        deployer: deployer,
-        workingDirectory: tempDir.path,
+    test(
+      'does not fail if .github/agents/inquiry.agent.md does not exist',
+      () async {
+        final command = HostCleanCommand(
+          HostCleanInput(),
+          deployer: deployer,
+          workingDirectory: tempDir.path,
+        );
+
+        await expectLater(applyCommand(command), completes);
+      },
+    );
+  });
+
+  // What `--plan` shows. `iq host get` deploys into whatever this machine
+  // happens to carry, which is exactly the kind of thing a user wants named
+  // before it happens: two assistants, one, or none look nothing alike.
+  group('under --plan', () {
+    void installFakeHost() =>
+        Directory(p.join(homeDir.path, '.fake')).createSync(recursive: true);
+
+    test('host get names one step per host it would deploy to', () async {
+      installFakeHost();
+
+      final previews = await previewCommand(
+        HostGetCommand(HostGetInput(), deployer: deployer),
       );
 
-      await expectLater(command.execute(), completes);
+      expect(previews.map((p) => p.verb).toList(), ['deploy']);
+      expect(previews.single.target, 'host fake');
+    });
+
+    test('host get plans nothing when no host is detected', () async {
+      final previews = await previewCommand(
+        HostGetCommand(HostGetInput(), deployer: deployer),
+      );
+
+      expect(previews, isEmpty);
+    });
+
+    test('host get touches nothing: no skill reaches the host', () async {
+      await previewCommand(
+        HostGetCommand(HostGetInput(host: 'fake'), deployer: deployer),
+      );
+
+      expect(
+        Directory(p.join(homeDir.path, '.fake', 'skills')).existsSync(),
+        isFalse,
+      );
+    });
+
+    test('host clean names the hosts and the repo-scoped agent', () async {
+      final previews = await previewCommand(
+        HostCleanCommand(
+          HostCleanInput(),
+          deployer: deployer,
+          workingDirectory: tempDir.path,
+        ),
+      );
+
+      expect(previews.map((p) => p.verb).toList(), ['clean', 'absent']);
+    });
+
+    test('host clean touches nothing: the deployment survives', () async {
+      deployer.deploy('fake');
+
+      await previewCommand(
+        HostCleanCommand(
+          HostCleanInput(),
+          deployer: deployer,
+          workingDirectory: tempDir.path,
+        ),
+      );
+
+      expect(
+        File(
+          p.join(homeDir.path, '.fake', 'skills', 'doc-read', 'SKILL.md'),
+        ).existsSync(),
+        isTrue,
+      );
     });
   });
 }

--- a/code/cli/test/implementation_start_test.dart
+++ b/code/cli/test/implementation_start_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:modular_cli_sdk/testing.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -28,7 +29,7 @@ void main() {
 
     test('creates the linked branch, scaffolds the cleanroom, enters ANALYZE',
         () async {
-      final out = await command('40').execute();
+      final out = await applyCommand(command('40'));
 
       expect(out.branch, '040-fix-login-timeout');
       expect(out.branchCreated, isTrue);
@@ -61,7 +62,7 @@ void main() {
         isFalse,
       );
 
-      final out = await command('40').execute();
+      final out = await applyCommand(command('40'));
 
       expect(out.initialized, isTrue);
       expect(
@@ -72,8 +73,8 @@ void main() {
 
     test('is idempotent: re-running lands on the same branch without error',
         () async {
-      await command('40').execute();
-      final second = await command('40').execute();
+      await applyCommand(command('40'));
+      final second = await applyCommand(command('40'));
 
       expect(second.branch, '040-fix-login-timeout');
       expect(second.branchCreated, isFalse);
@@ -88,7 +89,7 @@ void main() {
       );
 
       expect(
-        () => cmd.execute(),
+        () => applyCommand(cmd),
         throwsA(predicate((e) =>
             e.toString().contains('gh issue view') &&
             e.toString().contains('gh auth status'))),
@@ -102,6 +103,75 @@ void main() {
       final error = cmd.validate();
       expect(error, isNotNull);
       expect(error, contains('iq implementation start --issue 40'));
+    });
+
+    // What `--plan` shows. Opening a cycle creates a branch and writes a
+    // cleanroom into the user's repository, so the branch name derived from the
+    // issue title is the thing to see before it happens — a wrong slug is a
+    // cycle opened somewhere nobody asked for.
+    group('under --plan', () {
+      test('names the three steps in order', () async {
+        final previews = await previewCommand(command('40'));
+
+        expect(previews.map((p) => p.verb).toList(), [
+          'initialize',
+          'create',
+          'transition',
+        ]);
+      });
+
+      test(
+        'says the branch it would create and the cleanroom it would scaffold',
+        () async {
+          final previews = await previewCommand(command('40'));
+
+          expect(
+            previews.map((p) => p.target).toList(),
+            contains('branch 040-fix-login-timeout'),
+          );
+          expect(
+            previews.last.detail,
+            contains('cleanrooms/040-fix-login-timeout/analyze/'),
+          );
+        },
+      );
+
+      test('touches nothing: no branch, no workspace, no cleanroom', () async {
+        await previewCommand(command('40'));
+
+        final branch = _git(tempDir.path, [
+          'rev-parse',
+          '--abbrev-ref',
+          'HEAD',
+        ]).stdout.toString().trim();
+        expect(branch, isNot('040-fix-login-timeout'));
+        expect(
+          File(p.join(tempDir.path, '.inquiry', 'config.yaml')).existsSync(),
+          isFalse,
+        );
+        expect(
+          Directory(p.join(tempDir.path, 'cleanrooms')).existsSync(),
+          isFalse,
+        );
+      });
+
+      // The precondition fails before a single step is built, so no plan is
+      // ever shown for work that will not happen.
+      test('refuses to plan an issue GitHub cannot see', () async {
+        final cmd = ImplementationStartCommand(
+          ImplementationStartInput(
+            issue: '999',
+            workingDirectory: tempDir.path,
+          ),
+          assets: Assets(root: tempDir.path),
+          issueInfoProvider: (_, _) => null,
+        );
+
+        expect(
+          () => previewCommand(cmd),
+          throwsA(predicate((e) => e.toString().contains('gh issue view'))),
+        );
+      });
     });
   });
 }

--- a/code/cli/test/instruction_prompt_loader_test.dart
+++ b/code/cli/test/instruction_prompt_loader_test.dart
@@ -125,7 +125,7 @@ Ignored.
         equals(
           'Run iq doctor first and stop on any failed check.\n'
           'Verify the issue already exists with gh issue view.\n'
-          'Open the implementation with iq implementation start --issue NNN, which derives the NNN-slug branch, checks it out, scaffolds the cleanroom, and transitions to ANALYZE.\n'
+          'Open the implementation with iq implementation start --issue NNN --apply --autoapprove, which derives the NNN-slug branch, checks it out, scaffolds the cleanroom, and transitions to ANALYZE.\n'
           'Confirm iq fsm state reports ANALYZE for that issue.',
         ),
       );

--- a/code/cli/test/platform_ops_test.dart
+++ b/code/cli/test/platform_ops_test.dart
@@ -136,4 +136,20 @@ void main() {
       expect(ops.assetName, isNotEmpty);
     });
   });
+
+  // `iq host get` is a command now, so it refuses to act unless told which of
+  // --plan and --apply was meant. The post-install child has no terminal to be
+  // asked on, and the upgrade it belongs to was already approved — so it
+  // carries the approval rather than asking for a second one. Drop either flag
+  // and every upgrade reports a failed redeploy.
+  group('post-install arguments', () {
+    test('carry the approval the upgrade already took', () {
+      expect(postInstallArguments, [
+        'host',
+        'get',
+        '--apply',
+        '--autoapprove',
+      ]);
+    });
+  });
 }

--- a/code/cli/test/scaffold_test.dart
+++ b/code/cli/test/scaffold_test.dart
@@ -4,15 +4,43 @@ import 'package:test/test.dart';
 
 void main() {
   group('CLI scaffold', () {
-    test('responds to a registered command with exit code 0', () async {
+    test('responds to a registered query with exit code 0', () async {
       final cli = ModularCli();
-      cli.command<PingInput, PingOutput>(
+      cli.query<PingInput, PingOutput>(
         'ping',
-        (req) => PingCommand(PingInput.fromCliRequest(req)),
+        (req) => PingQuery(PingInput.fromCliRequest(req)),
         description: 'Ping test',
       );
 
       final code = await cli.run(['ping']);
+      expect(code, ExitCode.ok);
+    });
+
+    // A query answers on the spot; a command does not. The scaffold has to
+    // dispatch both kinds, and the difference between them is the whole point
+    // of registering them apart — so it belongs in the scaffold's own test.
+    test('refuses a registered command that names neither --plan nor --apply',
+        () async {
+      final cli = ModularCli();
+      cli.command<PingInput, PingOutput>(
+        'touch',
+        (req) => PingCommand(PingInput.fromCliRequest(req)),
+        description: 'Command test',
+      );
+
+      final code = await cli.run(['touch']);
+      expect(code, ExitCode.validationFailed);
+    });
+
+    test('runs a registered command under --plan', () async {
+      final cli = ModularCli();
+      cli.command<PingInput, PingOutput>(
+        'touch',
+        (req) => PingCommand(PingInput.fromCliRequest(req)),
+        description: 'Command test',
+      );
+
+      final code = await cli.run(['touch', '--plan']);
       expect(code, ExitCode.ok);
     });
 
@@ -25,7 +53,7 @@ void main() {
   });
 }
 
-// ─── Dummy command for scaffold validation ──────────────────────────────────
+// ─── Dummy routes for scaffold validation ───────────────────────────────────
 
 class PingInput extends Input {
   PingInput();
@@ -45,6 +73,18 @@ class PingOutput extends Output {
   int get exitCode => ExitCode.ok;
 }
 
+class PingQuery implements Query<PingInput, PingOutput> {
+  @override
+  final PingInput input;
+  PingQuery(this.input);
+
+  @override
+  String? validate() => null;
+
+  @override
+  Future<PingOutput> execute() async => PingOutput();
+}
+
 class PingCommand implements Command<PingInput, PingOutput> {
   @override
   final PingInput input;
@@ -54,5 +94,17 @@ class PingCommand implements Command<PingInput, PingOutput> {
   String? validate() => null;
 
   @override
-  Future<PingOutput> execute() async => PingOutput();
+  Future<List<Step>> steps() async => [PingStep()];
+
+  @override
+  PingOutput describe(Execution execution) => PingOutput();
+}
+
+class PingStep implements Step {
+  @override
+  Preview preview() => Preview(verb: 'ping', target: 'nothing at all');
+
+  @override
+  Future<Outcome> perform(StepContext context) async =>
+      Outcome(verb: 'ping', target: 'nothing at all');
 }

--- a/code/cli/test/uninstall_test.dart
+++ b/code/cli/test/uninstall_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:modular_cli_sdk/modular_cli_sdk.dart';
+import 'package:modular_cli_sdk/testing.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -74,10 +75,10 @@ void main() {
         platformOps: FakePlatformOps(),
       );
 
-      final output = await command.execute();
+      final output = await applyCommand(command);
 
       expect(output.exitCode, ExitCode.ok);
-      expect(output.message, contains('uninstalled'));
+      expect(output.toText(), contains('uninstalled'));
 
       // Hosts should be cleaned
       expect(
@@ -97,7 +98,7 @@ void main() {
         platformOps: FakePlatformOps(),
       );
 
-      final output = await command.execute();
+      final output = await applyCommand(command);
       expect(output.exitCode, ExitCode.ok);
     });
 
@@ -115,7 +116,7 @@ void main() {
         platformOps: ops,
       );
 
-      await command.execute();
+      await applyCommand(command);
 
       expect(ops.calls, contains('getEnvVariable(PATH)'));
       final expectedNew = '$otherA$sep$otherB';
@@ -137,7 +138,7 @@ void main() {
         platformOps: ops,
       );
 
-      await command.execute();
+      await applyCommand(command);
 
       expect(ops.calls, contains('getEnvVariable(PATH)'));
       expect(
@@ -155,7 +156,7 @@ void main() {
         platformOps: ops,
       );
 
-      await command.execute();
+      await applyCommand(command);
 
       expect(ops.calls, contains('scheduleDeletion(${tempDir.path})'));
     });
@@ -175,7 +176,7 @@ void main() {
         platformOps: FakePlatformOps(),
       );
 
-      await command.execute();
+      await applyCommand(command);
 
       expect(agentFile.existsSync(), isFalse,
           reason: 'iq uninstall must remove repo-scoped agent');
@@ -190,7 +191,105 @@ void main() {
         platformOps: FakePlatformOps(),
       );
 
-      await expectLater(command.execute(), completes);
+      await expectLater(applyCommand(command), completes);
+    });
+  });
+
+  // What `--plan` shows. These are the assertions the old `execute()` could not
+  // make: that the order is a fact about the command rather than a comment, and
+  // that planning an uninstall uninstalls nothing.
+  group('UninstallCommand under --plan', () {
+    test('names the four steps, hosts first and the directory last', () async {
+      final previews = await previewCommand(
+        UninstallCommand(
+          UninstallInput(installDir: tempDir.path),
+          deployer: deployer,
+          workingDirectory: tempDir.path,
+          platformOps: FakePlatformOps(),
+        ),
+      );
+
+      expect(
+        previews.map((p) => p.verb).toList(),
+        ['clean', 'absent', 'unset', 'delete'],
+      );
+    });
+
+    // PATH comes off before the directory is scheduled for deletion, so there
+    // is never a window in which the entry points at a directory on its way
+    // out.
+    test('unsets PATH before it deletes the installation', () async {
+      final previews = await previewCommand(
+        UninstallCommand(
+          UninstallInput(installDir: tempDir.path),
+          deployer: deployer,
+          workingDirectory: tempDir.path,
+          platformOps: FakePlatformOps(),
+        ),
+      );
+
+      expect(
+        previews.indexWhere((p) => p.verb == 'unset'),
+        lessThan(previews.indexWhere((p) => p.verb == 'delete')),
+      );
+    });
+
+    test('says the installation directory it would delete', () async {
+      final previews = await previewCommand(
+        UninstallCommand(
+          UninstallInput(installDir: tempDir.path),
+          deployer: deployer,
+          workingDirectory: tempDir.path,
+          platformOps: FakePlatformOps(),
+        ),
+      );
+
+      final delete = previews.firstWhere((p) => p.verb == 'delete');
+      expect(delete.target, tempDir.path);
+      expect(delete.detail, contains('not touched'));
+    });
+
+    test('touches nothing: the deployed host survives the plan', () async {
+      deployer.deploy('fake');
+      final ops = FakePlatformOps();
+
+      await previewCommand(
+        UninstallCommand(
+          UninstallInput(installDir: tempDir.path),
+          deployer: deployer,
+          workingDirectory: tempDir.path,
+          platformOps: ops,
+        ),
+      );
+
+      expect(
+        File(
+          p.join(homeDir.path, '.fake', 'skills', 'doc-read', 'SKILL.md'),
+        ).existsSync(),
+        isTrue,
+      );
+      expect(ops.calls, isEmpty);
+    });
+
+    test('reports the repo-scoped agent as present when it is there', () async {
+      final agentFile = File(
+        p.join(tempDir.path, '.github', 'agents', 'inquiry.agent.md'),
+      );
+      agentFile.parent.createSync(recursive: true);
+      agentFile.writeAsStringSync('# APE Agent');
+
+      final previews = await previewCommand(
+        UninstallCommand(
+          UninstallInput(installDir: tempDir.path),
+          deployer: deployer,
+          workingDirectory: tempDir.path,
+          platformOps: FakePlatformOps(),
+        ),
+      );
+
+      expect(previews.map((p) => p.verb).toList(),
+          ['clean', 'remove', 'unset', 'delete']);
+      expect(agentFile.existsSync(), isTrue);
     });
   });
 }

--- a/code/cli/test/upgrade_test.dart
+++ b/code/cli/test/upgrade_test.dart
@@ -1,9 +1,15 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:modular_cli_sdk/testing.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'package:inquiry_cli/modules/global/commands/upgrade.dart';
 import 'package:inquiry_cli/modules/global/commands/version.dart';
+
+import 'platform_ops_test.dart' show FakePlatformOps;
 
 void main() {
   group('inquiry upgrade', () {
@@ -14,19 +20,18 @@ void main() {
 
     test('UpgradeOutput reports no upgrade when already latest', () {
       final output = UpgradeOutput(
-        message: 'Already on the latest version',
         previousVersion: inquiryVersion,
         newVersion: inquiryVersion,
         upgraded: false,
+        reason: 'Already on the latest version',
       );
       expect(output.exitCode, 0);
       expect(output.upgraded, isFalse);
-      expect(output.toJson()['message'], contains('latest'));
+      expect(output.toJson()['reason'], contains('latest'));
     });
 
     test('UpgradeOutput reports successful upgrade', () {
       final output = UpgradeOutput(
-        message: 'Upgraded from 0.0.1 to 0.0.2',
         previousVersion: '0.0.1',
         newVersion: '0.0.2',
         upgraded: true,
@@ -39,7 +44,6 @@ void main() {
 
     test('toText() returns checkmark message when upgraded', () {
       final output = UpgradeOutput(
-        message: 'Upgraded from 0.0.1 to 0.0.2',
         previousVersion: '0.0.1',
         newVersion: '0.0.2',
         upgraded: true,
@@ -51,12 +55,26 @@ void main() {
 
     test('toText() returns plain message when not upgraded', () {
       final output = UpgradeOutput(
-        message: 'Already on the latest version',
         previousVersion: '0.0.2',
         newVersion: '0.0.2',
         upgraded: false,
+        reason: 'Already on the latest version',
       );
       expect(output.toText(), equals('Already on the latest version'));
+    });
+
+    // The upgrade succeeded; only the redeploy did not. Saying so is the whole
+    // point of `deployed` being separate from `upgraded` — a failed redeploy
+    // must not read as a failed upgrade.
+    test('toText() points at `iq host get` when the redeploy was skipped', () {
+      final output = UpgradeOutput(
+        previousVersion: '0.0.1',
+        newVersion: '0.0.2',
+        upgraded: true,
+        deployed: false,
+      );
+      expect(output.toText(), contains('✓ Upgraded'));
+      expect(output.toText(), contains('iq host get'));
     });
   });
 
@@ -103,4 +121,231 @@ void main() {
       expect(lines, ['No AI coding host found on this machine']);
     });
   });
+
+  // What `--plan` shows. An upgrade replaces the binary the user is running
+  // from, so the version it would move to, the asset it would fetch and the URL
+  // it would fetch it from are exactly what a person needs before approving.
+  group('inquiry upgrade under --plan', () {
+    UpgradeCommand upgradeTo(
+      String tag, {
+      required _FakeReleasesClient client,
+      FakePlatformOps? ops,
+      Downloader? download,
+    }) => UpgradeCommand(
+      UpgradeInput(installDir: '/fake/dir'),
+      platformOps: ops ?? FakePlatformOps(),
+      httpClientOverride: client,
+      download: download ?? (url, destination) async {},
+      progress: _NullSink(),
+      runningExecutable: '/fake/dir/bin/never-touched',
+    );
+
+    test('names the replacement, with version, asset and URL', () async {
+      final client = _FakeReleasesClient(
+        tag: 'v9.9.9',
+        assets: {'ape-fake.zip': 'https://example.test/ape-fake.zip'},
+      );
+
+      final previews = await previewCommand(upgradeTo('v9.9.9', client: client));
+
+      expect(previews.map((p) => p.verb).toList(), ['replace', 'deploy']);
+      expect(previews.first.detail, contains('$inquiryVersion → 9.9.9'));
+      expect(previews.first.detail, contains('ape-fake.zip'));
+      expect(previews.first.detail, contains('https://example.test/'));
+    });
+
+    // The honesty of the plan rests on this: the version, asset and URL a
+    // person approves are the ones downloaded. A second lookup at perform time
+    // could resolve a release published in between.
+    test('asks the releases API once, when the plan is built', () async {
+      final client = _FakeReleasesClient(
+        tag: 'v9.9.9',
+        assets: {'ape-fake.zip': 'https://example.test/ape-fake.zip'},
+      );
+
+      await previewCommand(upgradeTo('v9.9.9', client: client));
+
+      expect(client.calls, 1);
+    });
+
+    test('touches nothing: no download, no extraction', () async {
+      final ops = FakePlatformOps();
+      var downloads = 0;
+      final client = _FakeReleasesClient(
+        tag: 'v9.9.9',
+        assets: {'ape-fake.zip': 'https://example.test/ape-fake.zip'},
+      );
+
+      await previewCommand(
+        upgradeTo(
+          'v9.9.9',
+          client: client,
+          ops: ops,
+          download: (url, destination) async => downloads++,
+        ),
+      );
+
+      expect(downloads, 0);
+      expect(ops.calls, isEmpty);
+    });
+
+    // Nothing to upgrade to is an answer, not a failure: no steps, and a
+    // reason.
+    test('plans nothing when already on the latest version', () async {
+      final client = _FakeReleasesClient(
+        tag: 'v$inquiryVersion',
+        assets: {'ape-fake.zip': 'https://example.test/ape-fake.zip'},
+      );
+      final command = upgradeTo('v$inquiryVersion', client: client);
+
+      expect(await previewCommand(command), isEmpty);
+
+      final output = await applyCommand(command);
+      expect(output.upgraded, isFalse);
+      expect(output.toText(), contains('Already on the latest version'));
+    });
+
+    test('refuses a release that carries no asset for this platform', () async {
+      final client = _FakeReleasesClient(
+        tag: 'v9.9.9',
+        assets: {'some-other-platform.zip': 'https://example.test/other.zip'},
+      );
+
+      expect(
+        () => previewCommand(upgradeTo('v9.9.9', client: client)),
+        throwsA(
+          predicate((e) => e.toString().contains('ape-fake.zip')),
+        ),
+      );
+    });
+  });
+
+  group('inquiry upgrade under --apply', () {
+    test('reports the redeploy separately from the upgrade itself', () async {
+      // A real directory with a real binary in it: on Windows the step moves
+      // the running executable aside before extracting over it, and
+      // `runningExecutable` is injected precisely so that binary is this
+      // throwaway file and never the Dart VM running the suite.
+      final installDir = Directory.systemTemp.createTempSync('iq_upgrade_');
+      addTearDown(() {
+        if (installDir.existsSync()) installDir.deleteSync(recursive: true);
+      });
+      final binary = File(p.join(installDir.path, 'bin', 'inquiry.exe'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('the outgoing binary');
+
+      final ops = FakePlatformOps()
+        ..postInstallResult = ProcessResult(0, 1, '', 'no host');
+      final client = _FakeReleasesClient(
+        tag: 'v9.9.9',
+        assets: {'ape-fake.zip': 'https://example.test/ape-fake.zip'},
+      );
+
+      final output = await applyCommand(
+        UpgradeCommand(
+          UpgradeInput(installDir: installDir.path),
+          platformOps: ops,
+          httpClientOverride: client,
+          download: (url, destination) async =>
+              File(destination).writeAsStringSync('archive'),
+          progress: _NullSink(),
+          runningExecutable: binary.path,
+        ),
+      );
+
+      expect(output.upgraded, isTrue);
+      expect(output.newVersion, '9.9.9');
+      expect(output.deployed, isFalse, reason: 'the child exited non-zero');
+      expect(output.toText(), contains('iq host get'));
+    });
+  });
+}
+
+/// Discards the steps' running commentary, which is stderr in production.
+class _NullSink implements IOSink {
+  @override
+  void writeln([Object? object = '']) {}
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Serves one canned GitHub releases payload, and counts how often it is asked.
+class _FakeReleasesClient implements HttpClient {
+  _FakeReleasesClient({required this.tag, required this.assets});
+
+  final String tag;
+  final Map<String, String> assets;
+
+  /// How many times the releases API was reached. The plan is only as honest
+  /// as this number is 1.
+  int calls = 0;
+
+  String get _body => jsonEncode({
+    'tag_name': tag,
+    'assets': [
+      for (final entry in assets.entries)
+        {'name': entry.key, 'browser_download_url': entry.value},
+    ],
+  });
+
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) async {
+    calls++;
+    return _FakeRequest(_FakeResponse(_body));
+  }
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeRequest implements HttpClientRequest {
+  _FakeRequest(this._response);
+
+  final HttpClientResponse _response;
+
+  @override
+  final HttpHeaders headers = _FakeHeaders();
+
+  @override
+  Future<HttpClientResponse> close() async => _response;
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeHeaders implements HttpHeaders {
+  @override
+  void set(String name, Object value, {bool preserveHeaderCase = false}) {}
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeResponse extends Stream<List<int>> implements HttpClientResponse {
+  _FakeResponse(this.body);
+
+  final String body;
+
+  @override
+  int get statusCode => 200;
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void Function(List<int> event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) => Stream<List<int>>.value(utf8.encode(body)).listen(
+    onData,
+    onError: onError,
+    onDone: onDone,
+    cancelOnError: cancelOnError,
+  );
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.24.1</span>
+      <span class="badge">v0.25.0</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">
@@ -98,8 +98,11 @@
       <pre class="quickstart"><span class="comment"># verify prerequisites (inquiry, git, gh, gh auth)</span>
 <span class="cmd">iq doctor</span>
 
-<span class="comment"># deploy Inquiry skills to your AI host (OpenCode or Copilot)</span>
-<span class="cmd">iq host get</span>
+<span class="comment"># see what deploying to your AI host would change — nothing is touched</span>
+<span class="cmd">iq host get --plan</span>
+
+<span class="comment"># show it, ask for approval, then do it</span>
+<span class="cmd">iq host get --apply</span>
 
 <span class="comment"># scaffold .inquiry/ in your repo</span>
 <span class="cmd">cd your-repo &amp;&amp; iq init</span></pre>
@@ -111,12 +114,14 @@
         <li class="cmd"><code>iq</code><span class="desc">Print ASCII banner + version</span></li>
         <li class="cmd"><code>iq init</code><span class="desc">Scaffold repo-scoped Inquiry files (<code>.inquiry/config.yaml</code>, ignore rules, agent)</span></li>
         <li class="cmd"><code>iq doctor</code><span class="desc">Verify prerequisites</span></li>
-        <li class="cmd"><code>iq host get</code><span class="desc">Deploy skills to every AI host detected</span></li>
+        <li class="cmd"><code>iq host get</code><span class="desc">Deploy skills to every AI host detected — <code>--plan</code>/<code>--apply</code></span></li>
+        <li class="cmd"><code>iq implementation start</code><span class="desc">Open a cycle: branch, cleanroom, ANALYZE — <code>--plan</code>/<code>--apply</code></span></li>
         <li class="cmd"><code>iq fsm transition</code><span class="desc">Execute a deterministic FSM transition</span></li>
         <li class="cmd"><code>iq fsm state</code><span class="desc">Show current FSM state as JSON</span></li>
         <li class="cmd"><code>iq ape prompt</code><span class="desc">Assemble sub-agent prompt from state</span></li>
-        <li class="cmd"><code>iq upgrade</code><span class="desc">Update to the latest release</span></li>
+        <li class="cmd"><code>iq upgrade</code><span class="desc">Update to the latest release — <code>--plan</code>/<code>--apply</code></span></li>
       </ul>
+      <p class="see-all">Commands that install, remove, or write into your repository refuse to act until you say which of <code>--plan</code> (show what would change) and <code>--apply</code> (show it, ask, then do it) you meant. Neither is the default.</p>
       <p class="see-all">13 commands total — see <a href="https://github.com/ccisnedev/inquiry#available-commands">the full table on GitHub</a>.</p>
     </section>
 

--- a/code/site/install.ps1
+++ b/code/site/install.ps1
@@ -9,7 +9,7 @@
 #   3. Extracts to $env:LOCALAPPDATA\inquiry\
 #   4. Adds inquiry\bin\ to the user PATH
 #   5. Creates `iq.cmd` batch shim
-#   6. Runs `inquiry host get` for the active host (OpenCode or Copilot)
+#   6. Runs `inquiry host get --apply --autoapprove` for the active host (OpenCode or Copilot)
 #   7. Verifies with `inquiry version`
 
 $ErrorActionPreference = 'Stop'
@@ -86,7 +86,9 @@ if ($userPath -notlike "*$binDir*") {
 # ─── Deploy and verify ───────────────────────────────────────────────────────
 
 Write-Host '>>> Deploying Inquiry skills to the active host...'
-& (Join-Path $binDir 'inquiry.exe') host get
+# `--apply --autoapprove`: the user approved this by running the installer,
+# and there is no terminal to ask on inside `irm ... | iex`.
+& (Join-Path $binDir 'inquiry.exe') host get --apply --autoapprove
 
 Write-Host '>>> Verifying installation...'
 $versionOutput = & (Join-Path $binDir 'inquiry.exe') version

--- a/code/site/install.sh
+++ b/code/site/install.sh
@@ -10,7 +10,7 @@
 #   3. Extracts to ~/.inquiry/
 #   4. Symlinks to ~/.local/bin (XDG standard, in default PATH)
 #   5. Symlinks `iq` alias
-#   6. Runs `inquiry host get` for the active host (OpenCode or Copilot)
+#   6. Runs `inquiry host get --apply --autoapprove` for every detected host
 #   7. Verifies with `inquiry version`
 
 set -euo pipefail
@@ -113,7 +113,9 @@ done
 # ─── Deploy and verify ───────────────────────────────────────────────────────
 
 echo ">>> Deploying Inquiry skills to the active host..."
-"$BIN_DIR/inquiry" host get
+# `--apply --autoapprove`: the user approved this by running the installer,
+# and there is no terminal to ask on inside `curl ... | bash`.
+"$BIN_DIR/inquiry" host get --apply --autoapprove
 
 echo ">>> Verifying installation..."
 VERSION_OUTPUT=$("$BIN_DIR/inquiry" version)

--- a/code/vscode/CHANGELOG.md
+++ b/code/vscode/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.4.2]
+
+### Fixed
+- **The post-install deploy would have silently stopped deploying anything.**
+  From CLI 0.25.0, `iq host get` writes into third-party tools' own directories
+  and so refuses to act until told which of `--plan` and `--apply` was meant.
+  The extension ran a bare `host get`, whose usage error was swallowed by the
+  surrounding `catch` — the CLI would install, no agent or skill would be
+  deployed, and the notification would still report success. It now passes
+  `--apply --autoapprove`: the user approved this by installing the extension,
+  and a progress notification is not somewhere an approval can be taken. A test
+  pins the exact argument list, since the failure mode here is silence.
+
 ## [0.4.1] - 2026-06-01
 
 ### Fixed

--- a/code/vscode/docs/ape_vscode_extension.md
+++ b/code/vscode/docs/ape_vscode_extension.md
@@ -82,7 +82,7 @@ inquiry-vscode/
 │   │   ├── mutations.ts         ← add mutation note
 │   │   ├── doctor.ts            ← ape.doctor
 │   │   ├── install.ts           ← install/update CLI
-│   │   ├── installer.ts         ← install/update CLI + `inquiry host get`
+│   │   ├── installer.ts         ← install/update CLI + `host get --apply --autoapprove`
 │   │   └── state.ts             ← ape state transition wrapper
 │   │
 │   ├── views/                   ← Sidebar panels

--- a/code/vscode/package.json
+++ b/code/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "inquiry",
   "displayName": "Inquiry — Analyze. Plan. Execute.",
   "publisher": "ccisnedev",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Structured AI-aided development for GitHub Copilot.",
   "license": "MIT",
   "icon": "assets/icon.png",

--- a/code/vscode/src/installer.ts
+++ b/code/vscode/src/installer.ts
@@ -254,10 +254,17 @@ export async function installInquiryCli(deps?: Partial<InstallerDeps>): Promise<
       }
 
       // 6. Deploy to active host
+      //
+      // `--apply --autoapprove`: `host get` writes into third-party tools' own
+      // directories, so the CLI refuses to act until told which of --plan and
+      // --apply was meant. The user approved this by installing the extension,
+      // and a progress notification is not somewhere an approval can be taken.
+      // Without the flags the child exits with a usage error that the catch
+      // below swallows — CLI installed, nothing deployed, nothing said.
       progress.report({ message: 'Deploying to active host...' });
       const binaryPath = path.join(binDir, platform === 'win32' ? 'inquiry.exe' : 'inquiry');
       try {
-        await execFileFn(binaryPath, ['host', 'get']);
+        await execFileFn(binaryPath, ['host', 'get', '--apply', '--autoapprove']);
       } catch { /* non-fatal */ }
 
       // 7. Verify

--- a/code/vscode/test/unit/installer.test.ts
+++ b/code/vscode/test/unit/installer.test.ts
@@ -218,4 +218,21 @@ describe('installInquiryCli', () => {
     assert.ok(commands.some(c => c.includes('host') && c.includes('get')));
     assert.ok(commands.some(c => c.includes('version')));
   });
+
+  // `host get` changes things outside the CLI, so it refuses to act unless
+  // told which of --plan and --apply was meant. The deploy is wrapped in a
+  // catch, so getting this wrong is silent: the CLI installs, nothing is
+  // deployed, and the user is told the install succeeded.
+  it('deploys with --apply --autoapprove, not a bare `host get`', async () => {
+    const commands: string[][] = [];
+    const deps: InstallerDeps = {
+      ...baseDeps('win32'),
+      execFile: async (_cmd, args) => { commands.push(args); return 'v1.0.0'; },
+    };
+
+    await installInquiryCli(deps);
+
+    const deploy = commands.find(c => c.includes('host') && c.includes('get'));
+    assert.deepStrictEqual(deploy, ['host', 'get', '--apply', '--autoapprove']);
+  });
 });

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# ADR 0001: Record Architecture Decisions
+
+**Status:** Accepted
+
+## Context
+
+We need to record architectural decisions made on this project so that future
+contributors understand why the system is structured the way it is.
+
+## Decision
+
+We will use Architecture Decision Records (ADRs) stored in `docs/adr/` to
+document significant architectural decisions.
+
+## Consequences
+
+- Every significant architectural choice gets a short document.
+- ADRs are numbered sequentially and never deleted (superseded ones are marked as such).
+- The record grows as the project evolves.

--- a/docs/adr/0002-a-query-may-write-what-the-cli-itself-owns.md
+++ b/docs/adr/0002-a-query-may-write-what-the-cli-itself-owns.md
@@ -1,0 +1,119 @@
+# ADR 0002: A query may write what the CLI itself owns
+
+**Status:** Accepted
+
+**Date:** 2026-08-13
+
+## Context
+
+`modular_cli_sdk` 0.4.0 splits a CLI's routes in two, and the split is
+structural rather than an annotation:
+
+- a **`Query`** reads and answers. Its contract says, in as many words,
+  *"Must change nothing"*
+- a **`Command`** changes something, as an ordered list of steps that state what
+  they would do before anything runs. The framework declares `--plan`,
+  `--apply` and `--autoapprove` on every one of them, and refuses a bare
+  invocation: neither flag is a default
+
+The two share no method, so a route cannot be both.
+
+Registering every route that writes a byte as a `Command` would put
+`--plan` / `--apply` on `iq fsm transition`, `iq ape transition`, `iq ape
+prompt` and `iq init`. Those are the operations a person runs continuously
+while driving a cycle. Asking them to approve each one would make the
+convention noise, and noise is what gets `--autoapprove` pasted into every
+invocation until the approval means nothing.
+
+The alternative — registering them as queries and saying nothing — leaves the
+next reader with three queries that write, a contract that says they must not,
+and no way to tell a deliberate decision from a mistake.
+
+## Decision
+
+**A route is a `Command` when it changes the user's work or their machine. A
+route that only changes state the CLI itself owns is a `Query`.**
+
+"State the CLI itself owns" is not a judgement call here. Inquiry declares it,
+in code, in `lib/src/gitignore.dart`:
+
+```dart
+const inquiryGitignoreEntries = <String>[
+  '.inquiry/',
+  // The cleanroom is a per-cycle working area, not documentation: the durable
+  // artifacts of a cycle are the published issue, the code and the tests. The
+  // whole directory is local — previously only `.iq.state.yaml` was ignored,
+  // which left diagnosis.md / plan.md accumulating in the repo.
+  'cleanrooms/',
+];
+```
+
+`iq init` writes those two entries into the target repository's `.gitignore`.
+Everything under them is, by the CLI's own declaration, derived and local: it
+is reproducible from the issue, the code and the tests, and it is never
+committed.
+
+So the test is mechanical rather than a matter of taste: **if the CLI git-ignores
+it in the repositories it serves, writing it does not make a route a command.**
+
+### The five commands
+
+`iq upgrade`, `iq uninstall`, `iq host get`, `iq host clean`,
+`iq implementation start`.
+
+Each changes something outside that boundary: the installed binary, the PATH,
+the agent and skills deployed into a host's global directory, or a git branch
+in the user's repository. `iq implementation start` is the clearest case — it
+creates and checks out a branch, and there is no way today to ask it what it
+would do first.
+
+### The queries that write, and why
+
+| Route | Writes | Why it is still a query |
+| --- | --- | --- |
+| `iq fsm transition` | `.iq.state.yaml`, and cleanroom scaffolds through its effects | Both are under `cleanrooms/`, which the CLI git-ignores in every repository it serves |
+| `iq ape transition` | `.iq.state.yaml` | Cycle-local runtime state, and the `.gitignore` says so: *"cycle-local runtime state is derived, never tracked"* |
+| `iq ape prompt` | `cleanrooms/<cycle>/run_trace.yaml` | Same boundary. Whether assembling a prompt should record telemetry at all is a separate question, tracked apart from this decision |
+| `iq init` | the workspace, and two entries in the repository's `.gitignore` | It is configuration, not the user's work. It is also the command that *establishes* the boundary the rest of this rule depends on |
+
+**This repository is the exception that proves the boundary.** `cleanrooms/` is
+versioned *here*, and only here, because Inquiry's own cycles are research
+artifacts worth keeping. Its `.gitignore` says so out loud. In every other
+repository the CLI serves, the directory it writes into is ignored — which is
+what the rule turns on.
+
+## Consequences
+
+**Easier**
+
+- Driving a cycle stays direct. `iq fsm transition --event ...` needs no flag,
+  and the approval that `--apply` asks for keeps meaning something because it is
+  only asked where something outside the CLI's own workspace changes
+- The five commands gain a preview of an operation that had none.
+  `iq implementation start --issue N --plan` will say which branch it would
+  create and which cleanroom it would scaffold, before it does either
+- The migration is small: nine routes become queries with a one-word change,
+  and five become commands
+
+**Harder**
+
+- **Three queries write, and the SDK's contract says they must not.** That is a
+  deliberate divergence, and this record is the only thing standing between it
+  and someone "fixing" it. The `Query` doc comment is the framework's general
+  rule; this is Inquiry's reading of it, and the boundary that makes the reading
+  safe is the one the CLI itself declares
+- A route that starts inside the boundary and grows outside it has to be
+  reclassified, and that is a breaking change for whoever invokes it. The rule
+  tells you when: the day it writes something the CLI does not git-ignore
+
+**Deliberately left for later**
+
+- **The FSM's effects are not steps.** `effect_executor.dart` already has the
+  shape — named, discrete operations dispatched by name, with `executed.add(...)`
+  keeping a list of what ran. What it lacks is the other half: saying what it
+  would do before doing it. Converting them buys nothing while `fsm transition`
+  is a query, because nothing would compare the claim against the report. The
+  day transitions become commands, this is where to start
+- **Whether `iq ape prompt` should record a trace at all.** It is a query either
+  way under this rule; the open question is one of cohesion, and it is tracked
+  separately

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,9 +214,12 @@ SKILL.md files are **shared across hosts** (same SKILL.md for Copilot, Claude, e
 ## Host deployment model
 
 The command surface is `iq host get`; the operational model is host-bound.
+It deploys into third-party tools' own directories, so it is a `Command`: it
+says what it would deploy and takes approval before it does
+(`--plan` / `--apply`).
 
 ```
-iq host get
+iq host get --apply
     │
     ├── Reads bundled assets/ from alongside the inquiry binary
   ├── Cleans ~/.copilot/skills/  (idempotent reset)
@@ -270,3 +273,21 @@ A complete APE cycle from issue to merge:
 | **Single host until MVP** | Copilot only (D20) | Prove methodology on one tool before fragmenting |
 | **Prompt delivery is explicit** | `iq ape prompt` prints identity + contract + context | The effective prompt stays inspectable; no hidden glue in standard APE YAMLs |
 | **EVOLUTION is opt-in** | config.yaml flag | Self-modification is powerful but must be conscious |
+| **Queries answer, commands plan** | A route that reaches outside the CLI's own files is registered as a `Command` and takes `--plan`/`--apply`; everything else is a `Query` ([ADR 0002](adr/0002-a-query-may-write-what-the-cli-itself-owns.md)) | The kind is a fact about the registration, not a comment — a query cannot be given the flags and a command cannot skip them |
+
+## What the CLI is built on
+
+The CLI is a Dart package (`code/cli/`) assembled from three of its own
+dependencies, each owning one layer of the request path:
+
+| Package | Owns | Why it is separate |
+|---|---|---|
+| [`cli_router`](https://pub.dev/packages/cli_router) | Parsing `argv` into a routed request: segments, flags, two-phase dispatch of root routes vs mounted modules | Routing is not Inquiry-specific; the FSM has no opinion about how a flag is spelled |
+| [`modular_cli_sdk`](https://pub.dev/packages/modular_cli_sdk) | The shape of a route — `Input`, `Output`, `Query`, `Command`, the module builder, `--json`/`--quiet`, exit codes, and the approval gate between `--plan` and `--apply` | Every Inquiry route has the same lifecycle; describing it once is what keeps `iq host get` and `iq upgrade` from each inventing their own idea of "would change" |
+| [`preview_executor`](https://pub.dev/packages/preview_executor) | Running a command's steps: previewing them, performing them, and checking that what happened is what was announced | Reached only through `modular_cli_sdk` — a command that could reach the executor directly could run steps with no plan shown and no approval taken, which is the one thing the arrangement exists to prevent |
+
+A command declares an ordered list of steps; each step says what it would do
+(`preview()`) and does it (`perform()`). Under `--apply` the executor previews
+each step again immediately before running it and compares — so what a person
+approved and what the run did are held together by the engine rather than by
+everyone remembering.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -236,11 +236,19 @@ whole manual bootstrap (slug + branch + cleanroom + transition) into one explici
 command. It is the template the remaining stages migrate toward — incrementally,
 each stage keeping its old command working until its module lands.
 
-Two principles this direction locks in (see the `mejora-ux` requisition):
+Three principles this direction locks in (see the `mejora-ux` requisition):
 - **Every mechanical process is an `iq` command**, never an instruction that has
   the model run `git`/`mkdir`/write scaffold by hand.
 - **Commands are not flow-aware**: they do their job and report it; they do not
   print a "next step" that would bias what the user does next.
+- **Each new route declares which kind it is.** A route that reaches outside the
+  files the CLI itself owns is a `Command` — it names its steps and takes
+  approval (`--plan` / `--apply`); everything else is a `Query` and answers on
+  the spot. The rule for telling them apart is in
+  [ADR 0002](adr/0002-a-query-may-write-what-the-cli-itself-owns.md): *if the
+  CLI git-ignores it in the repositories it serves, writing it does not make a
+  route a command.* Most stage verbs will be queries — `iq plan check` reads a
+  gate, `iq analyze skill` prints an instruction.
 
 ## How this roadmap is updated
 

--- a/docs/spec/cli-as-api.md
+++ b/docs/spec/cli-as-api.md
@@ -72,16 +72,21 @@ The current Inquiry CLI already enforces the runtime FSM and deployment operatio
 
 ### Existing
 
-| Command | Description |
-|---------|-------------|
-| `iq init` | Initialize Inquiry in a repo (`.inquiry/` runtime files) |
-| `iq doctor` | Verify prerequisites and environment readiness |
-| `iq host get` | Deploy skills to the active host |
-| `iq host clean` | Remove deployed skills from all known hosts |
-| `iq fsm transition --event <e>` | Execute a declared FSM transition |
-| `iq upgrade` | Upgrade CLI binary |
-| `iq version` | Show version |
-| `iq uninstall` | Remove Inquiry completely |
+Routes marked **command** change something outside the CLI's own files and take
+`--plan` / `--apply`; the rest answer on the spot. The line between the two is
+drawn in [ADR 0002](../adr/0002-a-query-may-write-what-the-cli-itself-owns.md).
+
+| Command | Description | Kind |
+|---------|-------------|------|
+| `iq init` | Initialize Inquiry in a repo (`.inquiry/` runtime files) | query |
+| `iq doctor` | Verify prerequisites and environment readiness | query |
+| `iq host get` | Deploy skills to every detected host | command |
+| `iq host clean` | Remove deployed skills from all known hosts | command |
+| `iq fsm transition --event <e>` | Execute a declared FSM transition | query |
+| `iq implementation start --issue <N>` | Open a cycle: branch, cleanroom, ANALYZE | command |
+| `iq upgrade` | Upgrade CLI binary | command |
+| `iq version` | Show version | query |
+| `iq uninstall` | Remove Inquiry completely | command |
 
 ### Planned
 


### PR DESCRIPTION
Brings the query/command separation of `modular_cli_sdk` 0.4 to Inquiry, taking
the lessons from the same migration in MACSS.

## The rule

From [ADR 0002](docs/adr/0002-a-query-may-write-what-the-cli-itself-owns.md):
**if the CLI git-ignores it in the repositories it serves, writing it does not
make a route a command.**

That is what keeps `iq fsm transition` a query even though it writes
`.iq.state.yaml`, and what makes these five commands:

| Route | Why it is a command |
|---|---|
| `iq upgrade` | replaces the binary the user is running from |
| `iq uninstall` | removes it, and takes PATH with it |
| `iq host get` | writes into third-party tools' own directories |
| `iq host clean` | removes what it wrote there |
| `iq implementation start` | creates a branch and a cleanroom in the user's repository |

Everything else answers on the spot, and is now **refused** `--plan` and
`--apply` rather than quietly ignoring them.

## Breaking

`iq host get` on its own is now a usage error naming both options. Every
script, alias, or agent instruction that invokes one of the five must name a
mode. All of Inquiry's own were updated in this PR: the three installers, the
post-upgrade redeploy, `iq doctor`'s remediation hints, the branch-policy error
and `inquiry-start.md`.

The one that would have bitten silently: the post-install child that redeploys
hosts after an upgrade runs the *freshly written* binary, so without a mode
every upgrade would have reported a failed redeploy. Both platforms now share
one named argument list, pinned by a test.

## What the split bought beyond the gate

- **Orderings that were comments are now lists a test reads.** `uninstall`
  takes PATH off before scheduling deletion, and cleans the hosts first, while
  the assets they were deployed from are still there.
- **`upgrade` asks the releases API once, at plan time.** The version, asset
  and URL a person approves are the ones downloaded.
- **`implementation start` reads the issue title once, before the plan.** The
  branch approved is the branch created.
- **Ollama configuration left `host get`** and moved behind
  `--configure-ollama` — it shells out to `ollama create`, which is slow and
  blocks when the daemon is down. An optimization, not part of installing a
  CLI, and now a named step rather than a surprise.

## Tests

535 pass, up from 510. The 25 new ones are what `execute()` could not express:
that a plan names its steps in order, and that planning changes nothing.

Every commit was verified to analyze and test clean on its own.
