### PR TITLE
The site claims skills Inquiry does not ship, and never invoked

### DIFF
--- a/code/site/agents.html
+++ b/code/site/agents.html
@@ -200,9 +200,15 @@
     </section>
 
     <section aria-labelledby="skills-heading">
-      <h2 id="skills-heading">Private skills</h2>
+      <h2 id="skills-heading">Three skills that are not Inquiry's</h2>
       <p class="section-intro">
-        These are skills, not phase-bound agents. They are private skills that can be invoked from different points in the cycle when the task calls for collective judgment, external investigation, or disciplined criticism.
+        These were parked here because there was nowhere else to put a skill that
+        belonged to no single project. They belong to none — Inquiry's cycle
+        never invoked them — and since 0.26.0 they ship with
+        <a href="https://pub.dev/packages/skillwire">skillwire_cli</a> instead,
+        which puts them where any AI coding host reads them. They are described
+        here because they are worth knowing about, not because Inquiry provides
+        them.
       </p>
       <div class="agents-grid skills-grid">
         <article class="agent-card skill-card" id="legion">

--- a/code/site/index.html
+++ b/code/site/index.html
@@ -45,7 +45,7 @@
             <button class="copy-btn" onclick="copy(this)" aria-label="Copy install command">Copy</button>
             <code>irm https://inquiry.ccisne.dev/install.ps1 | iex</code>
           </div>
-          <p class="install-note">Installs to <code>%LOCALAPPDATA%\inquiry\</code>, adds to <code>PATH</code>, and deploys Inquiry skills to your AI coding host.</p>
+          <p class="install-note">Installs to <code>%LOCALAPPDATA%\inquiry\</code>, adds to <code>PATH</code>, and deploys the Inquiry agent to your AI coding host.</p>
         </div>
         <div id="panel-linux" class="os-panel" role="tabpanel" aria-labelledby="tab-linux" hidden>
           <div class="install-block">
@@ -53,7 +53,7 @@
             <button class="copy-btn" onclick="copy(this)" aria-label="Copy install command">Copy</button>
             <code>curl -fsSL https://inquiry.ccisne.dev/install.sh | bash</code>
           </div>
-          <p class="install-note">Installs to <code>~/.inquiry/</code> and deploys Inquiry skills to your AI coding host.</p>
+          <p class="install-note">Installs to <code>~/.inquiry/</code> and deploys the Inquiry agent to your AI coding host.</p>
         </div>
       </div>
 
@@ -114,7 +114,7 @@
         <li class="cmd"><code>iq</code><span class="desc">Print ASCII banner + version</span></li>
         <li class="cmd"><code>iq init</code><span class="desc">Scaffold repo-scoped Inquiry files (<code>.inquiry/config.yaml</code>, ignore rules, agent)</span></li>
         <li class="cmd"><code>iq doctor</code><span class="desc">Verify prerequisites</span></li>
-        <li class="cmd"><code>iq host get</code><span class="desc">Deploy skills to every AI host detected — <code>--plan</code>/<code>--apply</code></span></li>
+        <li class="cmd"><code>iq host get</code><span class="desc">Deploy the agent to every AI host detected — <code>--plan</code>/<code>--apply</code></span></li>
         <li class="cmd"><code>iq implementation start</code><span class="desc">Open a cycle: branch, cleanroom, ANALYZE — <code>--plan</code>/<code>--apply</code></span></li>
         <li class="cmd"><code>iq fsm transition</code><span class="desc">Execute a deterministic FSM transition</span></li>
         <li class="cmd"><code>iq fsm state</code><span class="desc">Show current FSM state as JSON</span></li>
@@ -127,7 +127,7 @@
 
     <section id="targets">
       <h2>Hosts</h2>
-      <p>Inquiry deploys host-scoped skills to the global configuration of your AI coding tool. The repo-scoped agent is scaffolded by <code>iq init</code>.</p>
+      <p>Inquiry deploys its agent to the global configuration of your AI coding tool. The repo-scoped agent is scaffolded by <code>iq init</code>. It ships no skills: the three it once carried were transversal and now ship with <a href="https://pub.dev/packages/skillwire">skillwire_cli</a>.</p>
       <ul class="targets">
         <li class="target-badge"><span class="dot"></span>OpenCode</li>
         <li class="target-badge"><span class="dot"></span>GitHub Copilot</li>


### PR DESCRIPTION
Four places on the live site say Inquiry deploys skills. Since 0.26.0 it ships none.

But the page was already wrong before 0.26.0, and **that** is the finding worth having:

```
$ grep -riE '\blegion\b|\bkritik\b' code/cli/assets
(no matches)
```

The cycle never invoked them. `agents.html` presented LEGION, RESEARCH and KRITIK as *"private skills that can be invoked from different points in the cycle when the task calls for collective judgment, external investigation, or disciplined criticism"* — an integration that was never wired up. They were parked here because there was nowhere else to put a skill belonging to no single project.

## What changed

| Was | Is |
|---|---|
| "deploys Inquiry skills to your AI coding host" (Windows **and** Linux panels) | "deploys the Inquiry agent" |
| `iq host get` — "Deploy skills to every AI host detected" | "Deploy the agent to every AI host detected" |
| "Inquiry deploys host-scoped skills to the global configuration" | "deploys its agent… It ships no skills" |
| "Private skills" | "Three skills that are not Inquiry's" |

The section stays rather than going, because the three are worth knowing about — it just stops claiming them. It says they were parked here, that the cycle never called them, and that they ship with [skillwire_cli](https://pub.dev/packages/skillwire) now.

Site only. No version bump.

https://claude.ai/code/session_012vQNdbsn1bvhVnRNU8X9cr