### PR TITLE
Say why nothing would change, instead of only that nothing would

### DIFF
--- a/code/cli/lib/modules/global/commands/upgrade.dart
+++ b/code/cli/lib/modules/global/commands/upgrade.dart
@@ -262,7 +262,8 @@ class UpgradeOutput extends Output {
 
 // ─── Command ────────────────────────────────────────────────────────────────
 
-class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
+class UpgradeCommand
+    implements Command<UpgradeInput, UpgradeOutput>, ExplainsNothingToDo {
   @override
   final UpgradeInput input;
   final PlatformOps platformOps;
@@ -296,6 +297,12 @@ class UpgradeCommand implements Command<UpgradeInput, UpgradeOutput> {
 
   String _latest = inquiryVersion;
   String? _reason;
+
+  /// Being current is the ordinary outcome, not a non-answer. Without this the
+  /// framework would report `nothing would change`, which states the fact and
+  /// withholds the only part worth reading.
+  @override
+  String? get nothingToDo => _reason;
 
   /// Two steps, and everything they need read before the plan is built.
   ///

--- a/code/cli/lib/modules/host/commands/get.dart
+++ b/code/cli/lib/modules/host/commands/get.dart
@@ -176,7 +176,18 @@ class ConfigureOllama implements Step {
 
 // ─── Command ────────────────────────────────────────────────────────────────
 
-class HostGetCommand implements Command<HostGetInput, HostGetOutput> {
+/// What `host get` says when this machine carries no AI coding host.
+///
+/// One wording, reached two ways: as the reason an empty plan gives, and as
+/// [HostGetOutput.toText] for a run that produced no deploy. Written once so
+/// the two cannot drift.
+String noHostFoundMessage(List<String> supported) =>
+    'No AI coding host found on this machine — nothing deployed.\n'
+    'Supported: ${supported.join(', ')}.\n'
+    'Pass --host <host> to install into one anyway.';
+
+class HostGetCommand
+    implements Command<HostGetInput, HostGetOutput>, ExplainsNothingToDo {
   @override
   final HostGetInput input;
   final HostDeployer deployer;
@@ -186,6 +197,12 @@ class HostGetCommand implements Command<HostGetInput, HostGetOutput> {
   final OpenCodeOllamaConfigurator? configurator;
 
   HostGetCommand(this.input, {required this.deployer, this.configurator});
+
+  /// A machine with no AI assistant is an answer, not a failure — and the
+  /// answer says which hosts exist and how to install one anyway.
+  @override
+  String? get nothingToDo =>
+      noHostFoundMessage(deployer.adapters.map((a) => a.name).toList());
 
   @override
   String? validate() {

--- a/code/cli/pubspec.lock
+++ b/code/cli/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: "direct main"
     description:
       name: modular_cli_sdk
-      sha256: "2b7e9767fe9d838d3a407a5f907ff1d7d36102ce4615ec02e57e2849962546fb"
+      sha256: "9928cf38e6f478d6f4f085e371f37d580dae686cb16a23ebe0695b0b0bd05a1c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.8.1
 dependencies:
   cli_router: ^0.1.0
-  modular_cli_sdk: ^0.4.1
+  modular_cli_sdk: ^0.5.1
   path: ^1.9.1
   yaml: ^3.1.3
 dev_dependencies:

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.8.1
 dependencies:
   cli_router: ^0.1.0
-  modular_cli_sdk: ^0.5.1
+  modular_cli_sdk: ^0.5.0
   path: ^1.9.1
   yaml: ^3.1.3
 dev_dependencies:


### PR DESCRIPTION
Moves this CLI to `modular_cli_sdk` 0.5.0 and takes up the one thing it adds.

## Why

Two commands here can come out with an empty plan, and both know something worth saying about it. Until now the reason was computed and discarded:

| Command | Said | Now says |
|---|---|---|
| `upgrade`, already current | `nothing would change` | `Already on the latest version` |
| `host get`, no host on the machine | `nothing would change` | `No AI coding host found on this machine — nothing deployed.`<br>`Supported: opencode, claude.`<br>`Pass --host <host> to install into one anyway.` |

`host get` is the sharper case. The old wording reads like a bug; the new one tells someone what to do next.

## Also on `--plan`

An empty plan had always been mute there — that path never calls `describe`, so this was never a regression, just a silence nobody had a way to fill:

```
Plan — upgrade

  Already on the latest version

Nothing to carry out, so --apply would do nothing either.
```

## One wording, two readers

`host get`'s message moves into `noHostFoundMessage`, reached both as the empty plan's reason and as `HostGetOutput.toText`, so the two cannot drift.

## Verification

Against the **published** 0.5.0, no dependency override:

```
dart analyze --fatal-infos    No issues found!
dart test                     536 tests passed
```

Both messages confirmed by running the real binary on `--plan` and `--apply --autoapprove`.
