### PR TITLE
Make every command the CLI names runnable as written

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.25.1]
+
+### Fixed
+
+- **Twelve messages told you to run a command that would fail.** 0.25.0 made
+  five routes require `--plan` or `--apply`, and updated the places that
+  *invoke* them — but not every place that *names* them to a reader. So the CLI
+  handed out instructions that were dead ends, which is worse than saying
+  nothing: it reads as guidance and behaves as a wall.
+
+  The one actually hit in the wild: upgrading to 0.25.0 ends with
+  ``Run `iq host get` to retry`` — and that retry fails. Also corrected: the
+  update banner (`run 'iq upgrade'`), `iq doctor`'s update remediation, the
+  `iq init` route description, the `INIT_HINT` baked into the OpenCode and
+  Claude agent files, and six messages in `iq implementation start` — including
+  its `Example:` line, which exists to be copied verbatim.
+
+  A new test sweeps all of `lib/` for any message that names one of the five
+  without a mode, so this cannot be missed a second time. It was written by
+  reintroducing one of the twelve and confirming it failed.
+
+- **`iq implementation start`'s usage line now says a mode is required** —
+  `--issue <number> (--plan | --apply)` — instead of a synopsis that will not
+  run.
+
+### Known
+
+- **Upgrading *from* 0.24.1 reports a failed host deploy.** Expected, and not
+  fixable from this side: `iq upgrade` runs as the *outgoing* version, so
+  0.24.1's post-install — frozen in that release — invokes a bare `host get`
+  against the newly installed 0.25.x binary, which refuses it. The upgrade
+  itself succeeds; run `iq host get --apply` once afterwards. From 0.25.0
+  onward the child carries `--apply --autoapprove` and the step passes.
+
 ## [0.25.0]
 
 ### Changed — BREAKING

--- a/code/cli/lib/hosts/claude_adapter.dart
+++ b/code/cli/lib/hosts/claude_adapter.dart
@@ -24,7 +24,7 @@ class ClaudeAdapter extends HostAdapter {
 
   @override
   Map<String, String> get agentSubstitutions => const {
-        'INIT_HINT': 'Run `iq host get --host claude`',
+        'INIT_HINT': 'Run `iq host get --host claude --apply --autoapprove`',
         'DISPATCH_TOOL': 'Agent',
       };
 }

--- a/code/cli/lib/hosts/opencode_adapter.dart
+++ b/code/cli/lib/hosts/opencode_adapter.dart
@@ -27,7 +27,7 @@ class OpenCodeAdapter extends HostAdapter {
   // OpenCode's sub-agent dispatch tool is `task` (there is no `agent` tool).
   @override
   Map<String, String> get agentSubstitutions => const {
-        'INIT_HINT': 'Run `iq host get --host opencode`',
+        'INIT_HINT': 'Run `iq host get --host opencode --apply --autoapprove`',
         'DISPATCH_TOOL': 'task',
       };
 }

--- a/code/cli/lib/modules/global/commands/doctor.dart
+++ b/code/cli/lib/modules/global/commands/doctor.dart
@@ -671,7 +671,7 @@ class DoctorCommand implements Query<DoctorInput, DoctorOutput> {
           name: 'update',
           passed: true,
           version: '${result.latestVersion} available',
-          remediation: "Run 'iq upgrade' to update",
+          remediation: "Run 'iq upgrade --apply' to update",
         );
       }
       return null; // No update, no check to show

