### PR TITLE
0.25.2, so the improvement reaches somebody

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.25.2]
+
+### Changed
+
+- **A command that has nothing to do now says why, not just that.** Two
+  messages here were being computed and thrown away, because a plan that comes
+  out empty never reaches `describe`. The caller was told `nothing would
+  change` — a fact, with the actionable half removed.
+
+  | Command | Now says |
+  |---|---|
+  | `iq upgrade`, already current | `Already on the latest version` |
+  | `iq host get`, no host on this machine | `No AI coding host found on this machine — nothing deployed.` `Supported: opencode, claude.` `Pass --host <host> to install into one anyway.` |
+
+  `host get` is the sharper case: the old wording reads like a bug, and the new
+  one tells you what to do next.
+
+  The reason now reaches `--plan` as well, where an empty plan had always been
+  mute — that path never called `describe`, so this was never a regression,
+  just a silence with no way to fill it:
+
+  ```
+  Plan — upgrade
+
+    Already on the latest version
+
+  Nothing to carry out, so --apply would do nothing either.
+  ```
+
+- **`modular_cli_sdk` 0.5.0**, which is where the mechanism
+  (`ExplainsNothingToDo`) comes from. It also stops `--apply` from asking for
+  approval over a plan that changes nothing — which, with no terminal to
+  answer, used to fail an invocation that had nothing to do.
+
+### Internal
+
+- **The sweep that checks remediation messages no longer keeps its own list of
+  commands.** It carried a literal five, which is a second place the truth
+  lives and goes blind exactly when the CLI grows — register `iq analyze start`
+  and the check would keep passing while the new command's messages went
+  unread. It now derives them from `iq help --json`, which publishes `kind` per
+  route, so registering a command extends the check with no edit to the test.
+
 ## [0.25.1]
 
 ### Fixed

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.25.1';
+const String inquiryVersion = '0.25.2';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.25.1
+version: 0.25.2
 
 environment:
   sdk: ^3.8.1

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.25.1</span>
+      <span class="badge">v0.25.2</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
#313 landed on `main` and stopped there.

It did not raise the version, so the release workflow read `0.25.1`, found the tag already published, and skipped `create-release`, `build` and `publish-release`. That is correct behaviour — and the result is that `iq upgrade` still hands out 0.25.1, without the two messages #313 was for. `main` is not where users are.

## What ships

| Command | Was | Now |
|---|---|---|
| `iq upgrade`, already current | `nothing would change` | `Already on the latest version` |
| `iq host get`, no host on this machine | `nothing would change` | `No AI coding host found on this machine — nothing deployed.`<br>`Supported: opencode, claude.`<br>`Pass --host <host> to install into one anyway.` |

Also on `--plan`, where an empty plan had always been mute:

```
Plan — upgrade

  Already on the latest version

Nothing to carry out, so --apply would do nothing either.
```

The changelog also records #311 — the remediation sweep deriving its command list from `iq help --json` instead of keeping its own copy — which was equally release-less, for the same reason.

## Version sources

All three move together, because `version_sync_test` holds them to it:

- `code/cli/pubspec.yaml`
- `code/cli/lib/src/version.dart`
- `code/site/index.html` badge

## Verification

```
dart analyze --fatal-infos    No issues found!
dart test                     537 tests passed
```

Merging this triggers the release workflow, which this time will find no `v0.25.2` tag and build.
