### PR TITLE
host get said it deployed skills, and it does not

### DIFF
--- a/code/cli/CHANGELOG.md
+++ b/code/cli/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/)
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.26.1]
+
+### Fixed
+
+- **`iq host get` said it deployed skills, and it does not.** 0.26.0 stopped
+  shipping them and stopped deploying them, but the line it prints on success
+  still read `Inquiry agent + skills deployed (global) to host <host>` — as did
+  three comments describing the same work. A message that promises what the tool
+  does not do is a defect whether or not any bytes move, and this one appeared
+  in the middle of an upgrade, which is exactly where a user has no way to check.
+
+  It now reads `Inquiry agent deployed (global) to host <host>`, and the sweep
+  line says what the removal actually is: `removed <skill> (from before Inquiry
+  stopped shipping skills)` rather than "no longer shipped", which described a
+  comparison against a shipped set that no longer exists.
+
 ## [0.26.0]
 
 ### Changed — breaking

--- a/code/cli/lib/hosts/all_adapters.dart
+++ b/code/cli/lib/hosts/all_adapters.dart
@@ -15,7 +15,7 @@ final List<HostAdapter> allAdapters = [
   GeminiAdapter(),
 ];
 
-/// Active deploy targets (#280): `iq host get` installs the agent + skills
+/// Active deploy targets (#280): `iq host get` installs the agent
 /// GLOBALLY for these, additively. Copilot/Codex/Gemini are kept only in
 /// [allAdapters] for `host clean` migration.
 final List<HostAdapter> deployAdapters = [

--- a/code/cli/lib/hosts/host_adapter.dart
+++ b/code/cli/lib/hosts/host_adapter.dart
@@ -20,7 +20,7 @@ abstract class HostAdapter {
   bool exists(String homeDir) => Directory(baseDirectory(homeDir)).existsSync();
 
   /// Whether `iq host get` deploys the inquiry agent (globally) for this host.
-  /// Active hosts (OpenCode, Claude) deploy the agent + skills; hosts kept only
+  /// Active hosts (OpenCode, Claude) deploy the agent; hosts kept only
   /// for `host clean` migration leave it `false`.
   bool get deploysAgent => false;
 

--- a/code/cli/lib/modules/global/commands/init.dart
+++ b/code/cli/lib/modules/global/commands/init.dart
@@ -5,7 +5,7 @@
 /// 2. Add .inquiry/ and cleanrooms/**/.iq.state.yaml to .gitignore
 /// 3. Create .inquiry/config.yaml with defaults
 ///
-/// The inquiry agent + skills are installed GLOBALLY per host by
+/// The inquiry agent is installed GLOBALLY per host by
 /// `iq host get --host <host>` (#280) — NOT here. Cycle runtime
 /// (`.iq.state.yaml`, `mutations.md`) is materialized per cycle under
 /// `cleanrooms/<branch>/` by the FSM, not scaffolded at init.

--- a/code/cli/lib/modules/host/commands/get.dart
+++ b/code/cli/lib/modules/host/commands/get.dart
@@ -103,9 +103,9 @@ class HostGetOutput extends Output {
             'Pass --host <host> to install into one anyway.'
       : [
           for (final host in hosts) ...[
-            'Inquiry agent + skills deployed (global) to host $host',
+            'Inquiry agent deployed (global) to host $host',
             for (final skill in retired[host] ?? const <String>[])
-              '  removed  $skill (no longer shipped)',
+              '  removed  $skill (from before Inquiry stopped shipping skills)',
           ],
           ...ollamaLines,
         ].join('\n');
@@ -113,8 +113,8 @@ class HostGetOutput extends Output {
 
 // ─── Steps ──────────────────────────────────────────────────────────────────
 
-/// Deploys the agent and skills into one host, retiring what it no longer
-/// ships.
+/// Deploys the agent into one host, and sweeps the `iq-` namespace left there
+/// by releases that did ship skills.
 ///
 /// One step per host, so the plan names each of them: deploying to two
 /// assistants and deploying to none look nothing alike, and a single line

--- a/code/cli/lib/src/version.dart
+++ b/code/cli/lib/src/version.dart
@@ -2,4 +2,4 @@
 ///
 /// Update this constant when bumping version in pubspec.yaml.
 /// Both are kept in sync manually to avoid build-time complexity.
-const String inquiryVersion = '0.26.0';
+const String inquiryVersion = '0.26.1';

--- a/code/cli/pubspec.yaml
+++ b/code/cli/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inquiry_cli
 description: >
   CLI for Inquiry — structured development through the APE methodology.
-version: 0.26.0
+version: 0.26.1
 
 environment:
   sdk: ^3.8.1

--- a/code/cli/test/host_commands_test.dart
+++ b/code/cli/test/host_commands_test.dart
@@ -190,7 +190,7 @@ void main() {
         expect(deployed('iq-specification'), isFalse);
         expect(
           out.toText(),
-          contains('removed  iq-analyze (no longer shipped)'),
+          contains('removed  iq-analyze (from before Inquiry stopped shipping skills)'),
         );
       });
 

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -31,7 +31,7 @@
       <h1><span class="ape">Inquiry</span></h1>
       <p class="primary-tagline">Analyze. Plan. Execute.</p>
       <p class="secondary-tagline">Available for OpenCode and GitHub Copilot. More hosts coming soon.</p>
-      <span class="badge">v0.26.0</span>
+      <span class="badge">v0.26.1</span>
       <p class="secondary-tagline">Public entry surface. For the canonical documentation map, start in the repository docs.</p>
 
       <div class="hero-install" id="install">


### PR DESCRIPTION
0.26.0 stopped shipping skills and stopped deploying them. The line it prints on success still read `Inquiry agent + skills deployed (global) to host <host>`, and three comments described the same work the same way.

A message that promises what the tool does not do is a defect whether or not any bytes move. This one is worse than most for **where it appears**: in the middle of `iq upgrade`, which is precisely the moment a user has no way to check. On this machine it was read as evidence that 0.26.0 had overwritten another consumer's artifacts, and only the ledger settled that it had not.

```
- Inquiry agent + skills deployed (global) to host claude
+ Inquiry agent deployed (global) to host claude
```

The sweep line changes with it. `no longer shipped` described a comparison against a shipped set, and there is no shipped set any more — it now says `from before Inquiry stopped shipping skills`, which is what the removal actually is.

545 tests pass; `dart analyze --fatal-infos` clean.

https://claude.ai/code/session_012vQNdbsn1bvhVnRNU8X9cr