--- a/code/cli/lib/modules/global/commands/tui.dart
+++ b/code/cli/lib/modules/global/commands/tui.dart
@@ -79,7 +79,7 @@ class TuiCommand implements Query<TuiInput, TuiOutput> {
       final result = await checker(currentVersion: inquiryVersion);
       if (result.updateAvailable && result.latestVersion != null) {
         diagram += "\n\nUpdate available: $inquiryVersion → ${result.latestVersion}"
-            " — run 'iq upgrade'";
+            " — run 'iq upgrade --apply'";
       }
     } catch (_) {
       // Silent on failure

--- a/code/cli/lib/modules/global/commands/upgrade.dart
+++ b/code/cli/lib/modules/global/commands/upgrade.dart
@@ -194,8 +194,8 @@ class RedeployHosts implements Step {
         return Outcome(
           verb: 'deploy',
           target: 'every host on this machine',
-          detail: 'failed (exit ${result.exitCode}) — run `iq host get` to '
-              'retry, or `iq doctor` to inspect',
+          detail: 'failed (exit ${result.exitCode}) — run '
+              '`iq host get --apply` to retry, or `iq doctor` to inspect',
           values: {'deployed': false},
         );
       }
@@ -208,8 +208,8 @@ class RedeployHosts implements Step {
       return Outcome(
         verb: 'deploy',
         target: 'every host on this machine',
-        detail: 'stopped: $error — run `iq host get` to retry, or `iq doctor` '
-            'to inspect',
+        detail: 'stopped: $error — run `iq host get --apply` to retry, or '
+            '`iq doctor` to inspect',
         values: {'deployed': false},
       );
     }
@@ -254,7 +254,8 @@ class UpgradeOutput extends Output {
       ? [
           '✓ Upgraded: $previousVersion → $newVersion',
           if (!deployed)
-            '  The CLI is upgraded. Run `iq host get` to deploy the hosts.',
+            '  The CLI is upgraded. Run `iq host get --apply` to deploy '
+                'the hosts.',
         ].join('\n')
       : (reason ?? 'Already on the latest version');
 }

--- a/code/cli/lib/modules/global/global_builder.dart
+++ b/code/cli/lib/modules/global/global_builder.dart
@@ -29,7 +29,7 @@ void buildGlobalModule(
     'init',
     (req) => InitCommand(InitInput.fromCliRequest(req)),
     description:
-        'Set up the Inquiry workspace in this repo (cleanrooms + .inquiry). Install a host first with `iq host get`.',
+        'Set up the Inquiry workspace in this repo (cleanrooms + .inquiry). Install a host first with `iq host get --apply`.',
     params: InitInput.params,
   );
 

--- a/code/cli/lib/modules/implementation/commands/start.dart
+++ b/code/cli/lib/modules/implementation/commands/start.dart
@@ -154,13 +154,13 @@ class ImplementationStartCommand
   String? validate() {
     if (input.issue.isEmpty) {
       return 'Missing --issue.\n'
-          'Usage: iq implementation start --issue <number>\n'
-          'Example: iq implementation start --issue 40';
+          'Usage: iq implementation start --issue <number> (--plan | --apply)\n'
+          'Example: iq implementation start --issue 40 --apply';
     }
     if (int.tryParse(input.issue) == null) {
       return 'The --issue value must be a number, got "${input.issue}".\n'
-          'Usage: iq implementation start --issue <number>\n'
-          'Example: iq implementation start --issue 40';
+          'Usage: iq implementation start --issue <number> (--plan | --apply)\n'
+          'Example: iq implementation start --issue 40 --apply';
     }
     return null;
   }
@@ -185,8 +185,8 @@ class ImplementationStartCommand
         code: 'NOT_A_GIT_REPO',
         message:
             'Not inside a git repository, so there is no place to open a cycle.\n'
-            'Run `iq implementation start --issue ${input.issue}` from within your project, '
-            'or initialize one first with `git init`.',
+            'Run `iq implementation start --issue ${input.issue} --apply` from '
+            'within your project, or initialize one first with `git init`.',
         exitCode: ExitCode.validationFailed,
       );
     }
