### PR TITLE
Stop cleanup from deciding whether the suite is green

### DIFF
--- a/code/vscode/CHANGELOG.md
+++ b/code/vscode/CHANGELOG.md
@@ -13,6 +13,26 @@
   and a progress notification is not somewhere an approval can be taken. A test
   pins the exact argument list, since the failure mode here is silence.
 
+- **The extension had been unpublishable for a month, and three tests had
+  stopped running** (#308). The Windows integration job failed in an
+  `afterEach`, not in an assertion: `removeTempWorkspace` called `rmSync` on a
+  directory VS Code's file-watcher process still held open, and Windows refuses
+  that. Because mocha abandons the rest of a `describe` after a failing hook,
+  three status-bar tests silently stopped running — the total stayed plausible
+  enough that nothing looked wrong. `publish` depends on `test`, so it was
+  skipped rather than reported.
+
+  Nothing in the extension had changed: the only commit to `code/vscode/`
+  between the last green run and the first red one edited an unrelated fixture.
+  `@vscode/test-electron` installs the newest stable VS Code, and a release
+  changed the watcher's disposal timing. The test had always been racy; the
+  update just made it lose every time.
+
+  Cleanup can no longer fail the suite. `removeTempWorkspace` retries, and if
+  the handle is still held it leaves the directory for the OS to reclaim —
+  which is what a temp directory is for. 13 integration tests now pass, up from
+  10 passing and 3 never reached.
+
 ## [0.4.1] - 2026-06-01
 
 ### Fixed

--- a/code/vscode/test/integration/helpers.ts
+++ b/code/vscode/test/integration/helpers.ts
@@ -41,8 +41,35 @@ export function createCycleWorkspace(
   return { root, cyclePath, statePath };
 }
 
+/**
+ * Best-effort removal of a temp workspace. **Never throws.**
+ *
+ * Cleanup must not be able to fail the suite. When it can, a race in teardown
+ * does not merely report a failure that is not one — mocha abandons the rest of
+ * the `describe` after a failing hook, so the tests that never ran are counted
+ * as absent rather than failing. That is what happened here: three status-bar
+ * tests stopped running on Windows and the total stayed plausible enough that
+ * nothing looked wrong for a month.
+ *
+ * The race is real and not ours to win. VS Code's `FileSystemWatcher` is served
+ * by a separate process; `dispose()` sends an unsubscribe but the OS handle is
+ * released asynchronously, and Windows refuses to remove a directory anything
+ * still holds open. `maxRetries` gives it a few milliseconds to let go, and if
+ * it still has not, the directory is left for the OS to reclaim — which is what
+ * a temp directory is for.
+ */
 export function removeTempWorkspace(root: string): void {
-  fs.rmSync(root, { recursive: true, force: true });
+  try {
+    fs.rmSync(root, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 50,
+    });
+  } catch {
+    // Left behind under %TEMP%; the OS reclaims it. A test that fails only in
+    // cleanup is asserting nothing.
+  }
 }
 
 export function stubWindowMethod(


### PR DESCRIPTION
Fixes #308 — the Windows integration job, and with it the extension's
publish, which has been skipped rather than reported since 2026-07-14.

## It was never an assertion

`removeTempWorkspace` called `rmSync` on a directory VS Code's file-watcher
process still held open:

```
✔ createStatusBar crea un StatusBarItem visible (86ms)
1) "after each" hook for "createStatusBar crea un StatusBarItem visible":
   Error: EPERM, Permission denied: ...\Temp\inquiry-vscode-status-bar-lGvYt3
     at removeTempWorkspace (out/test/integration/helpers.js:72:8)
```

VS Code serves `FileSystemWatcher` from a separate process. `dispose()` sends
an unsubscribe; the OS handle is released some time later. Windows refuses to
remove a directory anything still holds open — Linux does not, which is why
one platform saw it and the other did not.

## Nothing in the extension had changed

The only commit to `code/vscode/` between the last green run (2026-06-01) and
the first red one (2026-07-14) edited an unrelated test fixture.
`@vscode/test-electron` installs the newest stable VS Code, and a release
changed the watcher's disposal timing. The test had always been racy; the
update just made it lose every time.

## The cost was not the red mark

Mocha abandons the rest of a `describe` after a failing hook, so **three
status-bar tests stopped running** — the ones covering state updates, the
completed→IDLE derivation, and that `dispose` actually detaches the watcher.
The suite reported `10 passing`, which is plausible enough that nothing looked
wrong for a month.

That is the defect worth fixing: cleanup could decide what got tested.

## The change

`removeTempWorkspace` no longer throws. It retries (`maxRetries: 10`,
`retryDelay: 50`), and if the handle is still held it leaves the directory for
the OS to reclaim — which is what a temp directory is for.

## Verification

| | before | after |
|---|---|---|
| integration | 10 passing, 1 failing, 3 never reached | **13 passing** |
| unit | 80 passing | 80 passing |
| `tsc --noEmit` | clean | clean |

Stable across three consecutive local runs on Windows. The three recovered
tests pass on their own merits — nothing was hiding behind them.