@@ -390,7 +390,8 @@ class CheckoutBranch implements Step {
         message:
             'Could not switch to branch "$branch":\n'
             '${_gitErrorOf(checkout)}\n'
-            'Commit or stash your changes, then retry `iq implementation start --issue $issue`.',
+            'Commit or stash your changes, then retry '
+            '`iq implementation start --issue $issue --apply`.',
         exitCode: ExitCode.genericError,
       );
     }

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.25.0';
+const String inquiryVersion = '0.25.1';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.25.0
+version: 0.25.1
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/remediations_are_runnable_test.dart
+++ b/code/cli/test/remediations_are_runnable_test.dart
@@ -1,0 +1,85 @@
+/// Every command this CLI tells someone to run must be runnable as written.
+///
+/// Five routes refuse to act until they are told which of `--plan` and
+/// `--apply` was meant. A message that says "run `iq host get`" therefore hands
+/// the reader — or the agent acting on it — something that will fail. That is
+/// worse than saying nothing: it reads as instruction and behaves as a dead
+/// end.
+///
+/// This is a whole-source sweep rather than a per-message assertion because the
+/// mistake is not one anybody makes on purpose. It was made six times in the
+/// 0.25.0 release, in files nobody thought of as documentation: an adapter's
+/// substitution map, the update banner, a route description, and the upgrade's
+/// own remediation — the last of which a user read on screen, followed, and
+/// found broken.
+library;
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// The routes that take `--plan` / `--apply`. See ADR 0002.
+const _commands = [
+  'host get',
+  'host clean',
+  'upgrade',
+  'uninstall',
+  'implementation start',
+];
+
+/// `iq upgrade`, `inquiry host get`, … — the shapes a message uses to name one.
+final _namesACommand = RegExp(
+  '(iq|inquiry) (${_commands.join('|')})',
+);
+
+final _namesAMode = RegExp(r'--plan|--apply');
+
+bool _isComment(String line) {
+  final t = line.trimLeft();
+  return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*');
+}
+
+void main() {
+  test('no message tells someone to run a command without a mode', () {
+    final offenders = <String>[];
+
+    final files = Directory(p.join(Directory.current.path, 'lib'))
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.dart'));
+
+    for (final file in files) {
+      final lines = file.readAsLinesSync();
+      for (var i = 0; i < lines.length; i++) {
+        final line = lines[i];
+        if (_isComment(line)) continue;
+        if (!_namesACommand.hasMatch(line)) continue;
+
+        // A long message wraps, so the flag may sit on the next line — the
+        // adjacent line counts as part of the same sentence.
+        final context = [
+          line,
+          if (i + 1 < lines.length) lines[i + 1],
+        ].join(' ');
+        if (_namesAMode.hasMatch(context)) continue;
+
+        offenders.add(
+          '${p.relative(file.path)}:${i + 1}\n      ${line.trim()}',
+        );
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'These name a command that refuses to run without --plan or --apply, '
+          'so the reader is handed something that fails:\n\n'
+          '  ${offenders.join('\n\n  ')}\n\n'
+          'Add the mode the reader should use: --apply for a person at a '
+          'terminal, --apply --autoapprove where an agent or installer acts '
+          'unattended, --plan to only look.',
+    );
+  });
+}

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.25.0</span>
+      <span class="badge">v0.25.1</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
0.25.0 made five routes require `--plan` or `--apply`. It updated every place
that **invokes** one. It did not update every place that **names** one to a
reader — twelve messages were left handing out instructions that fail.

## Found by using it

```
❯ iq upgrade
...
Host deployment failed (exit 7).
The CLI is upgraded. Run `iq host get` to retry, or `iq doctor` to inspect.
```

That retry fails, for the same reason the deploy did. The user is told to do
the thing that just broke. An instruction that is a dead end is worse than no
instruction: it reads as guidance and behaves as a wall.

## Corrected

| Where | Was |
|---|---|
| `upgrade` — deploy failed | ``run `iq host get` to retry`` |
| `upgrade` — deploy stopped | ``run `iq host get` to retry`` |
| `upgrade` — output line | ``Run `iq host get` to deploy the hosts.`` |
| `tui` — update banner | `run 'iq upgrade'` |
| `doctor` — update remediation | `Run 'iq upgrade' to update` |
| `global_builder` — `init` description | ``Install a host first with `iq host get`.`` |
| `claude_adapter` — `INIT_HINT` | ``Run `iq host get --host claude``` |
| `opencode_adapter` — `INIT_HINT` | ``Run `iq host get --host opencode``` |
| `implementation start` × 6 | usage, `Example:`, `NOT_A_GIT_REPO`, `BRANCH_CHECKOUT_FAILED` |

The `INIT_HINT` pair is baked into the agent files deployed to OpenCode and
Claude, so it was wrong inside every host on every machine.

`implementation start`'s usage line now states that a mode is required —
`--issue <number> (--plan | --apply)` — rather than showing a synopsis that
does not run.

## The durable part

Nothing enforced this, which is why it was missed twelve times across files
nobody thinks of as documentation: an adapter's substitution map, a route
description, a status banner.

`test/remediations_are_runnable_test.dart` reads all of `lib/`, skips comments,
and fails on any message naming one of the five without a mode — quoting file,
line and text, and saying which flag to add. It was written by reintroducing
one of the twelve, confirming it failed, then restoring it and confirming it
passed.

## Not fixed, because it cannot be

Upgrading **from** 0.24.1 still reports the failed deploy. `iq upgrade` runs as
the *outgoing* version, so 0.24.1's post-install is frozen in that release and
will always invoke a bare `host get`. Recorded under **Known** in the
changelog, with the one-time remedy: `iq host get --apply`. From 0.25.0 onward
the child carries `--apply --autoapprove`.

## Verification

536 tests pass; `dart analyze --fatal-infos` clean. Version bumped to 0.25.1
across pubspec, `version.dart` and the site badge.
